### PR TITLE
test(cache): serialize global cache tests to fix flakiness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -807,6 +807,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2104,10 +2115,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "semver"
@@ -2168,6 +2194,32 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2661,6 +2713,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "serial_test",
  "strsim",
  "sysinfo",
  "tar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,7 @@ tempfile = "3.23"
 assert_cmd = "2.0"
 predicates = "3.1"
 criterion = { version = "0.5", features = ["html_reports"] }
+serial_test = "3.2"
 
 [[bench]]
 name = "benchmarks"

--- a/tests/test_cache_global.rs
+++ b/tests/test_cache_global.rs
@@ -2,12 +2,14 @@
 //
 // Tests global cache singleton operations
 
+use serial_test::serial;
 use std::fs::File;
 use std::io::Write;
 use tempfile::tempdir;
 use vibe_coding_tracker::cache::{clear_global_cache, global_cache};
 
 #[test]
+#[serial]
 fn test_global_cache_exists() {
     // Test that global cache can be accessed
     let cache = global_cache();
@@ -17,6 +19,7 @@ fn test_global_cache_exists() {
 }
 
 #[test]
+#[serial]
 fn test_global_cache_singleton() {
     // Test that global_cache returns the same instance
     let cache1 = global_cache();
@@ -27,6 +30,7 @@ fn test_global_cache_singleton() {
 }
 
 #[test]
+#[serial]
 fn test_global_cache_clear() {
     // Test clearing global cache
     let cache = global_cache();
@@ -50,6 +54,7 @@ fn test_global_cache_clear() {
 }
 
 #[test]
+#[serial]
 fn test_global_cache_persistence_across_calls() {
     // Test that cache persists across function calls
     let cache = global_cache();
@@ -75,6 +80,7 @@ fn test_global_cache_persistence_across_calls() {
 }
 
 #[test]
+#[serial]
 fn test_global_cache_stats() {
     // Test that cache stats are accessible
     clear_global_cache();
@@ -87,6 +93,7 @@ fn test_global_cache_stats() {
 }
 
 #[test]
+#[serial]
 fn test_clear_global_cache_multiple_times() {
     // Test that clearing cache multiple times works
     clear_global_cache();
@@ -100,6 +107,7 @@ fn test_clear_global_cache_multiple_times() {
 }
 
 #[test]
+#[serial]
 fn test_global_cache_thread_safety() {
     // Test that global cache can be accessed from multiple threads
     use std::thread;
@@ -125,6 +133,7 @@ fn test_global_cache_thread_safety() {
 }
 
 #[test]
+#[serial]
 fn test_global_cache_with_operations() {
     // Test global cache with actual operations
     clear_global_cache();

--- a/tests/test_cache_global.rs
+++ b/tests/test_cache_global.rs
@@ -9,7 +9,7 @@ use tempfile::tempdir;
 use vibe_coding_tracker::cache::{clear_global_cache, global_cache};
 
 #[test]
-#[serial]
+#[serial(global_cache)]
 fn test_global_cache_exists() {
     // Test that global cache can be accessed
     let cache = global_cache();
@@ -19,7 +19,7 @@ fn test_global_cache_exists() {
 }
 
 #[test]
-#[serial]
+#[serial(global_cache)]
 fn test_global_cache_singleton() {
     // Test that global_cache returns the same instance
     let cache1 = global_cache();
@@ -30,7 +30,7 @@ fn test_global_cache_singleton() {
 }
 
 #[test]
-#[serial]
+#[serial(global_cache)]
 fn test_global_cache_clear() {
     // Test clearing global cache
     let cache = global_cache();
@@ -54,7 +54,7 @@ fn test_global_cache_clear() {
 }
 
 #[test]
-#[serial]
+#[serial(global_cache)]
 fn test_global_cache_persistence_across_calls() {
     // Test that cache persists across function calls
     let cache = global_cache();
@@ -80,7 +80,7 @@ fn test_global_cache_persistence_across_calls() {
 }
 
 #[test]
-#[serial]
+#[serial(global_cache)]
 fn test_global_cache_stats() {
     // Test that cache stats are accessible
     clear_global_cache();
@@ -93,7 +93,7 @@ fn test_global_cache_stats() {
 }
 
 #[test]
-#[serial]
+#[serial(global_cache)]
 fn test_clear_global_cache_multiple_times() {
     // Test that clearing cache multiple times works
     clear_global_cache();
@@ -107,7 +107,7 @@ fn test_clear_global_cache_multiple_times() {
 }
 
 #[test]
-#[serial]
+#[serial(global_cache)]
 fn test_global_cache_thread_safety() {
     // Test that global cache can be accessed from multiple threads
     use std::thread;
@@ -133,7 +133,7 @@ fn test_global_cache_thread_safety() {
 }
 
 #[test]
-#[serial]
+#[serial(global_cache)]
 fn test_global_cache_with_operations() {
     // Test global cache with actual operations
     clear_global_cache();


### PR DESCRIPTION
## Summary

- Fix flaky CI failure in `test_global_cache_persistence_across_calls` (run [24733783004](https://github.com/Mai0313/VibeCodingTracker/actions/runs/24733783004/job/72355069406), also [24667922973](https://github.com/Mai0313/VibeCodingTracker/actions/runs/24667922973))
- Root cause: all 8 tests in `tests/test_cache_global.rs` operate on the same `GLOBAL_FILE_CACHE` singleton. Cargo runs tests in parallel per test binary, so one test's `clear_global_cache()` or insertion would race with another test's assertions, producing errors like `assertion left: 0, right: 2`.
- Fix: add `serial_test` dev-dependency and mark every test in this file with `#[serial]`. Other test binaries stay parallel, so overall CI time is unaffected.

## Test plan

- [x] `cargo test --test test_cache_global` x5 consecutive runs, all pass
- [x] Full `cargo test` suite passes locally
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)