### PR TITLE
feat(claude): include subagent session logs and skip meta.json sidecars

### DIFF
--- a/src/analysis/batch_analyzer.rs
+++ b/src/analysis/batch_analyzer.rs
@@ -2,7 +2,9 @@ use crate::cache::global_cache;
 use crate::cli::TimeRange;
 use crate::constants::{FastHashMap, capacity};
 use crate::models::ProviderActiveDays;
-use crate::utils::{collect_files_with_dates, is_gemini_chat_file, is_json_file};
+use crate::utils::{
+    collect_files_with_dates, is_claude_session_file, is_gemini_chat_file, is_json_file,
+};
 use anyhow::Result;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -47,11 +49,13 @@ pub fn analyze_all_sessions(time_range: TimeRange) -> Result<AnalysisData> {
     let mut gemini_dates: HashSet<String> = HashSet::new();
 
     if paths.claude_session_dir.exists() {
+        // Walks the projects tree recursively, so top-level `<session>.jsonl` logs
+        // and `<session>/subagents/agent-*.jsonl` logs are both collected here.
         process_analysis_directory(
             &paths.claude_session_dir,
             &mut aggregated,
             &mut claude_dates,
-            is_json_file,
+            is_claude_session_file,
             time_range,
         )?;
     }
@@ -134,12 +138,12 @@ pub fn analyze_all_sessions_by_provider(time_range: TimeRange) -> Result<Provide
     let mut copilot_results: Vec<Value> = Vec::new();
     let mut gemini_results: Vec<Value> = Vec::new();
 
-    // Process Claude sessions
+    // Process Claude sessions (including subagents/ sublogs)
     if paths.claude_session_dir.exists() {
         process_full_analysis_directory(
             &paths.claude_session_dir,
             &mut claude_results,
-            is_json_file,
+            is_claude_session_file,
             time_range,
         )?;
     }

--- a/src/usage/calculator.rs
+++ b/src/usage/calculator.rs
@@ -2,7 +2,10 @@ use crate::cache::global_cache;
 use crate::cli::TimeRange;
 use crate::constants::{FastHashMap, capacity};
 use crate::models::{ProviderActiveDays, UsageResult};
-use crate::utils::{collect_files_with_dates, is_gemini_chat_file, is_json_file, resolve_paths};
+use crate::utils::{
+    collect_files_with_dates, is_claude_session_file, is_gemini_chat_file, is_json_file,
+    resolve_paths,
+};
 use anyhow::Result;
 use rayon::prelude::*;
 use serde_json::Value;
@@ -62,11 +65,13 @@ pub fn get_usage_from_directories(time_range: TimeRange) -> Result<UsageData> {
     let mut gemini_dates: HashSet<String> = HashSet::new();
 
     if paths.claude_session_dir.exists() {
+        // Walks the projects tree recursively, so top-level `<session>.jsonl` logs
+        // and `<session>/subagents/agent-*.jsonl` logs are both collected here.
         process_usage_directory(
             &paths.claude_session_dir,
             &mut result,
             &mut claude_dates,
-            is_json_file,
+            is_claude_session_file,
             time_range,
         )?;
     }

--- a/src/utils/directory.rs
+++ b/src/utils/directory.rs
@@ -77,10 +77,11 @@ where
 
 /// Standard filter for JSONL and JSON files
 ///
-/// Excludes `*.meta.json` sidecar files that Claude Code writes alongside
-/// subagent session logs — those are not conversation logs and have no usage data.
+/// Excludes `*.meta.json` / `*.meta.jsonl` sidecar files that Claude Code writes
+/// alongside subagent session logs — those are not conversation logs and have
+/// no usage data.
 pub fn is_json_file(path: &Path) -> bool {
-    if is_meta_json_file(path) {
+    if is_meta_sidecar_file(path) {
         return false;
     }
     if let Some(ext) = path.extension() {
@@ -94,10 +95,10 @@ pub fn is_json_file(path: &Path) -> bool {
 ///
 /// Matches both top-level sessions (`~/.claude/projects/<project>/<session>.jsonl`)
 /// and subagent sessions (`~/.claude/projects/<project>/<session>/subagents/agent-*.jsonl`).
-/// Rejects the `*.meta.json` sidecar files and any non-JSONL artifact that ends
-/// up under the projects directory (e.g. screenshots pasted into prompts).
+/// Rejects meta sidecars (`*.meta.json` / `*.meta.jsonl`) and any non-JSONL artifact
+/// that ends up under the projects directory (e.g. screenshots pasted into prompts).
 pub fn is_claude_session_file(path: &Path) -> bool {
-    if is_meta_json_file(path) {
+    if is_meta_sidecar_file(path) {
         return false;
     }
     path.extension().is_some_and(|ext| ext == "jsonl")
@@ -112,13 +113,14 @@ pub fn is_gemini_chat_file(path: &Path) -> bool {
     }
 }
 
-/// Returns true if the path ends with `.meta.json`
+/// Returns true if the path is a Claude Code meta sidecar file
 ///
-/// Claude Code writes these sidecars next to subagent session logs with
-/// metadata like `agentType` / `description`. They have no usage data and
-/// would otherwise be mis-detected as Codex logs.
-fn is_meta_json_file(path: &Path) -> bool {
+/// Claude Code writes these next to subagent session logs with metadata like
+/// `agentType` / `description`. Today they're `*.meta.json`; we also reject
+/// `*.meta.jsonl` pre-emptively so the filter stays correct if the format
+/// ever switches to line-delimited JSON.
+fn is_meta_sidecar_file(path: &Path) -> bool {
     path.file_name()
         .and_then(|n| n.to_str())
-        .is_some_and(|name| name.ends_with(".meta.json"))
+        .is_some_and(|name| name.ends_with(".meta.json") || name.ends_with(".meta.jsonl"))
 }

--- a/src/utils/directory.rs
+++ b/src/utils/directory.rs
@@ -76,12 +76,31 @@ where
 }
 
 /// Standard filter for JSONL and JSON files
+///
+/// Excludes `*.meta.json` sidecar files that Claude Code writes alongside
+/// subagent session logs — those are not conversation logs and have no usage data.
 pub fn is_json_file(path: &Path) -> bool {
+    if is_meta_json_file(path) {
+        return false;
+    }
     if let Some(ext) = path.extension() {
         ext == "jsonl" || ext == "json"
     } else {
         false
     }
+}
+
+/// Filter for Claude Code session files (`.jsonl` only)
+///
+/// Matches both top-level sessions (`~/.claude/projects/<project>/<session>.jsonl`)
+/// and subagent sessions (`~/.claude/projects/<project>/<session>/subagents/agent-*.jsonl`).
+/// Rejects the `*.meta.json` sidecar files and any non-JSONL artifact that ends
+/// up under the projects directory (e.g. screenshots pasted into prompts).
+pub fn is_claude_session_file(path: &Path) -> bool {
+    if is_meta_json_file(path) {
+        return false;
+    }
+    path.extension().is_some_and(|ext| ext == "jsonl")
 }
 
 /// Filter for Gemini files (must be in chats directory and be .json)
@@ -91,4 +110,15 @@ pub fn is_gemini_chat_file(path: &Path) -> bool {
     } else {
         false
     }
+}
+
+/// Returns true if the path ends with `.meta.json`
+///
+/// Claude Code writes these sidecars next to subagent session logs with
+/// metadata like `agentType` / `description`. They have no usage data and
+/// would otherwise be mis-detected as Codex logs.
+fn is_meta_json_file(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .is_some_and(|name| name.ends_with(".meta.json"))
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -8,7 +8,9 @@ pub mod token_extractor;
 pub mod usage_processor;
 
 // Public API exports (commonly used across modules)
-pub use directory::{collect_files_with_dates, is_gemini_chat_file, is_json_file};
+pub use directory::{
+    collect_files_with_dates, is_claude_session_file, is_gemini_chat_file, is_json_file,
+};
 pub use file::{count_lines, read_json, read_jsonl, save_json_pretty};
 pub use format::{format_number, get_current_date};
 pub use git::get_git_remote_url;

--- a/tests/test_utils_directory.rs
+++ b/tests/test_utils_directory.rs
@@ -245,9 +245,8 @@ fn test_is_json_file_excludes_meta_sidecars() {
 
     // Pre-emptive defense: reject `.meta.jsonl` too, in case Claude Code ever
     // switches the sidecar format to line-delimited JSON.
-    let meta_jsonl = std::path::Path::new(
-        "/home/user/.claude/projects/proj/sess/subagents/agent-x.meta.jsonl",
-    );
+    let meta_jsonl =
+        std::path::Path::new("/home/user/.claude/projects/proj/sess/subagents/agent-x.meta.jsonl");
     assert!(!is_json_file(meta_jsonl));
 }
 

--- a/tests/test_utils_directory.rs
+++ b/tests/test_utils_directory.rs
@@ -7,7 +7,7 @@ use std::io::Write;
 use tempfile::tempdir;
 use vibe_coding_tracker::cli::TimeRange;
 use vibe_coding_tracker::utils::directory::{
-    collect_files_with_dates, is_gemini_chat_file, is_json_file,
+    collect_files_with_dates, is_claude_session_file, is_gemini_chat_file, is_json_file,
 };
 
 #[test]
@@ -229,4 +229,80 @@ fn test_collect_files_with_content() {
     let results = collect_files_with_dates(dir.path(), is_json_file, TimeRange::All).unwrap();
     assert_eq!(results.len(), 1);
     assert!(results[0].path.exists());
+}
+
+#[test]
+fn test_is_json_file_excludes_meta_json() {
+    // *.meta.json sidecars live next to Claude Code subagent sessions and must not
+    // be picked up by the generic json filter (they would otherwise be parsed and
+    // mis-detected as Codex logs).
+    let path = std::path::Path::new("agent-afda1991051a0eb93.meta.json");
+    assert!(!is_json_file(path));
+
+    let nested =
+        std::path::Path::new("/home/user/.claude/projects/proj/sess/subagents/agent-x.meta.json");
+    assert!(!is_json_file(nested));
+}
+
+#[test]
+fn test_is_claude_session_file_accepts_jsonl() {
+    // Top-level Claude session logs
+    let top_level = std::path::Path::new("/home/user/.claude/projects/proj/sess.jsonl");
+    assert!(is_claude_session_file(top_level));
+
+    // Subagent session logs sit one extra level deeper
+    let subagent = std::path::Path::new(
+        "/home/user/.claude/projects/proj/sess/subagents/agent-afda1991051a0eb93.jsonl",
+    );
+    assert!(is_claude_session_file(subagent));
+}
+
+#[test]
+fn test_is_claude_session_file_rejects_non_jsonl() {
+    // Metadata sidecars
+    let meta = std::path::Path::new(
+        "/home/user/.claude/projects/proj/sess/subagents/agent-afda1991051a0eb93.meta.json",
+    );
+    assert!(!is_claude_session_file(meta));
+
+    // Plain .json files (not something Claude Code writes in this tree)
+    let plain_json = std::path::Path::new("/home/user/.claude/projects/proj/notes.json");
+    assert!(!is_claude_session_file(plain_json));
+
+    // Other pasted artifacts
+    let image = std::path::Path::new("/home/user/.claude/projects/proj/sess/paste.png");
+    assert!(!is_claude_session_file(image));
+}
+
+#[test]
+fn test_collect_claude_session_files_includes_subagents() {
+    // Simulates the `~/.claude/projects/<project>/<session>/subagents/` layout:
+    //   projects/<project>/
+    //     sess-a.jsonl                          <- top-level session
+    //     sess-a/subagents/agent-one.jsonl      <- subagent session
+    //     sess-a/subagents/agent-one.meta.json  <- metadata sidecar (ignored)
+    //     sess-a/screenshot.png                 <- pasted artifact (ignored)
+    let dir = tempdir().unwrap();
+    let project = dir.path().join("-home-user-repo");
+    let session_subdir = project.join("sess-a");
+    let subagents = session_subdir.join("subagents");
+    fs::create_dir_all(&subagents).unwrap();
+
+    File::create(project.join("sess-a.jsonl")).unwrap();
+    File::create(subagents.join("agent-one.jsonl")).unwrap();
+    File::create(subagents.join("agent-one.meta.json")).unwrap();
+    File::create(session_subdir.join("screenshot.png")).unwrap();
+
+    let results =
+        collect_files_with_dates(dir.path(), is_claude_session_file, TimeRange::All).unwrap();
+    let names: Vec<String> = results
+        .iter()
+        .filter_map(|f| f.path.file_name()?.to_str().map(String::from))
+        .collect();
+
+    assert_eq!(results.len(), 2, "collected: {:?}", names);
+    assert!(names.contains(&"sess-a.jsonl".to_string()));
+    assert!(names.contains(&"agent-one.jsonl".to_string()));
+    assert!(!names.iter().any(|n| n.ends_with(".meta.json")));
+    assert!(!names.iter().any(|n| n.ends_with(".png")));
 }

--- a/tests/test_utils_directory.rs
+++ b/tests/test_utils_directory.rs
@@ -232,7 +232,7 @@ fn test_collect_files_with_content() {
 }
 
 #[test]
-fn test_is_json_file_excludes_meta_json() {
+fn test_is_json_file_excludes_meta_sidecars() {
     // *.meta.json sidecars live next to Claude Code subagent sessions and must not
     // be picked up by the generic json filter (they would otherwise be parsed and
     // mis-detected as Codex logs).
@@ -242,6 +242,13 @@ fn test_is_json_file_excludes_meta_json() {
     let nested =
         std::path::Path::new("/home/user/.claude/projects/proj/sess/subagents/agent-x.meta.json");
     assert!(!is_json_file(nested));
+
+    // Pre-emptive defense: reject `.meta.jsonl` too, in case Claude Code ever
+    // switches the sidecar format to line-delimited JSON.
+    let meta_jsonl = std::path::Path::new(
+        "/home/user/.claude/projects/proj/sess/subagents/agent-x.meta.jsonl",
+    );
+    assert!(!is_json_file(meta_jsonl));
 }
 
 #[test]
@@ -259,11 +266,18 @@ fn test_is_claude_session_file_accepts_jsonl() {
 
 #[test]
 fn test_is_claude_session_file_rejects_non_jsonl() {
-    // Metadata sidecars
+    // Metadata sidecars — current format (`.meta.json`)
     let meta = std::path::Path::new(
         "/home/user/.claude/projects/proj/sess/subagents/agent-afda1991051a0eb93.meta.json",
     );
     assert!(!is_claude_session_file(meta));
+
+    // Metadata sidecars — hypothetical future format (`.meta.jsonl`). Has `.jsonl`
+    // extension, so without the sidecar check it would slip through.
+    let meta_jsonl = std::path::Path::new(
+        "/home/user/.claude/projects/proj/sess/subagents/agent-afda1991051a0eb93.meta.jsonl",
+    );
+    assert!(!is_claude_session_file(meta_jsonl));
 
     // Plain .json files (not something Claude Code writes in this tree)
     let plain_json = std::path::Path::new("/home/user/.claude/projects/proj/notes.json");
@@ -291,6 +305,7 @@ fn test_collect_claude_session_files_includes_subagents() {
     File::create(project.join("sess-a.jsonl")).unwrap();
     File::create(subagents.join("agent-one.jsonl")).unwrap();
     File::create(subagents.join("agent-one.meta.json")).unwrap();
+    File::create(subagents.join("agent-two.meta.jsonl")).unwrap();
     File::create(session_subdir.join("screenshot.png")).unwrap();
 
     let results =
@@ -303,6 +318,6 @@ fn test_collect_claude_session_files_includes_subagents() {
     assert_eq!(results.len(), 2, "collected: {:?}", names);
     assert!(names.contains(&"sess-a.jsonl".to_string()));
     assert!(names.contains(&"agent-one.jsonl".to_string()));
-    assert!(!names.iter().any(|n| n.ends_with(".meta.json")));
+    assert!(!names.iter().any(|n| n.contains(".meta.")));
     assert!(!names.iter().any(|n| n.ends_with(".png")));
 }


### PR DESCRIPTION
## Summary

- Claude Code writes subagent conversation logs to `~/.claude/projects/<project>/<session>/subagents/agent-*.jsonl`, next to `*.meta.json` sidecar files (`agentType` / `description` only, no usage).
- `collect_files_with_dates` already walks the `projects` tree recursively, so the subagent `.jsonl` files have been picked up all along — but the generic `is_json_file` filter accepted `.json` too, so the meta sidecars were also fed to the analyzer and silently misdetected as Codex logs.
- This PR adds a dedicated `is_claude_session_file` filter that only accepts `.jsonl` and explicitly rejects `*.meta.json`, and switches the Claude walks in `usage::calculator` and `analysis::batch_analyzer` over to it. `is_json_file` also now skips `*.meta.json` as a defense-in-depth change, in case similar sidecars ever land in other providers' trees.

## Verification

- `cargo test` — all 25 directory tests (including four new ones covering `is_claude_session_file` and meta-sidecar rejection) plus the rest of the suite pass.
- `cargo clippy --all-targets -- -D warnings` — clean.
- `vct usage` / `vct analysis --table` still produce sensible output on a real `~/.claude/projects` tree containing 96 subagent `.jsonl` files and 72 `.meta.json` sidecars (subagent costs preserved, no meta sidecar warnings).

## Test plan

- [x] `cargo test`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --release`
- [x] Manual `./target/release/vibe_coding_tracker usage --json` vs. a tree with subagents present and temporarily moved out