### PR TITLE
fix(claude): include subagent logs in batch scans

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,8 @@ vct usage --json --daily
 
 The tool automatically scans these directories:
 
-- `~/.claude/projects/*.jsonl` (Claude Code)
+- `~/.claude/projects/*/*.jsonl` (Claude Code main sessions)
+- `~/.claude/projects/*/*/subagents/*.jsonl` (Claude Code subagents; `*.meta.json` is ignored)
 - `~/.codex/sessions/*.jsonl` (Codex)
 - `~/.copilot/history-session-state/*.json` (Copilot)
 - `~/.gemini/tmp/<project_hash>/chats/*.json` (Gemini)
@@ -260,7 +261,7 @@ vct analysis
 vct analysis --table
 
 # Analyze a single conversation file → stdout JSON
-vct analysis --path ~/.claude/projects/session.jsonl
+vct analysis --path ~/.claude/projects/<project>/<session>.jsonl
 
 # Save results to JSON
 vct analysis --output report.json

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -226,7 +226,8 @@ vct usage --json --daily
 
 该工具会自动扫描以下目录：
 
-- `~/.claude/projects/*.jsonl`（Claude Code）
+- `~/.claude/projects/*/*.jsonl`（Claude Code 主 session）
+- `~/.claude/projects/*/*/subagents/*.jsonl`（Claude Code subagents；会忽略 `*.meta.json`）
 - `~/.codex/sessions/*.jsonl`（Codex）
 - `~/.copilot/history-session-state/*.json`（Copilot）
 - `~/.gemini/tmp/<project_hash>/chats/*.json`（Gemini）
@@ -260,7 +261,7 @@ vct analysis
 vct analysis --table
 
 # 分析单一对话文件 → stdout JSON
-vct analysis --path ~/.claude/projects/session.jsonl
+vct analysis --path ~/.claude/projects/<project>/<session>.jsonl
 
 # Save results to JSON
 vct analysis --output report.json

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -226,7 +226,8 @@ vct usage --json --daily
 
 此工具會自動掃描以下目錄：
 
-- `~/.claude/projects/*.jsonl`（Claude Code）
+- `~/.claude/projects/*/*.jsonl`（Claude Code 主 session）
+- `~/.claude/projects/*/*/subagents/*.jsonl`（Claude Code subagents；會忽略 `*.meta.json`）
 - `~/.codex/sessions/*.jsonl`（Codex）
 - `~/.copilot/history-session-state/*.json`（Copilot）
 - `~/.gemini/tmp/<project_hash>/chats/*.json`（Gemini）
@@ -260,7 +261,7 @@ vct analysis
 vct analysis --table
 
 # 分析單一對話檔案 → stdout JSON
-vct analysis --path ~/.claude/projects/session.jsonl
+vct analysis --path ~/.claude/projects/<project>/<session>.jsonl
 
 # Save results to JSON
 vct analysis --output report.json

--- a/src/analysis/batch_analyzer.rs
+++ b/src/analysis/batch_analyzer.rs
@@ -2,7 +2,9 @@ use crate::cache::global_cache;
 use crate::cli::TimeRange;
 use crate::constants::{FastHashMap, capacity};
 use crate::models::ProviderActiveDays;
-use crate::utils::{collect_files_with_dates, is_gemini_chat_file, is_json_file};
+use crate::utils::{
+    collect_files_with_dates, is_claude_session_file, is_gemini_chat_file, is_json_file,
+};
 use anyhow::Result;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -51,7 +53,7 @@ pub fn analyze_all_sessions(time_range: TimeRange) -> Result<AnalysisData> {
             &paths.claude_session_dir,
             &mut aggregated,
             &mut claude_dates,
-            is_json_file,
+            is_claude_session_file,
             time_range,
         )?;
     }
@@ -139,7 +141,7 @@ pub fn analyze_all_sessions_by_provider(time_range: TimeRange) -> Result<Provide
         process_full_analysis_directory(
             &paths.claude_session_dir,
             &mut claude_results,
-            is_json_file,
+            is_claude_session_file,
             time_range,
         )?;
     }

--- a/src/usage/calculator.rs
+++ b/src/usage/calculator.rs
@@ -2,7 +2,10 @@ use crate::cache::global_cache;
 use crate::cli::TimeRange;
 use crate::constants::{FastHashMap, capacity};
 use crate::models::{ProviderActiveDays, UsageResult};
-use crate::utils::{collect_files_with_dates, is_gemini_chat_file, is_json_file, resolve_paths};
+use crate::utils::{
+    collect_files_with_dates, is_claude_session_file, is_gemini_chat_file, is_json_file,
+    resolve_paths,
+};
 use anyhow::Result;
 use rayon::prelude::*;
 use serde_json::Value;
@@ -66,7 +69,7 @@ pub fn get_usage_from_directories(time_range: TimeRange) -> Result<UsageData> {
             &paths.claude_session_dir,
             &mut result,
             &mut claude_dates,
-            is_json_file,
+            is_claude_session_file,
             time_range,
         )?;
     }

--- a/src/utils/directory.rs
+++ b/src/utils/directory.rs
@@ -1,5 +1,6 @@
 use crate::cli::TimeRange;
 use anyhow::Result;
+use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
 
@@ -73,6 +74,65 @@ where
     }
 
     Ok(results)
+}
+
+fn is_jsonl_file(path: &Path) -> bool {
+    path.extension()
+        .is_some_and(|ext| ext == OsStr::new("jsonl"))
+}
+
+fn is_claude_log_filename(file_name: &OsStr) -> bool {
+    let file_name = file_name.to_string_lossy();
+    file_name.ends_with(".jsonl")
+        && !file_name.ends_with(".meta.json")
+        && !file_name.ends_with(".meta.jsonl")
+}
+
+/// Filter for Claude Code session and subagent files.
+///
+/// Accepts these layouts under `~/.claude/projects`:
+/// - `*.jsonl`
+/// - `*/*.jsonl`
+/// - `*/*/subagents/*.jsonl`
+///
+/// Explicitly excludes Claude metadata files such as `*.meta.json`.
+pub fn is_claude_session_file(path: &Path) -> bool {
+    if !is_jsonl_file(path) {
+        return false;
+    }
+
+    let components: Vec<OsString> = path
+        .components()
+        .map(|component| component.as_os_str().to_os_string())
+        .collect();
+
+    let Some(projects_index) = components
+        .iter()
+        .rposition(|component| component == OsStr::new("projects"))
+    else {
+        return false;
+    };
+
+    let Some(claude_index) = projects_index.checked_sub(1) else {
+        return false;
+    };
+
+    if components[claude_index] != OsStr::new(".claude") {
+        return false;
+    }
+
+    match &components[projects_index + 1..] {
+        [file] => is_claude_log_filename(file.as_os_str()),
+        [project, file] => {
+            project != OsStr::new("memory") && is_claude_log_filename(file.as_os_str())
+        }
+        [project, _session, subagents, file] => {
+            project != OsStr::new("memory")
+                && subagents == OsStr::new("subagents")
+                && is_claude_log_filename(file.as_os_str())
+        }
+        _ => false,
+    }
 }
 
 /// Standard filter for JSONL and JSON files

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -8,7 +8,9 @@ pub mod token_extractor;
 pub mod usage_processor;
 
 // Public API exports (commonly used across modules)
-pub use directory::{collect_files_with_dates, is_gemini_chat_file, is_json_file};
+pub use directory::{
+    collect_files_with_dates, is_claude_session_file, is_gemini_chat_file, is_json_file,
+};
 pub use file::{count_lines, read_json, read_jsonl, save_json_pretty};
 pub use format::{format_number, get_current_date};
 pub use git::get_git_remote_url;

--- a/tests/test_utils_directory.rs
+++ b/tests/test_utils_directory.rs
@@ -7,7 +7,7 @@ use std::io::Write;
 use tempfile::tempdir;
 use vibe_coding_tracker::cli::TimeRange;
 use vibe_coding_tracker::utils::directory::{
-    collect_files_with_dates, is_gemini_chat_file, is_json_file,
+    collect_files_with_dates, is_claude_session_file, is_gemini_chat_file, is_json_file,
 };
 
 #[test]
@@ -43,6 +43,40 @@ fn test_is_json_file_uppercase() {
     // Test uppercase extension
     let path = std::path::Path::new("test.JSON");
     assert!(!is_json_file(path)); // Case-sensitive
+}
+
+#[test]
+fn test_is_claude_session_file_root_level_jsonl() {
+    let path = std::path::Path::new("/home/user/.claude/projects/session.jsonl");
+    assert!(is_claude_session_file(path));
+}
+
+#[test]
+fn test_is_claude_session_file_project_session_jsonl() {
+    let path = std::path::Path::new("/home/user/.claude/projects/my-project/session.jsonl");
+    assert!(is_claude_session_file(path));
+}
+
+#[test]
+fn test_is_claude_session_file_subagent_jsonl() {
+    let path = std::path::Path::new(
+        "/home/user/.claude/projects/my-project/session/subagents/agent.jsonl",
+    );
+    assert!(is_claude_session_file(path));
+}
+
+#[test]
+fn test_is_claude_session_file_rejects_meta_json() {
+    let path = std::path::Path::new(
+        "/home/user/.claude/projects/my-project/session/subagents/agent.meta.json",
+    );
+    assert!(!is_claude_session_file(path));
+}
+
+#[test]
+fn test_is_claude_session_file_rejects_memory_jsonl() {
+    let path = std::path::Path::new("/home/user/.claude/projects/memory/session.jsonl");
+    assert!(!is_claude_session_file(path));
 }
 
 #[test]
@@ -125,6 +159,38 @@ fn test_collect_files_with_dates_nested_directories() {
 
     let results = collect_files_with_dates(dir.path(), is_json_file, TimeRange::All).unwrap();
     assert_eq!(results.len(), 3);
+}
+
+#[test]
+fn test_collect_files_with_dates_claude_filter_includes_subagents_and_skips_meta() {
+    let dir = tempdir().unwrap();
+    let projects_dir = dir.path().join(".claude/projects");
+    let project_dir = projects_dir.join("my-project");
+    let session_file = project_dir.join("session.jsonl");
+    let subagent_file = project_dir.join("session/subagents/agent.jsonl");
+    let meta_file = project_dir.join("session/subagents/agent.meta.json");
+    let memory_file = projects_dir.join("memory/session.jsonl");
+
+    fs::create_dir_all(subagent_file.parent().unwrap()).unwrap();
+    fs::create_dir_all(memory_file.parent().unwrap()).unwrap();
+
+    File::create(&session_file).unwrap();
+    File::create(&subagent_file).unwrap();
+    File::create(&meta_file).unwrap();
+    File::create(&memory_file).unwrap();
+
+    let mut collected_paths: Vec<_> =
+        collect_files_with_dates(&projects_dir, is_claude_session_file, TimeRange::All)
+            .unwrap()
+            .into_iter()
+            .map(|file_info| file_info.path)
+            .collect();
+    collected_paths.sort();
+
+    let mut expected_paths = vec![session_file, subagent_file];
+    expected_paths.sort();
+
+    assert_eq!(collected_paths, expected_paths);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add a Claude-specific session file filter for batch scanning
- include nested `subagents/*.jsonl` files in Claude usage and analysis aggregation
- exclude Claude metadata files such as `*.meta.json`
- update README docs to describe the actual Claude log layout and single-file example path

## Testing

- `cargo test --test test_utils_directory`
- `cargo test --test integration_tests test_batch_analysis`
- `cargo test --test integration_tests test_get_usage_from_`
- `cargo test`
