### PR TITLE
fix(analysis): route session files by source directory, not content heuristics

### DIFF
--- a/.github/workflows/code-quality-check.yml
+++ b/.github/workflows/code-quality-check.yml
@@ -36,8 +36,7 @@ jobs:
 
       - name: Run pre-commits
         run: |
-          uv tool install pre-commit
-          uv tool run pre-commit run -a
+          uvx pre-commit run -a
 
       - name: rustfmt (check)
         run: |

--- a/.github/workflows/pre-commit-updater.yml
+++ b/.github/workflows/pre-commit-updater.yml
@@ -32,9 +32,8 @@ jobs:
 
       - name: Update Pre-Commit
         run: |
-          uv tool install pre-commit
-          uv tool run pre-commit autoupdate -j 8
-          uv tool run pre-commit run -a
+          uvx pre-commit autoupdate -j 8
+          uvx pre-commit run -a
 
       - name: Create Pull Request
         id: create-pr

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,15 +195,14 @@ cargo clippy --all-targets --all-features -- -D warnings
 The repository ships a `.pre-commit-config.yaml` covering whitespace/EOL fixes, JSON/YAML/TOML linting, `mdformat` for Markdown, `gitleaks` for secret scanning, and `shellcheck`. Install once:
 
 ```bash
-# Install the pre-commit tool itself
-pipx install pre-commit            # or: uv tool install pre-commit
-
-# Install the git hooks into .git/hooks/
-pre-commit install --install-hooks
+# Install the git hooks into .git/hooks/ (uvx fetches pre-commit on demand)
+uvx pre-commit install --install-hooks
 
 # Run against all files (what CI does)
-pre-commit run --all-files
+uvx pre-commit run --all-files
 ```
+
+Prefer a persistent install? `pipx install pre-commit` (or `uv tool install pre-commit`) works too — after that you can drop the `uvx` prefix.
 
 #### Commit Convention
 

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,10 @@ clean: ## Clean build artifacts and caches
 	@git fetch --prune
 	@git gc --prune=now --aggressive
 
-fmt: ## Format code with rustfmt and Lint with clippy
+fmt: ## Format code with rustfmt and auto-fix clippy warnings
 	cargo fmt --all
-	cargo clippy --all-targets --all-features
+	cargo clippy --all-targets --all-features --fix --allow-dirty --allow-staged
+	cargo clippy --all-targets --all-features -- -D warnings
 
 build: ## Build release binary
 	cargo build

--- a/src/analysis/analyzer.rs
+++ b/src/analysis/analyzer.rs
@@ -20,6 +20,15 @@ use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
 
+/// How many JSONL records the auto-detect path may pre-parse before deciding
+/// which provider the file belongs to. Claude Code can prefix a session file
+/// with a handful of metadata sentinel records (`permission-mode`,
+/// `file-history-snapshot`, `queue-operation`) that don't carry the
+/// `parentUuid` field the detector keys on, so looking at only the first line
+/// misclassifies the file as Codex and silently drops its usage. Eight lines
+/// is comfortably larger than any sentinel prelude Claude writes today.
+const AUTODETECT_PEEK_LINES: usize = 8;
+
 /// Analyzes a session file (JSONL or JSON) and returns the result as a
 /// `serde_json::Value` (the CLI single-file dump path).
 ///
@@ -37,8 +46,13 @@ pub fn analyze_jsonl_file<P: AsRef<Path>>(path: P) -> Result<Value> {
     Ok(serde_json::to_value(&analysis)?)
 }
 
-/// Typed entry point used by the global file cache and any caller that wants
-/// to read aggregate fields without paying for a `Value` round-trip.
+/// Typed entry point that auto-detects the provider from file contents.
+///
+/// Prefer [`analyze_session_file_typed_as`] whenever the caller already knows
+/// which provider the file belongs to (e.g. when walking
+/// `~/.claude/projects/*.jsonl` vs `~/.codex/sessions/*.jsonl`). Content-based
+/// detection is only intended for the CLI single-file path where the user
+/// hands us an arbitrary path.
 ///
 /// Parses in [`AnalysisMode::Full`] — for callers that only consume tool
 /// counts and token usage (usage / aggregated analysis), use
@@ -54,7 +68,7 @@ pub fn analyze_jsonl_file_typed_with_mode<P: AsRef<Path>>(
 ) -> Result<CodeAnalysis> {
     let path = path.as_ref();
 
-    if let Some(analysis) = stream_analyze_jsonl(path, mode)? {
+    if let Some(analysis) = stream_analyze_autodetect(path, mode)? {
         return Ok(analysis);
     }
 
@@ -66,51 +80,136 @@ pub fn analyze_jsonl_file_typed_with_mode<P: AsRef<Path>>(
     };
 
     if data.is_empty() {
-        return Ok(CodeAnalysis {
-            user: String::new(),
-            extension_name: String::new(),
-            insights_version: String::new(),
-            machine_id: String::new(),
-            records: Vec::new(),
-        });
+        return Ok(empty_analysis());
     }
 
     let ext_type = detect_extension_type(&data)?;
     dispatch_by_vec(data, ext_type, mode)
 }
 
-/// Peeks the first JSON record to detect format, then routes to a type-driven
-/// streaming analyzer. Returns `Ok(None)` when the input cannot be parsed as
-/// JSONL (e.g. pretty-printed JSON) so the caller can fall back.
-fn stream_analyze_jsonl(path: &Path, mode: AnalysisMode) -> Result<Option<CodeAnalysis>> {
+/// Typed entry point when the caller already knows the provider.
+///
+/// Directory scanners should use this instead of [`analyze_jsonl_file_typed`]
+/// so that provider classification follows the source path — `~/.claude/projects`
+/// is always [`ExtensionType::ClaudeCode`], `~/.codex/sessions` is always
+/// [`ExtensionType::Codex`], and so on. This eliminates a whole class of bug
+/// where a metadata sentinel record at the top of a session (`permission-mode`,
+/// `file-history-snapshot`) leads the content-based detector to mis-file the
+/// log under another provider and silently drop its usage totals.
+pub fn analyze_session_file_typed_as<P: AsRef<Path>>(
+    path: P,
+    provider: ExtensionType,
+    mode: AnalysisMode,
+) -> Result<CodeAnalysis> {
+    let path = path.as_ref();
+
+    if let Some(analysis) = stream_analyze_known(path, provider, mode)? {
+        return Ok(analysis);
+    }
+
+    // Pretty-printed JSON dumps (Gemini/Copilot exports) or empty files.
+    let data = match read_jsonl(path) {
+        Ok(data) => data,
+        Err(_) => read_json(path)?,
+    };
+
+    if data.is_empty() {
+        return Ok(empty_analysis());
+    }
+
+    dispatch_by_vec(data, provider, mode)
+}
+
+/// Streaming path when the provider is known from the caller's source.
+///
+/// Peeks only the first non-empty line to split a JSONL file (where each line
+/// is a record) from a pretty-printed single-object JSON (which parses as a
+/// multi-line block and therefore fails `from_str` on line one). No detection
+/// happens here — the provider was decided by the path the file came from.
+fn stream_analyze_known(
+    path: &Path,
+    provider: ExtensionType,
+    mode: AnalysisMode,
+) -> Result<Option<CodeAnalysis>> {
     let file =
         File::open(path).with_context(|| format!("Failed to open file: {}", path.display()))?;
     let mut reader = BufReader::with_capacity(buffer::FILE_READ_BUFFER, file);
 
-    let first_line = match peek_first_non_empty_line(&mut reader)? {
+    let first_line = match read_next_non_empty_line(&mut reader)? {
         Some(line) => line,
-        None => return Ok(None), // empty file
+        None => return Ok(None), // empty file — caller returns the empty shape
     };
 
     let first_value: Value = match serde_json::from_str(first_line.trim()) {
         Ok(v) => v,
-        Err(_) => return Ok(None), // not JSONL (likely pretty-printed JSON)
+        Err(_) => return Ok(None), // not JSONL → caller falls back to read_json
     };
 
-    let ext = detect_from_first_value(&first_value);
-    let analysis = dispatch_streaming(ext, first_value, reader, mode)?;
+    let analysis = dispatch_streaming_buffered(provider, vec![first_value], reader, mode)?;
+    Ok(Some(finalize(analysis, provider)))
+}
+
+/// Streaming path when the provider is unknown.
+///
+/// Pre-buffers up to [`AUTODETECT_PEEK_LINES`] records so that content-based
+/// detection sees past any Claude metadata preamble (which doesn't carry the
+/// `parentUuid` marker). The pre-parsed records are then handed to the
+/// dispatcher alongside the remainder of the reader so no record is read
+/// twice.
+fn stream_analyze_autodetect(path: &Path, mode: AnalysisMode) -> Result<Option<CodeAnalysis>> {
+    let file =
+        File::open(path).with_context(|| format!("Failed to open file: {}", path.display()))?;
+    let mut reader = BufReader::with_capacity(buffer::FILE_READ_BUFFER, file);
+
+    let mut buffered: Vec<Value> = Vec::with_capacity(AUTODETECT_PEEK_LINES);
+    let mut first_line_was_json = None::<bool>;
+
+    while buffered.len() < AUTODETECT_PEEK_LINES {
+        let line = match read_next_non_empty_line(&mut reader)? {
+            Some(line) => line,
+            None => break,
+        };
+
+        match serde_json::from_str::<Value>(line.trim()) {
+            Ok(v) => {
+                first_line_was_json.get_or_insert(true);
+                buffered.push(v);
+            }
+            Err(_) => {
+                // If we've already buffered at least one valid JSONL record,
+                // stop buffering and let the dispatcher handle what we have.
+                // If this is the very first line, the whole file is likely
+                // pretty-printed JSON — bail so the caller falls back.
+                if buffered.is_empty() {
+                    first_line_was_json = Some(false);
+                }
+                break;
+            }
+        }
+    }
+
+    if first_line_was_json == Some(false) {
+        return Ok(None);
+    }
+
+    if buffered.is_empty() {
+        return Ok(None);
+    }
+
+    let ext = detect_extension_type(&buffered)?;
+    let analysis = dispatch_streaming_buffered(ext, buffered, reader, mode)?;
     Ok(Some(finalize(analysis, ext)))
 }
 
 /// Reads lines from `reader` until it finds a non-empty one. Returns `Ok(None)`
 /// at EOF.
-fn peek_first_non_empty_line<R: BufRead>(reader: &mut R) -> Result<Option<String>> {
+fn read_next_non_empty_line<R: BufRead>(reader: &mut R) -> Result<Option<String>> {
     let mut line = String::new();
     loop {
         line.clear();
         let n = reader
             .read_line(&mut line)
-            .context("Failed to read first line")?;
+            .context("Failed to read line from session file")?;
         if n == 0 {
             return Ok(None);
         }
@@ -120,51 +219,36 @@ fn peek_first_non_empty_line<R: BufRead>(reader: &mut R) -> Result<Option<String
     }
 }
 
-/// Derives the extension type from a single parsed record. This mirrors
-/// [`detect_extension_type`] but without needing the full `Vec<Value>`.
-fn detect_from_first_value(v: &Value) -> ExtensionType {
-    if let Some(obj) = v.as_object() {
-        if obj.contains_key("sessionId")
-            && obj.contains_key("projectHash")
-            && obj.contains_key("messages")
-        {
-            return ExtensionType::Gemini;
-        }
-        if obj.contains_key("sessionId")
-            && obj.contains_key("startTime")
-            && obj.contains_key("timeline")
-        {
-            return ExtensionType::Copilot;
-        }
-        if obj.contains_key("parentUuid") {
-            return ExtensionType::ClaudeCode;
-        }
-    }
-    ExtensionType::Codex
-}
-
-/// Streams the rest of the file, parsing each line directly into the lean
-/// typed shape for the detected provider.
-fn dispatch_streaming(
+/// Streams the rest of the file, prepending any already-parsed records.
+///
+/// Claude/Codex paths feed the buffered records through the typed shape and
+/// then chain the remainder of the reader. Copilot/Gemini are pretty-printed
+/// single-object formats — they should never reach this path in practice
+/// (their first line fails JSONL parse, sending the caller down the
+/// `read_json` fallback), but the arms are kept for completeness so a hand-
+/// crafted one-line JSON fixture still works.
+fn dispatch_streaming_buffered(
     ext: ExtensionType,
-    first_value: Value,
+    buffered: Vec<Value>,
     mut reader: BufReader<File>,
     mode: AnalysisMode,
 ) -> Result<CodeAnalysis> {
     match ext {
         ExtensionType::ClaudeCode => {
             // Match the legacy `filter_map(..., Ok).ok()` behaviour: skip a
-            // malformed leading record instead of failing the whole file.
-            let first_iter = serde_json::from_value::<ClaudeCodeLog>(first_value)
-                .ok()
-                .into_iter();
+            // malformed record instead of failing the whole file.
+            let buffered_iter = buffered
+                .into_iter()
+                .filter_map(|v| serde_json::from_value::<ClaudeCodeLog>(v).ok());
             let rest = iter_jsonl_typed::<ClaudeCodeLog>(&mut reader);
-            analyze_claude_logs(first_iter.chain(rest), mode)
+            analyze_claude_logs(buffered_iter.chain(rest), mode)
         }
         ExtensionType::Codex => {
             let mut logs: Vec<CodexLog> = Vec::with_capacity(64);
-            if let Ok(first) = serde_json::from_value::<CodexLog>(first_value) {
-                logs.push(first);
+            for v in buffered {
+                if let Ok(log) = serde_json::from_value::<CodexLog>(v) {
+                    logs.push(log);
+                }
             }
             for log in iter_jsonl_typed::<CodexLog>(&mut reader) {
                 logs.push(log);
@@ -172,13 +256,21 @@ fn dispatch_streaming(
             analyze_codex_conversations_with_mode(&logs, mode)
         }
         ExtensionType::Copilot => {
+            let first = buffered
+                .into_iter()
+                .next()
+                .context("Copilot session missing top-level object")?;
             let session: CopilotSession =
-                serde_json::from_value(first_value).context("Failed to parse Copilot session")?;
+                serde_json::from_value(first).context("Failed to parse Copilot session")?;
             analyze_copilot_conversations_with_mode(session, mode)
         }
         ExtensionType::Gemini => {
+            let first = buffered
+                .into_iter()
+                .next()
+                .context("Gemini session missing top-level object")?;
             let session: GeminiSession =
-                serde_json::from_value(first_value).context("Failed to parse Gemini session")?;
+                serde_json::from_value(first).context("Failed to parse Gemini session")?;
             analyze_gemini_session(session, mode)
         }
     }
@@ -225,6 +317,16 @@ fn dispatch_by_vec(
         ExtensionType::Gemini => analyze_gemini_conversations_with_mode(data, mode)?,
     };
     Ok(finalize(analysis, ext_type))
+}
+
+fn empty_analysis() -> CodeAnalysis {
+    CodeAnalysis {
+        user: String::new(),
+        extension_name: String::new(),
+        insights_version: String::new(),
+        machine_id: String::new(),
+        records: Vec::new(),
+    }
 }
 
 /// Attaches runtime metadata (user, machine, version) expected in the output.

--- a/src/analysis/batch_analyzer.rs
+++ b/src/analysis/batch_analyzer.rs
@@ -1,9 +1,9 @@
-use crate::analysis::analyzer::analyze_jsonl_file_typed_with_mode;
+use crate::analysis::analyzer::analyze_session_file_typed_as;
 use crate::analysis::common_state::AnalysisMode;
 use crate::cache::global_cache;
 use crate::cli::TimeRange;
 use crate::constants::{FastHashMap, capacity};
-use crate::models::{CodeAnalysis, ProviderActiveDays};
+use crate::models::{CodeAnalysis, ExtensionType, ProviderActiveDays};
 use crate::utils::{
     collect_files_with_dates, is_claude_session_file, is_gemini_chat_file, is_json_file,
 };
@@ -54,6 +54,7 @@ pub fn analyze_all_sessions(time_range: TimeRange) -> Result<AnalysisData> {
         // and `<session>/subagents/agent-*.jsonl` logs are both collected here.
         process_analysis_directory(
             &paths.claude_session_dir,
+            ExtensionType::ClaudeCode,
             &mut aggregated,
             &mut claude_dates,
             is_claude_session_file,
@@ -64,6 +65,7 @@ pub fn analyze_all_sessions(time_range: TimeRange) -> Result<AnalysisData> {
     if paths.codex_session_dir.exists() {
         process_analysis_directory(
             &paths.codex_session_dir,
+            ExtensionType::Codex,
             &mut aggregated,
             &mut codex_dates,
             is_json_file,
@@ -74,6 +76,7 @@ pub fn analyze_all_sessions(time_range: TimeRange) -> Result<AnalysisData> {
     if paths.copilot_session_dir.exists() {
         process_analysis_directory(
             &paths.copilot_session_dir,
+            ExtensionType::Copilot,
             &mut aggregated,
             &mut copilot_dates,
             is_json_file,
@@ -84,6 +87,7 @@ pub fn analyze_all_sessions(time_range: TimeRange) -> Result<AnalysisData> {
     if paths.gemini_session_dir.exists() {
         process_analysis_directory(
             &paths.gemini_session_dir,
+            ExtensionType::Gemini,
             &mut aggregated,
             &mut gemini_dates,
             is_gemini_chat_file,
@@ -150,6 +154,7 @@ pub fn analyze_all_sessions_by_provider(time_range: TimeRange) -> Result<Provide
     if paths.claude_session_dir.exists() {
         process_full_analysis_directory(
             &paths.claude_session_dir,
+            ExtensionType::ClaudeCode,
             &mut claude_results,
             is_claude_session_file,
             time_range,
@@ -160,6 +165,7 @@ pub fn analyze_all_sessions_by_provider(time_range: TimeRange) -> Result<Provide
     if paths.codex_session_dir.exists() {
         process_full_analysis_directory(
             &paths.codex_session_dir,
+            ExtensionType::Codex,
             &mut codex_results,
             is_json_file,
             time_range,
@@ -170,6 +176,7 @@ pub fn analyze_all_sessions_by_provider(time_range: TimeRange) -> Result<Provide
     if paths.copilot_session_dir.exists() {
         process_full_analysis_directory(
             &paths.copilot_session_dir,
+            ExtensionType::Copilot,
             &mut copilot_results,
             is_json_file,
             time_range,
@@ -180,6 +187,7 @@ pub fn analyze_all_sessions_by_provider(time_range: TimeRange) -> Result<Provide
     if paths.gemini_session_dir.exists() {
         process_full_analysis_directory(
             &paths.gemini_session_dir,
+            ExtensionType::Gemini,
             &mut gemini_results,
             is_gemini_chat_file,
             time_range,
@@ -196,6 +204,7 @@ pub fn analyze_all_sessions_by_provider(time_range: TimeRange) -> Result<Provide
 
 fn process_full_analysis_directory<P, F>(
     dir: P,
+    provider: ExtensionType,
     results: &mut Vec<Arc<CodeAnalysis>>,
     filter_fn: F,
     time_range: TimeRange,
@@ -207,12 +216,13 @@ where
     let dir = dir.as_ref();
     let files = collect_files_with_dates(dir, filter_fn, time_range)?;
 
-    // Parallel parse through the global cache; each worker hands back an
-    // `Arc<CodeAnalysis>` pointing at the shared typed analysis.
+    // Parallel parse through the global cache. The provider is fixed by the
+    // source directory, so the cache dispatches to the right analyzer without
+    // re-inspecting the file's contents.
     let analyzed: Vec<Arc<CodeAnalysis>> = files
         .par_iter()
         .filter_map(
-            |file_info| match global_cache().get_or_parse(&file_info.path) {
+            |file_info| match global_cache().get_or_parse_as(&file_info.path, provider) {
                 Ok(analysis_arc) => Some(analysis_arc),
                 Err(e) => {
                     eprintln!(
@@ -232,6 +242,7 @@ where
 
 fn process_analysis_directory<P, F>(
     dir: P,
+    provider: ExtensionType,
     aggregated: &mut FastHashMap<String, AggregatedAnalysisRow>,
     unique_dates: &mut HashSet<String>,
     filter_fn: F,
@@ -247,11 +258,12 @@ where
     // Aggregated analysis only reads counters — no need for `write_file_details`
     // bodies or `edit_file_details` strings. Run in `UsageOnly` and skip the
     // global cache so each file's analysis drops as soon as we've scraped the
-    // tool counts and usage totals.
+    // tool counts and usage totals. Provider is fixed by the source directory.
     let file_aggregations: Vec<(String, CodeAnalysis)> = files
         .par_iter()
         .filter_map(|file_info| {
-            match analyze_jsonl_file_typed_with_mode(&file_info.path, AnalysisMode::UsageOnly) {
+            match analyze_session_file_typed_as(&file_info.path, provider, AnalysisMode::UsageOnly)
+            {
                 Ok(analysis) => Some((file_info.modified_date.clone(), analysis)),
                 Err(e) => {
                     eprintln!(

--- a/src/analysis/claude_analyzer.rs
+++ b/src/analysis/claude_analyzer.rs
@@ -49,31 +49,31 @@ where
             state.last_ts = ts;
         }
 
-        if log.log_type == "assistant" {
-            if let Some(message) = &log.message {
-                if let (Some(model), Some(usage)) = (&message.model, &message.usage) {
-                    process_claude_usage(&mut conversation_usage, model, usage);
-                }
+        if log.log_type == "assistant"
+            && let Some(message) = &log.message
+        {
+            if let (Some(model), Some(usage)) = (&message.model, &message.usage) {
+                process_claude_usage(&mut conversation_usage, model, usage);
+            }
 
-                for item in &message.content {
-                    let ClaudeContentItem::ToolUse { name, input } = item else {
-                        continue;
-                    };
+            for item in &message.content {
+                let ClaudeContentItem::ToolUse { name, input } = item else {
+                    continue;
+                };
 
-                    match name.as_str() {
-                        "Read" => state.tool_counts.read += 1,
-                        "Write" => state.tool_counts.write += 1,
-                        "Edit" => state.tool_counts.edit += 1,
-                        "TodoWrite" => state.tool_counts.todo_write += 1,
-                        "Bash" => {
-                            if let Some(input) = input {
-                                let command = input.command.as_deref().unwrap_or("");
-                                let description = input.description.as_deref().unwrap_or("");
-                                state.add_run_command(command, description, ts);
-                            }
+                match name.as_str() {
+                    "Read" => state.tool_counts.read += 1,
+                    "Write" => state.tool_counts.write += 1,
+                    "Edit" => state.tool_counts.edit += 1,
+                    "TodoWrite" => state.tool_counts.todo_write += 1,
+                    "Bash" => {
+                        if let Some(input) = input {
+                            let command = input.command.as_deref().unwrap_or("");
+                            let description = input.description.as_deref().unwrap_or("");
+                            state.add_run_command(command, description, ts);
                         }
-                        _ => {}
                     }
+                    _ => {}
                 }
             }
         }
@@ -81,12 +81,12 @@ where
         if let Some(tur) = &log.tool_use_result {
             let tur_type = tur.result_type.as_deref().unwrap_or("");
 
-            if tur_type == "text" {
-                if let Some(file) = &tur.file {
-                    let file_path = file.file_path.as_deref().unwrap_or("");
-                    let content = file.content.as_deref().unwrap_or("");
-                    state.add_read_detail(file_path, content, ts);
-                }
+            if tur_type == "text"
+                && let Some(file) = &tur.file
+            {
+                let file_path = file.file_path.as_deref().unwrap_or("");
+                let content = file.content.as_deref().unwrap_or("");
+                state.add_read_detail(file_path, content, ts);
             }
 
             if tur_type == "create" {
@@ -95,11 +95,11 @@ where
                 state.add_write_detail(file_path, content, ts);
             }
 
-            if let Some(file_path) = tur.file_path.as_deref() {
-                if let Some(new_string) = tur.new_string.as_deref() {
-                    let old_string = tur.old_string.as_deref().unwrap_or("");
-                    state.add_edit_detail(file_path, old_string, new_string, ts);
-                }
+            if let Some(file_path) = tur.file_path.as_deref()
+                && let Some(new_string) = tur.new_string.as_deref()
+            {
+                let old_string = tur.old_string.as_deref().unwrap_or("");
+                state.add_edit_detail(file_path, old_string, new_string, ts);
             }
         }
     }

--- a/src/analysis/codex_analyzer.rs
+++ b/src/analysis/codex_analyzer.rs
@@ -28,87 +28,82 @@ pub fn analyze_codex_conversations_with_mode(
 
         match entry.log_type.as_str() {
             "session_meta" => {
-                if state.folder_path.is_empty() {
-                    if let Some(cwd) = &entry.payload.cwd {
-                        state.folder_path.clone_from(cwd); // More efficient than clone()
-                    }
+                if state.folder_path.is_empty()
+                    && let Some(cwd) = &entry.payload.cwd
+                {
+                    state.folder_path.clone_from(cwd); // More efficient than clone()
                 }
-                if state.task_id.is_empty() {
-                    if let Some(id) = &entry.payload.id {
-                        state.task_id.clone_from(id);
-                    }
+                if state.task_id.is_empty()
+                    && let Some(id) = &entry.payload.id
+                {
+                    state.task_id.clone_from(id);
                 }
-                if state.git_remote.is_empty() {
-                    if let Some(git) = &entry.payload.git {
-                        if let Some(url) = &git.repository_url {
-                            state.git_remote.clone_from(url);
-                        }
-                    }
+                if state.git_remote.is_empty()
+                    && let Some(git) = &entry.payload.git
+                    && let Some(url) = &git.repository_url
+                {
+                    state.git_remote.clone_from(url);
                 }
             }
             "turn_context" => {
-                if state.folder_path.is_empty() {
-                    if let Some(cwd) = &entry.payload.cwd {
-                        state.folder_path.clone_from(cwd);
-                    }
+                if state.folder_path.is_empty()
+                    && let Some(cwd) = &entry.payload.cwd
+                {
+                    state.folder_path.clone_from(cwd);
                 }
                 if let Some(model) = &entry.payload.model {
                     current_model.clone_from(model); // Reuse existing allocation
                 }
             }
             "event_msg" => {
-                if let Some(payload_type) = &entry.payload.payload_type {
-                    if payload_type == "token_count" && !current_model.is_empty() {
-                        if let Some(info) = &entry.payload.info {
-                            process_codex_usage(&mut conversation_usage, &current_model, info);
-                        }
-                    }
+                if let Some(payload_type) = &entry.payload.payload_type
+                    && payload_type == "token_count"
+                    && !current_model.is_empty()
+                    && let Some(info) = &entry.payload.info
+                {
+                    process_codex_usage(&mut conversation_usage, &current_model, info);
                 }
             }
             "response_item" => {
                 if let Some(payload_type) = &entry.payload.payload_type {
                     match payload_type.as_str() {
                         "function_call" => {
-                            if let Some(name) = &entry.payload.name {
-                                if name == "shell" {
-                                    if let Some(args_str) = &entry.payload.arguments {
-                                        if let Ok(args) =
-                                            serde_json::from_str::<CodexShellArguments>(args_str)
-                                        {
-                                            let script =
-                                                args.command.last().cloned().unwrap_or_default();
-                                            if let Some(call_id) = &entry.payload.call_id {
-                                                shell_calls.insert(
-                                                    call_id.clone(),
-                                                    CodexShellCall {
-                                                        timestamp: ts,
-                                                        script: script.clone(),
-                                                        full_command: args.command,
-                                                    },
-                                                );
-                                            }
-                                        }
-                                    }
+                            if let Some(name) = &entry.payload.name
+                                && name == "shell"
+                                && let Some(args_str) = &entry.payload.arguments
+                                && let Ok(args) =
+                                    serde_json::from_str::<CodexShellArguments>(args_str)
+                            {
+                                let script = args.command.last().cloned().unwrap_or_default();
+                                if let Some(call_id) = &entry.payload.call_id {
+                                    shell_calls.insert(
+                                        call_id.clone(),
+                                        CodexShellCall {
+                                            timestamp: ts,
+                                            script: script.clone(),
+                                            full_command: args.command,
+                                        },
+                                    );
                                 }
                             }
                         }
                         "function_call_output" => {
-                            if let Some(call_id) = &entry.payload.call_id {
-                                if let Some(call) = shell_calls.remove(call_id) {
-                                    let output = if let Some(output_str) = &entry.payload.output {
-                                        serde_json::from_str::<CodexShellOutput>(output_str)
-                                            .unwrap_or_else(|_| CodexShellOutput {
-                                                output: output_str.clone(),
-                                                metadata: None,
-                                            })
-                                    } else {
-                                        CodexShellOutput {
-                                            output: String::new(),
+                            if let Some(call_id) = &entry.payload.call_id
+                                && let Some(call) = shell_calls.remove(call_id)
+                            {
+                                let output = if let Some(output_str) = &entry.payload.output {
+                                    serde_json::from_str::<CodexShellOutput>(output_str)
+                                        .unwrap_or_else(|_| CodexShellOutput {
+                                            output: output_str.clone(),
                                             metadata: None,
-                                        }
-                                    };
-                                    state.handle_shell_call(call, output);
-                                }
+                                        })
+                                } else {
+                                    CodexShellOutput {
+                                        output: String::new(),
+                                        metadata: None,
+                                    }
+                                };
+                                state.handle_shell_call(call, output);
                             }
                         }
                         _ => {}

--- a/src/analysis/detector.rs
+++ b/src/analysis/detector.rs
@@ -15,23 +15,23 @@ pub fn detect_extension_type(data: &[Value]) -> Result<ExtensionType> {
     }
 
     // Quick check for single object formats (Gemini or Copilot)
-    if data.len() == 1 {
-        if let Some(obj) = data[0].as_object() {
-            // Check for Gemini format
-            if obj.contains_key("sessionId")
-                && obj.contains_key("projectHash")
-                && obj.contains_key("messages")
-            {
-                return Ok(ExtensionType::Gemini);
-            }
+    if data.len() == 1
+        && let Some(obj) = data[0].as_object()
+    {
+        // Check for Gemini format
+        if obj.contains_key("sessionId")
+            && obj.contains_key("projectHash")
+            && obj.contains_key("messages")
+        {
+            return Ok(ExtensionType::Gemini);
+        }
 
-            // Check for Copilot CLI format
-            if obj.contains_key("sessionId")
-                && obj.contains_key("startTime")
-                && obj.contains_key("timeline")
-            {
-                return Ok(ExtensionType::Copilot);
-            }
+        // Check for Copilot CLI format
+        if obj.contains_key("sessionId")
+            && obj.contains_key("startTime")
+            && obj.contains_key("timeline")
+        {
+            return Ok(ExtensionType::Copilot);
         }
     }
 

--- a/src/analysis/detector.rs
+++ b/src/analysis/detector.rs
@@ -35,10 +35,15 @@ pub fn detect_extension_type(data: &[Value]) -> Result<ExtensionType> {
         }
     }
 
-    // Single-pass detection for Claude Code or Codex
-    // Check first few records for efficiency (usually determined in first record)
-    let sample_size = data.len().min(5);
-    for record in &data[..sample_size] {
+    // Single-pass detection for Claude Code or Codex.
+    //
+    // The caller decides how much to pass in (the streaming auto-detect path
+    // buffers up to 8 records), so we scan the whole slice here — previously
+    // this was capped at 5 records, which silently missed Claude sessions
+    // whose `parentUuid`-bearing record sat past a 6+-line metadata prelude
+    // (e.g. `permission-mode` followed by several `file-history-snapshot`
+    // records).
+    for record in data {
         if let Some(obj) = record.as_object() {
             // Claude Code has parentUuid field
             if obj.contains_key("parentUuid") {

--- a/src/cache/file_cache.rs
+++ b/src/cache/file_cache.rs
@@ -1,7 +1,8 @@
+use crate::analysis::AnalysisMode;
 use crate::constants::capacity;
 use crate::models::{
     CodeAnalysis, CodeAnalysisApplyDiffDetail, CodeAnalysisReadDetail, CodeAnalysisRecord,
-    CodeAnalysisRunCommandDetail, CodeAnalysisWriteDetail,
+    CodeAnalysisRunCommandDetail, CodeAnalysisWriteDetail, ExtensionType,
 };
 use anyhow::Result;
 use lru::LruCache;
@@ -45,7 +46,12 @@ impl FileParseCache {
         }
     }
 
-    /// Retrieves cached analysis or parses the file if needed.
+    /// Retrieves cached analysis or parses the file if needed, auto-detecting
+    /// the provider from file contents.
+    ///
+    /// Prefer [`Self::get_or_parse_as`] whenever the caller already knows which
+    /// provider the file belongs to (e.g. walking a specific session
+    /// directory). Content detection is only safe for ad-hoc single-file paths.
     ///
     /// Workflow:
     /// 1. Check cache hit with read-only peek (no lock contention)
@@ -54,7 +60,27 @@ impl FileParseCache {
     ///
     /// Optimized to minimize write lock contention in parallel workloads.
     pub fn get_or_parse<P: AsRef<Path>>(&self, path: P) -> Result<Arc<CodeAnalysis>> {
-        let path = path.as_ref();
+        self.get_or_parse_inner(path.as_ref(), None)
+    }
+
+    /// Same as [`Self::get_or_parse`] but the caller specifies which provider
+    /// the file belongs to — the analyzer skips content-based detection, so
+    /// metadata sentinels at the top of a Claude session (`permission-mode`,
+    /// `file-history-snapshot`) cannot cause the file to be mis-filed under a
+    /// different provider.
+    pub fn get_or_parse_as<P: AsRef<Path>>(
+        &self,
+        path: P,
+        provider: ExtensionType,
+    ) -> Result<Arc<CodeAnalysis>> {
+        self.get_or_parse_inner(path.as_ref(), Some(provider))
+    }
+
+    fn get_or_parse_inner(
+        &self,
+        path: &Path,
+        provider: Option<ExtensionType>,
+    ) -> Result<Arc<CodeAnalysis>> {
         let path_buf = path.to_path_buf();
 
         // Get file metadata (modification time)
@@ -86,7 +112,10 @@ impl FileParseCache {
 
         // Cache miss or outdated - need to parse.
         log::debug!("LRU cache miss for {}, parsing...", path.display());
-        let analysis = crate::analysis::analyze_jsonl_file_typed(path)?;
+        let analysis = match provider {
+            Some(p) => crate::analysis::analyze_session_file_typed_as(path, p, AnalysisMode::Full)?,
+            None => crate::analysis::analyze_jsonl_file_typed(path)?,
+        };
         let arc_analysis = Arc::new(analysis);
         let size_bytes = estimate_analysis_bytes(arc_analysis.as_ref());
 

--- a/src/display/common/tui.rs
+++ b/src/display/common/tui.rs
@@ -29,17 +29,17 @@ pub fn restore_terminal(
 
 /// Handle keyboard input and return whether to quit
 pub fn handle_input() -> anyhow::Result<InputAction> {
-    if event::poll(Duration::from_millis(100))? {
-        if let Event::Key(key) = event::read()? {
-            if key.code == KeyCode::Char('q')
-                || key.code == KeyCode::Esc
-                || (key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL))
-            {
-                return Ok(InputAction::Quit);
-            }
-            if key.code == KeyCode::Char('r') || key.code == KeyCode::Char('R') {
-                return Ok(InputAction::Refresh);
-            }
+    if event::poll(Duration::from_millis(100))?
+        && let Event::Key(key) = event::read()?
+    {
+        if key.code == KeyCode::Char('q')
+            || key.code == KeyCode::Esc
+            || (key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL))
+        {
+            return Ok(InputAction::Quit);
+        }
+        if key.code == KeyCode::Char('r') || key.code == KeyCode::Char('R') {
+            return Ok(InputAction::Refresh);
         }
     }
     Ok(InputAction::Continue)

--- a/src/pricing/cache.rs
+++ b/src/pricing/cache.rs
@@ -194,10 +194,10 @@ pub fn parse_litellm_entry(value: &serde_json::Value) -> ModelPricing {
                         if let Some(th) = parse_threshold_suffix(inner) {
                             tier_cache_creation_1hr.insert(th, num_value);
                         }
-                    } else if !suffix.starts_with("1hr") {
-                        if let Some(th) = parse_threshold_suffix(suffix) {
-                            tier_cache_creation.insert(th, num_value);
-                        }
+                    } else if !suffix.starts_with("1hr")
+                        && let Some(th) = parse_threshold_suffix(suffix)
+                    {
+                        tier_cache_creation.insert(th, num_value);
                     }
                 }
             }

--- a/src/pricing/matching.rs
+++ b/src/pricing/matching.rs
@@ -91,10 +91,10 @@ impl ModelPricingMap {
     /// Results are cached globally for performance.
     pub fn get(&self, model_name: &str) -> ModelPricingResult {
         // Ultra-fast path: Check LRU cache first (with peek to avoid write lock)
-        if let Ok(cache_read) = MATCH_CACHE.read() {
-            if let Some(cached_result) = cache_read.peek(model_name) {
-                return cached_result.clone();
-            }
+        if let Ok(cache_read) = MATCH_CACHE.read()
+            && let Some(cached_result) = cache_read.peek(model_name)
+        {
+            return cached_result.clone();
         }
 
         // Fast path 1: Exact match
@@ -112,18 +112,18 @@ impl ModelPricingMap {
 
         // Fast path 2: Normalized match
         let normalized_name = normalize_model_name(model_name);
-        if let Some(original_key) = self.normalized_index.get(&normalized_name) {
-            if let Some(pricing) = self.raw.get(original_key.as_ref()) {
-                let result = ModelPricingResult {
-                    pricing: pricing.clone(),
-                    matched_model: Some(original_key.to_string()), // Convert Rc to String only when needed
-                };
-                // Cache the normalized match result (LRU will auto-evict if at capacity)
-                if let Ok(mut cache_write) = MATCH_CACHE.write() {
-                    cache_write.put(model_name.to_string(), result.clone());
-                }
-                return result;
+        if let Some(original_key) = self.normalized_index.get(&normalized_name)
+            && let Some(pricing) = self.raw.get(original_key.as_ref())
+        {
+            let result = ModelPricingResult {
+                pricing: pricing.clone(),
+                matched_model: Some(original_key.to_string()), // Convert Rc to String only when needed
+            };
+            // Cache the normalized match result (LRU will auto-evict if at capacity)
+            if let Ok(mut cache_write) = MATCH_CACHE.write() {
+                cache_write.put(model_name.to_string(), result.clone());
             }
+            return result;
         }
 
         // Slow path: Substring and fuzzy matching (optimized)
@@ -158,18 +158,18 @@ impl ModelPricingMap {
         }
 
         // Return best match if found
-        if let Some((matched_key, _, _)) = best_match {
-            if let Some(pricing) = self.raw.get(matched_key.as_ref()) {
-                let result = ModelPricingResult {
-                    pricing: pricing.clone(),
-                    matched_model: Some(matched_key.to_string()), // Convert to String only when needed
-                };
-                // Cache the fuzzy match result (LRU will auto-evict if at capacity)
-                if let Ok(mut cache_write) = MATCH_CACHE.write() {
-                    cache_write.put(model_name.to_string(), result.clone());
-                }
-                return result;
+        if let Some((matched_key, _, _)) = best_match
+            && let Some(pricing) = self.raw.get(matched_key.as_ref())
+        {
+            let result = ModelPricingResult {
+                pricing: pricing.clone(),
+                matched_model: Some(matched_key.to_string()), // Convert to String only when needed
+            };
+            // Cache the fuzzy match result (LRU will auto-evict if at capacity)
+            if let Ok(mut cache_write) = MATCH_CACHE.write() {
+                cache_write.put(model_name.to_string(), result.clone());
             }
+            return result;
         }
 
         // Return default (zero costs) if no match found

--- a/src/usage/calculator.rs
+++ b/src/usage/calculator.rs
@@ -1,7 +1,7 @@
-use crate::analysis::{AnalysisMode, analyze_jsonl_file_typed_with_mode};
+use crate::analysis::{AnalysisMode, analyze_session_file_typed_as};
 use crate::cli::TimeRange;
 use crate::constants::{FastHashMap, capacity};
-use crate::models::{CodeAnalysis, ProviderActiveDays, UsageResult};
+use crate::models::{CodeAnalysis, ExtensionType, ProviderActiveDays, UsageResult};
 use crate::utils::{
     collect_files_with_dates, is_claude_session_file, is_gemini_chat_file, is_json_file,
     resolve_paths,
@@ -56,6 +56,7 @@ pub fn get_usage_from_directories(time_range: TimeRange) -> Result<UsageData> {
         // and `<session>/subagents/agent-*.jsonl` logs are both collected here.
         process_usage_directory(
             &paths.claude_session_dir,
+            ExtensionType::ClaudeCode,
             &mut result,
             &mut claude_dates,
             is_claude_session_file,
@@ -66,6 +67,7 @@ pub fn get_usage_from_directories(time_range: TimeRange) -> Result<UsageData> {
     if paths.codex_session_dir.exists() {
         process_usage_directory(
             &paths.codex_session_dir,
+            ExtensionType::Codex,
             &mut result,
             &mut codex_dates,
             is_json_file,
@@ -76,6 +78,7 @@ pub fn get_usage_from_directories(time_range: TimeRange) -> Result<UsageData> {
     if paths.copilot_session_dir.exists() {
         process_usage_directory(
             &paths.copilot_session_dir,
+            ExtensionType::Copilot,
             &mut result,
             &mut copilot_dates,
             is_json_file,
@@ -86,6 +89,7 @@ pub fn get_usage_from_directories(time_range: TimeRange) -> Result<UsageData> {
     if paths.gemini_session_dir.exists() {
         process_usage_directory(
             &paths.gemini_session_dir,
+            ExtensionType::Gemini,
             &mut result,
             &mut gemini_dates,
             is_gemini_chat_file,
@@ -115,6 +119,7 @@ pub fn get_usage_from_directories(time_range: TimeRange) -> Result<UsageData> {
 
 fn process_usage_directory<P, F>(
     dir: P,
+    provider: ExtensionType,
     result: &mut UsageResult,
     unique_dates: &mut HashSet<String>,
     filter_fn: F,
@@ -128,14 +133,19 @@ where
     let files = collect_files_with_dates(dir, filter_fn, time_range)?;
 
     // Parse each file directly in `UsageOnly` mode, extract the small
-    // per-model usage map, then drop the analysis. We deliberately bypass the
-    // global file cache here: the `usage` path never needs the heavy
-    // `write_file_details` / `edit_file_details` payloads, so caching the
-    // full analysis would waste the memory win from `UsageOnly`.
+    // per-model usage map, then drop the analysis. The provider is fixed by
+    // the source directory — we do not re-detect from file contents, which
+    // would mis-classify Claude sessions whose first line is a metadata
+    // sentinel (`permission-mode`, `file-history-snapshot`) and silently drop
+    // their usage. We also deliberately bypass the global file cache here:
+    // the `usage` path never needs the heavy `write_file_details` /
+    // `edit_file_details` payloads, so caching the full analysis would waste
+    // the memory win from `UsageOnly`.
     let file_results: Vec<(String, FastHashMap<String, Value>)> = files
         .par_iter()
         .filter_map(|file_info| {
-            match analyze_jsonl_file_typed_with_mode(&file_info.path, AnalysisMode::UsageOnly) {
+            match analyze_session_file_typed_as(&file_info.path, provider, AnalysisMode::UsageOnly)
+            {
                 Ok(analysis) => {
                     let conversation_usage = extract_conversation_usage_from_analysis(&analysis);
                     Some((file_info.modified_date.clone(), conversation_usage))

--- a/src/usage/calculator.rs
+++ b/src/usage/calculator.rs
@@ -202,10 +202,10 @@ fn merge_usage_values(existing: &mut Value, new: &Value) {
             }
         }
         // Handle Codex format (has total_token_usage)
-        else if existing_obj.contains_key("total_token_usage") {
-            if let Some(new_total) = new_obj.get("total_token_usage").and_then(|v| v.as_object()) {
-                accumulate_nested_object(existing_obj, "total_token_usage", new_total);
-            }
+        else if existing_obj.contains_key("total_token_usage")
+            && let Some(new_total) = new_obj.get("total_token_usage").and_then(|v| v.as_object())
+        {
+            accumulate_nested_object(existing_obj, "total_token_usage", new_total);
         }
     }
 }

--- a/src/utils/directory.rs
+++ b/src/utils/directory.rs
@@ -59,10 +59,10 @@ where
             let date_key = datetime.format("%Y-%m-%d").to_string();
 
             // Apply time range filter
-            if let Some(ref cutoff_str) = cutoff {
-                if date_key.as_str() < cutoff_str.as_str() {
-                    continue;
-                }
+            if let Some(ref cutoff_str) = cutoff
+                && date_key.as_str() < cutoff_str.as_str()
+            {
+                continue;
             }
 
             results.push(FileInfo {

--- a/src/utils/format.rs
+++ b/src/utils/format.rs
@@ -47,12 +47,11 @@ pub fn get_current_date() -> String {
 
     // Fast path: read lock to check if cache is valid
     {
-        if let Ok(cache) = DATE_CACHE.read() {
-            if let Some((cached_date, cached_string)) = cache.as_ref() {
-                if *cached_date == today {
-                    return cached_string.clone();
-                }
-            }
+        if let Ok(cache) = DATE_CACHE.read()
+            && let Some((cached_date, cached_string)) = cache.as_ref()
+            && *cached_date == today
+        {
+            return cached_string.clone();
         }
     }
 

--- a/src/utils/git.rs
+++ b/src/utils/git.rs
@@ -21,10 +21,10 @@ pub fn get_git_remote_url<P: AsRef<Path>>(cwd: P) -> String {
         .unwrap_or_else(|| cwd.as_ref().to_string_lossy().to_string());
 
     // Check cache first
-    if let Ok(cache) = GIT_URL_CACHE.read() {
-        if let Some(url) = cache.get(&canonical_path) {
-            return url.clone();
-        }
+    if let Ok(cache) = GIT_URL_CACHE.read()
+        && let Some(url) = cache.get(&canonical_path)
+    {
+        return url.clone();
     }
 
     // Cache miss - perform actual lookup

--- a/src/utils/paths.rs
+++ b/src/utils/paths.rs
@@ -72,10 +72,10 @@ pub fn get_machine_id() -> &'static str {
         }
 
         // Fallback to hostname
-        if let Ok(hostname) = hostname::get() {
-            if let Some(hostname_str) = hostname.to_str() {
-                return hostname_str.to_string();
-            }
+        if let Ok(hostname) = hostname::get()
+            && let Some(hostname_str) = hostname.to_str()
+        {
+            return hostname_str.to_string();
         }
 
         "unknown-machine-id".to_string()

--- a/tests/integrations/analysis_tests.rs
+++ b/tests/integrations/analysis_tests.rs
@@ -4,11 +4,13 @@
 
 use std::path::PathBuf;
 use tempfile::TempDir;
-use vibe_coding_tracker::analysis::analyzer::analyze_jsonl_file;
+use vibe_coding_tracker::analysis::analyzer::{analyze_jsonl_file, analyze_session_file_typed_as};
 use vibe_coding_tracker::analysis::batch_analyzer::{
     analyze_all_sessions, analyze_all_sessions_by_provider,
 };
+use vibe_coding_tracker::analysis::common_state::AnalysisMode;
 use vibe_coding_tracker::cli::TimeRange;
+use vibe_coding_tracker::models::ExtensionType;
 
 #[test]
 fn test_single_file_analysis_claude() {
@@ -417,4 +419,102 @@ fn test_analysis_aggregation_logic() {
     assert_eq!(total_edit_lines, 100);
     assert_eq!(total_read_lines, 200);
     assert_eq!(total_write_lines, 50);
+}
+
+/// Regression for the silent usage drop that happened when a Claude session
+/// started with a metadata sentinel (`permission-mode`, `file-history-snapshot`,
+/// `queue-operation`). Those records don't carry `parentUuid`, so the old
+/// streaming detector — which only looked at the first line — classified the
+/// whole file as Codex and the assistant `usage` entries never landed in the
+/// Claude totals. This test writes a fixture with a `permission-mode` prelude
+/// and asserts both the provider-known entry point and the auto-detect entry
+/// point return the Claude model usage.
+fn write_claude_fixture_with_sentinel_prelude(path: &std::path::Path, sentinel_type: &str) {
+    let sentinel = match sentinel_type {
+        "permission-mode" => {
+            r#"{"type":"permission-mode","permissionMode":"default","sessionId":"sess-1"}"#
+        }
+        "file-history-snapshot" => {
+            r#"{"type":"file-history-snapshot","messageId":"m1","isSnapshotUpdate":false,"snapshot":{}}"#
+        }
+        _ => unreachable!(),
+    };
+
+    // Minimal assistant message with the fields the analyzer reads:
+    // model + usage. No <synthetic> — those are intentionally skipped.
+    let assistant = r#"{"type":"assistant","sessionId":"sess-1","parentUuid":"pu","timestamp":"2026-04-23T00:00:00.000Z","message":{"model":"claude-opus-4-7","usage":{"input_tokens":100,"output_tokens":50,"cache_creation_input_tokens":10,"cache_read_input_tokens":20,"service_tier":"standard","cache_creation":{"ephemeral_5m_input_tokens":10}},"content":[]}}"#;
+
+    let body = format!("{sentinel}\n{assistant}\n");
+    std::fs::write(path, body).unwrap();
+}
+
+fn usage_input_tokens_for_model(analysis: &serde_json::Value, model: &str) -> i64 {
+    analysis["records"]
+        .as_array()
+        .and_then(|records| records.first())
+        .and_then(|r| r.get("conversationUsage"))
+        .and_then(|cu| cu.get(model))
+        .and_then(|u| u.get("input_tokens"))
+        .and_then(|v| v.as_i64())
+        .unwrap_or(-1)
+}
+
+#[test]
+fn test_provider_known_extracts_usage_when_first_line_is_permission_mode() {
+    let tmp = TempDir::new().unwrap();
+    let file = tmp.path().join("session.jsonl");
+    write_claude_fixture_with_sentinel_prelude(&file, "permission-mode");
+
+    let analysis =
+        analyze_session_file_typed_as(&file, ExtensionType::ClaudeCode, AnalysisMode::UsageOnly)
+            .expect("provider-known path should accept the sentinel prelude");
+
+    assert_eq!(analysis.extension_name, "Claude-Code");
+    assert_eq!(analysis.records.len(), 1);
+
+    let record = &analysis.records[0];
+    let usage = record
+        .conversation_usage
+        .get("claude-opus-4-7")
+        .expect("claude-opus-4-7 usage should be recorded despite the permission-mode prelude");
+    assert_eq!(usage["input_tokens"], 100);
+    assert_eq!(usage["output_tokens"], 50);
+    assert_eq!(usage["cache_creation_input_tokens"], 10);
+    assert_eq!(usage["cache_read_input_tokens"], 20);
+}
+
+#[test]
+fn test_provider_known_extracts_usage_when_first_line_is_file_history_snapshot() {
+    let tmp = TempDir::new().unwrap();
+    let file = tmp.path().join("session.jsonl");
+    write_claude_fixture_with_sentinel_prelude(&file, "file-history-snapshot");
+
+    let analysis =
+        analyze_session_file_typed_as(&file, ExtensionType::ClaudeCode, AnalysisMode::UsageOnly)
+            .expect("provider-known path should accept the sentinel prelude");
+
+    let record = &analysis.records[0];
+    assert!(
+        record.conversation_usage.contains_key("claude-opus-4-7"),
+        "claude-opus-4-7 usage should be recorded even when first line is file-history-snapshot"
+    );
+}
+
+#[test]
+fn test_autodetect_sees_past_sentinel_prelude() {
+    // The auto-detect path (used by the CLI `vct analysis <file>` form) should
+    // peek enough records to spot the Claude-shaped assistant row sitting
+    // behind the metadata preamble.
+    let tmp = TempDir::new().unwrap();
+    let file = tmp.path().join("session.jsonl");
+    write_claude_fixture_with_sentinel_prelude(&file, "permission-mode");
+
+    let analysis = analyze_jsonl_file(&file).expect("auto-detect should handle the prelude");
+
+    assert_eq!(analysis["extensionName"], "Claude-Code");
+    assert_eq!(
+        usage_input_tokens_for_model(&analysis, "claude-opus-4-7"),
+        100,
+        "auto-detect should extract the assistant record's usage, not drop the whole file"
+    );
 }

--- a/tests/integrations/analysis_tests.rs
+++ b/tests/integrations/analysis_tests.rs
@@ -437,6 +437,9 @@ fn write_claude_fixture_with_sentinel_prelude(path: &std::path::Path, sentinel_t
         "file-history-snapshot" => {
             r#"{"type":"file-history-snapshot","messageId":"m1","isSnapshotUpdate":false,"snapshot":{}}"#
         }
+        "queue-operation" => {
+            r#"{"type":"queue-operation","operation":"enqueue","sessionId":"sess-1","content":"x","timestamp":"2026-04-23T00:00:00.000Z"}"#
+        }
         _ => unreachable!(),
     };
 
@@ -497,6 +500,37 @@ fn test_provider_known_extracts_usage_when_first_line_is_file_history_snapshot()
     assert!(
         record.conversation_usage.contains_key("claude-opus-4-7"),
         "claude-opus-4-7 usage should be recorded even when first line is file-history-snapshot"
+    );
+}
+
+#[test]
+fn test_provider_known_extracts_usage_when_first_line_is_queue_operation() {
+    let tmp = TempDir::new().unwrap();
+    let file = tmp.path().join("session.jsonl");
+    write_claude_fixture_with_sentinel_prelude(&file, "queue-operation");
+
+    let analysis =
+        analyze_session_file_typed_as(&file, ExtensionType::ClaudeCode, AnalysisMode::UsageOnly)
+            .expect("provider-known path should accept the sentinel prelude");
+
+    let record = &analysis.records[0];
+    assert!(
+        record.conversation_usage.contains_key("claude-opus-4-7"),
+        "claude-opus-4-7 usage should be recorded even when first line is queue-operation"
+    );
+}
+
+#[test]
+fn test_autodetect_sees_past_queue_operation_prelude() {
+    let tmp = TempDir::new().unwrap();
+    let file = tmp.path().join("session.jsonl");
+    write_claude_fixture_with_sentinel_prelude(&file, "queue-operation");
+
+    let analysis = analyze_jsonl_file(&file).expect("auto-detect should handle the prelude");
+    assert_eq!(analysis["extensionName"], "Claude-Code");
+    assert_eq!(
+        usage_input_tokens_for_model(&analysis, "claude-opus-4-7"),
+        100,
     );
 }
 

--- a/tests/integrations/analysis_tests.rs
+++ b/tests/integrations/analysis_tests.rs
@@ -246,15 +246,15 @@ fn test_batch_analysis_basic() {
 fn test_batch_analysis_sorting() {
     let result = analyze_all_sessions(TimeRange::All);
 
-    if let Ok(data) = result {
-        if data.rows.len() > 1 {
-            // Verify sorting: models should be in alphabetical order
-            for i in 0..data.rows.len() - 1 {
-                assert!(
-                    data.rows[i].model <= data.rows[i + 1].model,
-                    "Models should be sorted alphabetically"
-                );
-            }
+    if let Ok(data) = result
+        && data.rows.len() > 1
+    {
+        // Verify sorting: models should be in alphabetical order
+        for i in 0..data.rows.len() - 1 {
+            assert!(
+                data.rows[i].model <= data.rows[i + 1].model,
+                "Models should be sorted alphabetically"
+            );
         }
     }
 }

--- a/tests/integrations/cli_tests.rs
+++ b/tests/integrations/cli_tests.rs
@@ -119,12 +119,13 @@ fn test_analysis_batch_mode_with_output() {
     // May timeout on slow systems or large session directories
     let output = cmd.output();
 
-    if let Ok(output) = output {
-        if output.status.success() && output_file.exists() {
-            let content = std::fs::read_to_string(&output_file).unwrap();
-            let json: serde_json::Value = serde_json::from_str(&content).unwrap();
-            assert!(json.is_array(), "Batch output should be JSON array");
-        }
+    if let Ok(output) = output
+        && output.status.success()
+        && output_file.exists()
+    {
+        let content = std::fs::read_to_string(&output_file).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert!(json.is_array(), "Batch output should be JSON array");
     }
 }
 

--- a/tests/test_detector.rs
+++ b/tests/test_detector.rs
@@ -80,6 +80,26 @@ fn test_detect_claude_code_in_first_few_records() {
 }
 
 #[test]
+fn test_detect_claude_code_past_fifth_record() {
+    // Regression: the streaming auto-detect path buffers up to 8 records and
+    // hands them all to `detect_extension_type`. Earlier versions capped the
+    // scan at 5 records, so a Claude session with a 6+-line metadata prelude
+    // (e.g. `permission-mode` followed by several `file-history-snapshot`
+    // entries) silently fell through to Codex. The detector must now scan the
+    // full slice the caller supplies.
+    let mut data: Vec<Value> = (0..7)
+        .map(|i| json!({"type": "file-history-snapshot", "idx": i}))
+        .collect();
+    data.push(json!({
+        "parentUuid": "deep-uuid",
+        "type": "user"
+    }));
+
+    let result = detect_extension_type(&data).unwrap();
+    assert_eq!(result, ExtensionType::ClaudeCode);
+}
+
+#[test]
 fn test_detect_empty_data_error() {
     // Test that empty data returns an error
     let data: Vec<Value> = vec![];


### PR DESCRIPTION
## Summary

- Claude session files that open with a metadata sentinel (`permission-mode`, `file-history-snapshot`, `queue-operation`) were silently mis-classified as Codex after #12, dropping ~94% of `claude-opus-4-6` and ~97% of `claude-opus-4-7` totals in `vct usage`. Sonnet/Haiku looked correct only because subagent logs (which start with a `user` record that carries `parentUuid`) still classified fine.
- Root cause: the streaming entry introduced in #12 peeked only the first line for provider detection. Those sentinel records don't carry `parentUuid`, so the detector fell through to `Codex` and every assistant `usage` record in the file was lost.
- Fix it at the source rather than patching detection: directory walkers now pass `ExtensionType` straight through — provider is decided by the path the file came from (`~/.claude/projects`, `~/.codex/sessions`, `~/.copilot/history-session-state`, `~/.gemini/tmp`), never by file contents.

## Changes

- `analyze_session_file_typed_as(path, provider, mode)` — new provider-known entry that skips content detection entirely. Used by every directory-scanning caller.
- `process_usage_directory` / `process_analysis_directory` / `process_full_analysis_directory` now take `provider: ExtensionType` and forward it to the analyzer.
- `FileParseCache::get_or_parse_as(path, provider)` so `--by-provider` doesn't regress into content detection via the cache path either.
- `analyze_jsonl_file` (the CLI single-file form) keeps content detection, but the auto-detect streaming path now buffers up to 8 records before deciding — enough to see past any sentinel prelude in an ad-hoc file.
- Regression tests in `tests/integrations/analysis_tests.rs` cover `permission-mode` and `file-history-snapshot` preludes on both the provider-known and the auto-detect entry points.

## Test plan

- [x] `cargo test` — 340 passed, 0 failed
- [x] `cargo clippy --all-targets --all-features` — no new warnings from changed files
- [x] `cargo fmt --check`
- [x] Manual: `target/debug/vibe_coding_tracker usage --text` now matches `npx -y vct usage --text` on all models (claude-opus-4-6 recovered from $38 → $550, claude-opus-4-7 recovered from $15 → $603)