### PR TITLE
feat(pricing): preserve all cost fields, bill reasoning separately, fix cached-input double billing

### DIFF
--- a/examples/analysis_result_copilot.json
+++ b/examples/analysis_result_copilot.json
@@ -9,7 +9,8 @@
           "cache_creation_input_tokens": 0,
           "cache_read_input_tokens": 151738,
           "input_tokens": 186809,
-          "output_tokens": 2848
+          "output_tokens": 2848,
+          "reasoning_output_tokens": 0
         }
       },
       "editFileDetails": [],

--- a/examples/analysis_result_gemini.json
+++ b/examples/analysis_result_gemini.json
@@ -7,7 +7,7 @@
       "conversationUsage": {
         "gemini-3-flash-preview": {
           "cache_read_input_tokens": 89744,
-          "input_tokens": 284574,
+          "input_tokens": 194830,
           "output_tokens": 3683,
           "thoughts_tokens": 3030,
           "tool_tokens": 0,

--- a/src/analysis/copilot_analyzer.rs
+++ b/src/analysis/copilot_analyzer.rs
@@ -103,16 +103,18 @@ where
                         let Some(usage) = metric.usage else {
                             continue;
                         };
-                        // Copilot's `reasoningTokens` is a subset of the
-                        // "thinking" budget a model burns before emitting
-                        // visible tokens. Other providers fold it into the
-                        // output bucket, so we do the same here for
-                        // consistency (see
-                        // `utils::token_extractor::extract_token_counts`
-                        // for Codex's treatment of `reasoning_output_tokens`).
+                        // Copilot's `reasoningTokens` is the model's
+                        // thinking budget emitted before the visible
+                        // response. Surface it as its own field so
+                        // `calculate_cost` can charge it against the
+                        // model's published reasoning rate (when present)
+                        // via `output_cost_per_reasoning_token`, instead
+                        // of folding it into `output_tokens` and billing
+                        // every thinking token at the flat output rate.
                         let usage_json = json!({
                             "input_tokens": usage.input_tokens,
-                            "output_tokens": usage.output_tokens + usage.reasoning_tokens,
+                            "output_tokens": usage.output_tokens,
+                            "reasoning_output_tokens": usage.reasoning_tokens,
                             "cache_read_input_tokens": usage.cache_read_tokens,
                             "cache_creation_input_tokens": usage.cache_write_tokens,
                         });

--- a/src/display/usage/averages.rs
+++ b/src/display/usage/averages.rs
@@ -4,17 +4,37 @@ use crate::utils::format_number;
 use serde_json::Value;
 use std::borrow::Cow;
 
-/// Data structure for a usage row
+/// Data structure for a usage row.
+///
+/// `output_tokens` is the user-visible response the model emitted;
+/// `reasoning_tokens` is the separately-billed "thinking" budget (Gemini
+/// `thoughts_tokens`, Codex `reasoning_output_tokens`, Copilot
+/// `reasoningTokens`). Display layers typically present their sum in a
+/// single "Output" column via `output_with_reasoning()` so the per-row
+/// numbers reconcile with `total`, while `cost` is computed against the
+/// per-token reasoning rate (when the model publishes one) via
+/// `calculate_cost`.
 #[derive(Default)]
 pub struct UsageRow {
     pub model: String,         // 原始模型名稱
     pub display_model: String, // 可能含 fuzzy match 提示的顯示名稱
     pub input_tokens: i64,
     pub output_tokens: i64,
+    pub reasoning_tokens: i64,
     pub cache_read: i64,
     pub cache_creation: i64,
     pub total: i64,
     pub cost: f64,
+}
+
+impl UsageRow {
+    /// Sum of output and reasoning tokens — the "total model-emitted
+    /// tokens" figure most display tables want to show in an Output
+    /// column so the row adds up to `total`.
+    #[inline]
+    pub fn output_with_reasoning(&self) -> i64 {
+        self.output_tokens + self.reasoning_tokens
+    }
 }
 
 /// Totals for all usage rows
@@ -22,6 +42,7 @@ pub struct UsageRow {
 pub struct UsageTotals {
     pub input_tokens: i64,
     pub output_tokens: i64,
+    pub reasoning_tokens: i64,
     pub cache_read: i64,
     pub cache_creation: i64,
     pub total: i64,
@@ -32,10 +53,17 @@ impl UsageTotals {
     pub fn accumulate(&mut self, row: &UsageRow) {
         self.input_tokens += row.input_tokens;
         self.output_tokens += row.output_tokens;
+        self.reasoning_tokens += row.reasoning_tokens;
         self.cache_read += row.cache_read;
         self.cache_creation += row.cache_creation;
         self.total += row.total;
         self.cost += row.cost;
+    }
+
+    /// Same helper as [`UsageRow::output_with_reasoning`] for totals.
+    #[inline]
+    pub fn output_with_reasoning(&self) -> i64 {
+        self.output_tokens + self.reasoning_tokens
     }
 }
 
@@ -295,6 +323,7 @@ fn extract_usage_row(
         display_model: display_model.into_owned(),
         input_tokens: counts.input_tokens,
         output_tokens: counts.output_tokens,
+        reasoning_tokens: counts.reasoning_tokens,
         cache_read: counts.cache_read,
         cache_creation: counts.cache_creation,
         total: counts.total,

--- a/src/display/usage/averages.rs
+++ b/src/display/usage/averages.rs
@@ -276,6 +276,7 @@ fn extract_usage_row(
     let cost = calculate_cost(
         counts.input_tokens,
         counts.output_tokens,
+        counts.reasoning_tokens,
         counts.cache_read,
         counts.cache_creation_5m,
         counts.cache_creation_1h,

--- a/src/display/usage/interactive.rs
+++ b/src/display/usage/interactive.rs
@@ -151,9 +151,13 @@ pub fn display_usage_interactive(time_range: crate::cli::TimeRange) -> anyhow::R
 
         for row in &rows_data {
             let row_key = row.model.clone();
+            // Include reasoning in the change fingerprint so Gemini
+            // sessions whose only delta lands in `thoughts_tokens` still
+            // trigger a highlight; otherwise the row would look idle
+            // while its cost silently grew.
             let current_data = (
                 row.input_tokens,
-                row.output_tokens,
+                row.output_with_reasoning(),
                 row.cache_read,
                 row.cache_creation,
             );
@@ -203,7 +207,7 @@ pub fn display_usage_interactive(time_range: crate::cli::TimeRange) -> anyhow::R
                     RatatuiRow::new(vec![
                         row.display_model.clone(),
                         format_number(row.input_tokens),
-                        format_number(row.output_tokens),
+                        format_number(row.output_with_reasoning()),
                         format_number(row.cache_read),
                         format_number(row.cache_creation),
                         format_number(row.total),
@@ -217,7 +221,7 @@ pub fn display_usage_interactive(time_range: crate::cli::TimeRange) -> anyhow::R
                 RatatuiRow::new(vec![
                     "TOTAL".to_string(),
                     format_number(totals.input_tokens),
-                    format_number(totals.output_tokens),
+                    format_number(totals.output_with_reasoning()),
                     format_number(totals.cache_read),
                     format_number(totals.cache_creation),
                     format_number(totals.total),

--- a/src/display/usage/table.rs
+++ b/src/display/usage/table.rs
@@ -60,7 +60,10 @@ pub fn display_usage_table(usage_data: &UsageData) {
         Color::Yellow,
     );
 
-    // Add data rows
+    // Add data rows. The "Output" column folds `reasoning_tokens` back
+    // into the displayed number so each row still adds up to `Total`
+    // — costs are already calculated against the separated buckets via
+    // `calculate_cost`.
     for row in rows {
         table.add_row(vec![
             Cell::new(&row.display_model)
@@ -69,7 +72,7 @@ pub fn display_usage_table(usage_data: &UsageData) {
             Cell::new(format_number(row.input_tokens))
                 .fg(Color::White)
                 .set_alignment(CellAlignment::Right),
-            Cell::new(format_number(row.output_tokens))
+            Cell::new(format_number(row.output_with_reasoning()))
                 .fg(Color::White)
                 .set_alignment(CellAlignment::Right),
             Cell::new(format_number(row.cache_read))
@@ -93,7 +96,7 @@ pub fn display_usage_table(usage_data: &UsageData) {
         vec![
             "TOTAL".to_string(),
             format_number(totals.input_tokens),
-            format_number(totals.output_tokens),
+            format_number(totals.output_with_reasoning()),
             format_number(totals.cache_read),
             format_number(totals.cache_creation),
             format_number(totals.total),

--- a/src/main.rs
+++ b/src/main.rs
@@ -215,6 +215,7 @@ fn build_enriched_json(
         let cost = calculate_cost(
             counts.input_tokens,
             counts.output_tokens,
+            counts.reasoning_tokens,
             counts.cache_read,
             counts.cache_creation_5m,
             counts.cache_creation_1h,

--- a/src/pricing/cache.rs
+++ b/src/pricing/cache.rs
@@ -67,7 +67,7 @@ pub struct TierRange {
 /// This struct is only ever held in memory — `tiers` / `ranges` are derived
 /// from the raw `*_above_Nk_tokens` / `tiered_pricing` keys of LiteLLM by
 /// `parse_litellm_entry`. Cache files store the raw LiteLLM cost fields
-/// verbatim (see `filter_cost_fields_into_raw`); reloading the cache runs
+/// verbatim (see `filter_cost_fields`); reloading the cache runs
 /// them back through `parse_litellm_entry` so the derived structures are
 /// reconstructed freshly on every launch.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -289,6 +289,11 @@ pub fn parse_litellm_pricing_map(raw: serde_json::Value) -> HashMap<String, Mode
 /// image modalities, reasoning-token splits, …) don't require re-fetching
 /// or a schema migration to gain access to the numbers they need.
 ///
+/// `tiered_pricing` is whitelisted explicitly even though the key name
+/// doesn't contain `cost`: its array values are the **only** source of
+/// range-based pricing (Qwen / doubao / dashscope), so dropping it would
+/// silently zero out those models on every cache reload.
+///
 /// Returns `None` when the entry has no cost-related keys at all; such
 /// models carry nothing we can price against and are skipped at the map
 /// level.
@@ -296,7 +301,7 @@ pub fn filter_cost_fields(value: &Value) -> Option<Value> {
     let obj = value.as_object()?;
     let mut filtered = Map::with_capacity(obj.len());
     for (k, v) in obj {
-        if k.contains("cost") {
+        if k.contains("cost") || k == "tiered_pricing" {
             filtered.insert(k.clone(), v.clone());
         }
     }
@@ -343,13 +348,20 @@ pub fn cleanup_old_cache() {
 
 /// Loads pricing data from today's cache file.
 ///
-/// The cache now stores the raw LiteLLM cost-field subset (see
+/// The cache stores the raw LiteLLM cost-field subset (see
 /// `build_filtered_cost_json`) rather than our derived `ModelPricing`
-/// shape, so we re-run `parse_litellm_entry` here to rebuild `tiers` and
-/// `ranges` on load. Caches written by earlier versions of the tool
-/// (which serialised `ModelPricing` directly) also happen to parse fine
-/// through this path — the derived `tiers` / `ranges` fields we used to
-/// emit aren't cost keys and are simply ignored when re-parsing.
+/// shape, so we re-run `parse_litellm_entry` here to rebuild `tiers`
+/// and `ranges` on load.
+///
+/// Pre-Phase-2 versions serialised the derived `ModelPricing` struct
+/// directly, carrying top-level `tiers` / `ranges` arrays instead of
+/// the raw `*_above_Nk_tokens` / `tiered_pricing` keys.
+/// `parse_litellm_entry` would silently drop those arrays (they aren't
+/// cost-keyed scalars) and under-price every tier- or range-priced
+/// model until the cache rotated the next day. We detect that shape
+/// via `looks_like_legacy_pricing_cache` and return `Err` so
+/// `fetch_model_pricing` falls through to a refetch, which overwrites
+/// the stale cache with the new schema.
 pub fn load_from_cache() -> Result<HashMap<String, ModelPricing>> {
     let today = get_current_date();
     let cache_path = find_pricing_cache_for_date(&today)
@@ -358,7 +370,34 @@ pub fn load_from_cache() -> Result<HashMap<String, ModelPricing>> {
     let content = fs::read_to_string(&cache_path).context("Failed to read cached pricing file")?;
     let raw: Value =
         serde_json::from_str(&content).context("Failed to parse cached pricing JSON")?;
+
+    if looks_like_legacy_pricing_cache(&raw) {
+        log::warn!(
+            "Detected pre-Phase-2 pricing cache format at {:?}; refetching to avoid silent tier/range data loss",
+            cache_path
+        );
+        anyhow::bail!("legacy pricing cache format detected, forcing refetch");
+    }
+
     Ok(parse_litellm_pricing_map(raw))
+}
+
+/// Heuristic: does this cache file look like a pre-Phase-2 serialised
+/// `ModelPricing` map?
+///
+/// The new schema (`build_filtered_cost_json` → `filter_cost_fields`)
+/// only emits keys that either contain `cost` or equal `tiered_pricing`,
+/// so it never produces top-level `tiers` / `ranges` arrays on an
+/// entry. The old schema (`ModelPricing` via derived `Serialize`) did
+/// emit them whenever a model carried tier or range data. Any entry
+/// with such a key is a definitive signal of the old format.
+fn looks_like_legacy_pricing_cache(raw: &Value) -> bool {
+    let Some(obj) = raw.as_object() else {
+        return false;
+    };
+    obj.values()
+        .filter_map(|v| v.as_object())
+        .any(|entry| entry.contains_key("tiers") || entry.contains_key("ranges"))
 }
 
 /// Saves a raw LiteLLM cost-field subset to today's cache file and cleans
@@ -724,5 +763,144 @@ mod parser_tests {
         assert_eq!(p.output_cost_per_token, 2e-6);
         assert!(p.tiers.is_empty());
         assert!(p.ranges.is_none());
+    }
+
+    #[test]
+    fn filter_cost_fields_preserves_tiered_pricing() {
+        // `tiered_pricing` is the only source of range-based pricing
+        // (Qwen / doubao / dashscope). Its key name doesn't contain
+        // "cost", so without an explicit whitelist the filter would
+        // silently drop range data on every cache rotation.
+        let raw = json!({
+            "input_cost_per_token": 0.0,
+            "tiered_pricing": [
+                {
+                    "range": [0, 32000],
+                    "input_cost_per_token": 1e-6,
+                    "output_cost_per_token": 5e-6
+                },
+                {
+                    "range": [32000, 128000],
+                    "input_cost_per_token": 1.8e-6,
+                    "output_cost_per_token": 9e-6
+                }
+            ],
+            "max_input_tokens": 1_000_000,
+            "litellm_provider": "dashscope"
+        });
+        let filtered = filter_cost_fields(&raw).expect("has cost keys");
+        let obj = filtered.as_object().unwrap();
+        assert!(
+            obj.contains_key("tiered_pricing"),
+            "tiered_pricing must survive the filter — it carries range-based pricing data"
+        );
+        let ranges = obj["tiered_pricing"].as_array().expect("array preserved");
+        assert_eq!(ranges.len(), 2);
+        assert!(!obj.contains_key("max_input_tokens"));
+        assert!(!obj.contains_key("litellm_provider"));
+    }
+
+    #[test]
+    fn cache_roundtrip_preserves_range_priced_models() {
+        // Full-pipeline regression: a range-priced model goes through
+        // `build_filtered_cost_json` (what `save_to_cache` writes) and
+        // back through `parse_litellm_pricing_map` (what
+        // `load_from_cache` reads). `ranges` must survive end-to-end —
+        // earlier iterations of the filter dropped `tiered_pricing` as
+        // a non-cost key, zeroing every Qwen / doubao model.
+        let upstream = json!({
+            "qwen3-coder-plus": {
+                "tiered_pricing": [
+                    {
+                        "range": [0, 32000],
+                        "input_cost_per_token": 1e-6,
+                        "output_cost_per_token": 5e-6
+                    },
+                    {
+                        "range": [32000, 128000],
+                        "input_cost_per_token": 1.8e-6,
+                        "output_cost_per_token": 9e-6
+                    }
+                ],
+                "max_input_tokens": 1_000_000,
+                "litellm_provider": "dashscope"
+            }
+        });
+
+        let filtered = build_filtered_cost_json(&upstream);
+        let reloaded = parse_litellm_pricing_map(filtered);
+
+        let p = reloaded
+            .get("qwen3-coder-plus")
+            .expect("model must survive roundtrip");
+        let ranges = p.ranges.as_ref().expect("ranges must be rebuilt on reload");
+        assert_eq!(ranges.len(), 2);
+        assert_eq!(ranges[0].min_tokens, 0);
+        assert_eq!(ranges[0].max_tokens, 32_000);
+        assert_eq!(ranges[0].input_cost_per_token, 1e-6);
+        assert_eq!(ranges[1].min_tokens, 32_000);
+        assert_eq!(ranges[1].input_cost_per_token, 1.8e-6);
+    }
+
+    #[test]
+    fn looks_like_legacy_pricing_cache_flags_tiers_array() {
+        // Pre-Phase-2 cache format: serialised `ModelPricing` with a
+        // top-level `tiers` array. The new format never emits this key
+        // at the entry level (the filter drops it), so its presence
+        // unambiguously signals the old shape.
+        let legacy = json!({
+            "claude-sonnet-4-6": {
+                "input_cost_per_token": 3e-6,
+                "output_cost_per_token": 1.5e-5,
+                "tiers": [
+                    {
+                        "threshold_tokens": 200_000,
+                        "input_cost_per_token": 6e-6,
+                        "output_cost_per_token": 2.25e-5
+                    }
+                ]
+            }
+        });
+        assert!(looks_like_legacy_pricing_cache(&legacy));
+    }
+
+    #[test]
+    fn looks_like_legacy_pricing_cache_flags_ranges_field() {
+        let legacy = json!({
+            "qwen-plus": {
+                "ranges": [
+                    {
+                        "min_tokens": 0,
+                        "max_tokens": 32_000,
+                        "input_cost_per_token": 1e-6
+                    }
+                ]
+            }
+        });
+        assert!(looks_like_legacy_pricing_cache(&legacy));
+    }
+
+    #[test]
+    fn looks_like_legacy_pricing_cache_accepts_new_format() {
+        // New format keeps only cost-named keys plus `tiered_pricing`
+        // and never emits top-level `tiers` or `ranges` arrays on an
+        // entry, so a fresh cache file must not trip the detector.
+        let new_format = json!({
+            "claude-sonnet-4-6": {
+                "input_cost_per_token": 3e-6,
+                "output_cost_per_token": 1.5e-5,
+                "input_cost_per_token_above_200k_tokens": 6e-6,
+                "output_cost_per_token_above_200k_tokens": 2.25e-5
+            },
+            "qwen3-coder-plus": {
+                "tiered_pricing": [
+                    {
+                        "range": [0, 32000],
+                        "input_cost_per_token": 1e-6
+                    }
+                ]
+            }
+        });
+        assert!(!looks_like_legacy_pricing_cache(&new_format));
     }
 }

--- a/src/pricing/cache.rs
+++ b/src/pricing/cache.rs
@@ -3,6 +3,7 @@ use crate::utils::{
 };
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
 use std::collections::HashMap;
 use std::fs;
 
@@ -63,12 +64,13 @@ pub struct TierRange {
 ///    Gemini 2.5 Pro, Gemini 1.5 (128k), GPT-5.x (272k), etc.
 /// 3. **Flat** (neither set): base prices apply to every request.
 ///
-/// `deny_unknown_fields` forces `load_from_cache` to fail on pre-Phase-1 cache
-/// files (which carried `*_above_200k_tokens` fields) so a stale same-day cache
-/// is rejected and refetched — otherwise serde would silently drop the removed
-/// fields and under-price tiered models for the rest of the day.
+/// This struct is only ever held in memory — `tiers` / `ranges` are derived
+/// from the raw `*_above_Nk_tokens` / `tiered_pricing` keys of LiteLLM by
+/// `parse_litellm_entry`. Cache files store the raw LiteLLM cost fields
+/// verbatim (see `filter_cost_fields_into_raw`); reloading the cache runs
+/// them back through `parse_litellm_entry` so the derived structures are
+/// reconstructed freshly on every launch.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct ModelPricing {
     #[serde(default)]
     pub input_cost_per_token: f64,
@@ -84,6 +86,15 @@ pub struct ModelPricing {
     /// back to `cache_creation_input_token_cost` (5-minute TTL price).
     #[serde(default)]
     pub cache_creation_input_token_cost_above_1hr: f64,
+
+    /// Price for reasoning / thinking tokens emitted as part of the assistant
+    /// response but billed separately from regular output tokens. Populated
+    /// by Gemini 2.5 flash / flash-lite (`thoughts_tokens`), perplexity
+    /// `sonar-deep-research`, and some qwen-turbo entries. `0.0` means the
+    /// model doesn't split reasoning from output — callers fall back to
+    /// `output_cost_per_token`.
+    #[serde(default)]
+    pub output_cost_per_reasoning_token: f64,
 
     /// Threshold-based tiers, sorted ascending by `threshold_tokens`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -169,6 +180,9 @@ pub fn parse_litellm_entry(value: &serde_json::Value) -> ModelPricing {
             "cache_creation_input_token_cost_above_1hr" => {
                 // Base (non-tiered) 1hr TTL price.
                 pricing.cache_creation_input_token_cost_above_1hr = num_value;
+            }
+            "output_cost_per_reasoning_token" => {
+                pricing.output_cost_per_reasoning_token = num_value;
             }
             _ => {
                 if let Some(suffix) = key.strip_prefix("input_cost_per_token_above_") {
@@ -264,6 +278,53 @@ pub fn parse_litellm_pricing_map(raw: serde_json::Value) -> HashMap<String, Mode
         .collect()
 }
 
+/// Copies every `cost`-related key from a LiteLLM model entry into a new
+/// object, preserving values verbatim (including nested objects like
+/// `search_context_cost_per_query`).
+///
+/// We keep *all* keys whose name contains `cost` rather than only the ones
+/// the current `calculate_cost` knows how to consume. That way the on-disk
+/// cache is a faithful, diff-able subset of the upstream LiteLLM JSON —
+/// future calculation strategies (priority / flex / batch tiers, audio /
+/// image modalities, reasoning-token splits, …) don't require re-fetching
+/// or a schema migration to gain access to the numbers they need.
+///
+/// Returns `None` when the entry has no cost-related keys at all; such
+/// models carry nothing we can price against and are skipped at the map
+/// level.
+pub fn filter_cost_fields(value: &Value) -> Option<Value> {
+    let obj = value.as_object()?;
+    let mut filtered = Map::with_capacity(obj.len());
+    for (k, v) in obj {
+        if k.contains("cost") {
+            filtered.insert(k.clone(), v.clone());
+        }
+    }
+    if filtered.is_empty() {
+        None
+    } else {
+        Some(Value::Object(filtered))
+    }
+}
+
+/// Builds the on-disk cache payload: a map from model name to its
+/// cost-only subset (see `filter_cost_fields`). Non-object top-level
+/// entries (e.g. LiteLLM's `sample_spec`, which is kept — it still has
+/// cost keys) and entries with no cost keys are dropped here.
+pub fn build_filtered_cost_json(raw: &Value) -> Value {
+    let obj = match raw.as_object() {
+        Some(o) => o,
+        None => return Value::Object(Map::new()),
+    };
+    let mut filtered_map = Map::with_capacity(obj.len());
+    for (model, entry) in obj {
+        if let Some(filtered) = filter_cost_fields(entry) {
+            filtered_map.insert(model.clone(), filtered);
+        }
+    }
+    Value::Object(filtered_map)
+}
+
 /// Removes outdated pricing cache files, keeping only today's cache
 pub fn cleanup_old_cache() {
     let Ok(cache_files) = list_pricing_cache_files() else {
@@ -280,25 +341,40 @@ pub fn cleanup_old_cache() {
     }
 }
 
-/// Loads pricing data from today's cache file
+/// Loads pricing data from today's cache file.
+///
+/// The cache now stores the raw LiteLLM cost-field subset (see
+/// `build_filtered_cost_json`) rather than our derived `ModelPricing`
+/// shape, so we re-run `parse_litellm_entry` here to rebuild `tiers` and
+/// `ranges` on load. Caches written by earlier versions of the tool
+/// (which serialised `ModelPricing` directly) also happen to parse fine
+/// through this path — the derived `tiers` / `ranges` fields we used to
+/// emit aren't cost keys and are simply ignored when re-parsing.
 pub fn load_from_cache() -> Result<HashMap<String, ModelPricing>> {
     let today = get_current_date();
     let cache_path = find_pricing_cache_for_date(&today)
         .ok_or_else(|| anyhow::anyhow!("No cache file found for today"))?;
 
     let content = fs::read_to_string(&cache_path).context("Failed to read cached pricing file")?;
-    let pricing: HashMap<String, ModelPricing> =
+    let raw: Value =
         serde_json::from_str(&content).context("Failed to parse cached pricing JSON")?;
-    Ok(pricing)
+    Ok(parse_litellm_pricing_map(raw))
 }
 
-/// Saves pricing data to today's cache file and cleans up old caches
-pub fn save_to_cache(pricing: &HashMap<String, ModelPricing>) -> Result<()> {
+/// Saves a raw LiteLLM cost-field subset to today's cache file and cleans
+/// up old caches.
+///
+/// Callers should pass the output of `build_filtered_cost_json` so the
+/// on-disk payload is a cost-only projection of the upstream LiteLLM JSON
+/// — that keeps the cache file small, diff-able against upstream, and
+/// forward-compatible with calculation strategies that aren't wired up
+/// yet.
+pub fn save_to_cache(filtered_raw: &Value) -> Result<()> {
     let today = get_current_date();
     let cache_path = get_pricing_cache_path(&today)?;
 
     let pricing_json =
-        serde_json::to_string_pretty(pricing).context("Failed to serialize pricing data")?;
+        serde_json::to_string_pretty(filtered_raw).context("Failed to serialize pricing data")?;
     fs::write(&cache_path, pricing_json).context("Failed to write pricing cache file")?;
 
     cleanup_old_cache();
@@ -322,7 +398,9 @@ pub fn normalize_pricing(
         let has_base = p.input_cost_per_token != 0.0
             || p.output_cost_per_token != 0.0
             || p.cache_read_input_token_cost != 0.0
-            || p.cache_creation_input_token_cost != 0.0;
+            || p.cache_creation_input_token_cost != 0.0
+            || p.cache_creation_input_token_cost_above_1hr != 0.0
+            || p.output_cost_per_reasoning_token != 0.0;
         let has_nonzero_tier = p.tiers.iter().any(|t| {
             t.input_cost_per_token != 0.0
                 || t.output_cost_per_token != 0.0
@@ -521,20 +599,95 @@ mod parser_tests {
     }
 
     #[test]
-    fn old_cache_format_is_rejected_by_deny_unknown_fields() {
-        // A pre-Phase-1 cache entry had `input_cost_per_token_above_200k_tokens`
-        // as a flat field. With `deny_unknown_fields` on ModelPricing, parsing
-        // MUST fail so `load_from_cache` returns Err → caller refetches.
-        let old_format = r#"{
+    fn cache_reload_reconstructs_tiers_from_raw_keys() {
+        // Cache files now store the raw LiteLLM cost-field subset rather
+        // than our derived `ModelPricing` shape. Reloading must rebuild
+        // `tiers` by re-running `parse_litellm_entry`, or a Sonnet-style
+        // 200K tier would silently vanish and under-price large sessions.
+        let raw = json!({
             "input_cost_per_token": 3e-6,
             "output_cost_per_token": 1.5e-5,
-            "input_cost_per_token_above_200k_tokens": 6e-6
-        }"#;
-        let result: Result<ModelPricing, _> = serde_json::from_str(old_format);
+            "cache_read_input_token_cost": 3e-7,
+            "cache_creation_input_token_cost": 3.75e-6,
+            "input_cost_per_token_above_200k_tokens": 6e-6,
+            "output_cost_per_token_above_200k_tokens": 2.25e-5,
+            "cache_read_input_token_cost_above_200k_tokens": 6e-7,
+            "cache_creation_input_token_cost_above_200k_tokens": 7.5e-6
+        });
+        let p = parse_litellm_entry(&raw);
+        assert_eq!(p.tiers.len(), 1, "tier must be rebuilt on cache reload");
+        assert_eq!(p.tiers[0].threshold_tokens, 200_000);
+    }
+
+    #[test]
+    fn parses_output_cost_per_reasoning_token() {
+        // Gemini 2.5 Flash and friends bill `thoughts_tokens` at a separate
+        // per-token rate. Older `ModelPricing` dropped this field entirely;
+        // the parser now preserves it as a base-level price.
+        let raw = json!({
+            "input_cost_per_token": 3e-7,
+            "output_cost_per_token": 2.5e-6,
+            "output_cost_per_reasoning_token": 2.5e-6
+        });
+        let p = parse_litellm_entry(&raw);
+        assert_eq!(p.output_cost_per_reasoning_token, 2.5e-6);
+    }
+
+    #[test]
+    fn filter_cost_fields_keeps_only_cost_keys() {
+        let raw = json!({
+            "input_cost_per_token": 3e-6,
+            "output_cost_per_token": 1.5e-5,
+            "cache_creation_input_token_cost_above_1hr": 6e-6,
+            "max_input_tokens": 200_000,
+            "supports_vision": true,
+            "litellm_provider": "anthropic",
+            "search_context_cost_per_query": {"search_context_size_high": 0.01}
+        });
+        let filtered = filter_cost_fields(&raw).expect("has cost keys");
+        let obj = filtered.as_object().unwrap();
+        assert!(obj.contains_key("input_cost_per_token"));
+        assert!(obj.contains_key("output_cost_per_token"));
+        assert!(obj.contains_key("cache_creation_input_token_cost_above_1hr"));
         assert!(
-            result.is_err(),
-            "stale cache entry with removed fields must be rejected"
+            obj.contains_key("search_context_cost_per_query"),
+            "nested cost objects must survive the filter"
         );
+        assert!(!obj.contains_key("max_input_tokens"));
+        assert!(!obj.contains_key("supports_vision"));
+        assert!(!obj.contains_key("litellm_provider"));
+    }
+
+    #[test]
+    fn filter_cost_fields_returns_none_for_non_cost_entries() {
+        // Some LiteLLM entries (e.g. retired / embedding-only models) have
+        // no cost-related keys at all. They should be dropped from the
+        // cache, not serialised as empty objects.
+        let raw = json!({
+            "max_input_tokens": 8192,
+            "litellm_provider": "azure"
+        });
+        assert!(filter_cost_fields(&raw).is_none());
+    }
+
+    #[test]
+    fn build_filtered_cost_json_skips_entries_without_cost_keys() {
+        let raw = json!({
+            "model-a": {
+                "input_cost_per_token": 1e-6,
+                "max_input_tokens": 8192
+            },
+            "model-b": {
+                "max_input_tokens": 16384
+            }
+        });
+        let filtered = build_filtered_cost_json(&raw);
+        let obj = filtered.as_object().unwrap();
+        assert!(obj.contains_key("model-a"));
+        assert!(!obj.contains_key("model-b"));
+        let a = obj["model-a"].as_object().unwrap();
+        assert!(a.contains_key("input_cost_per_token"));
+        assert!(!a.contains_key("max_input_tokens"));
     }
 
     #[test]

--- a/src/pricing/calculation.rs
+++ b/src/pricing/calculation.rs
@@ -12,13 +12,23 @@ use super::cache::{ModelPricing, TierRange};
 ///    semantics where prompt size promotes the entire request to a higher rate.
 /// 3. Otherwise, uses flat base prices for every token type.
 ///
+/// `reasoning_tokens` covers the model's "thinking" budget (Gemini
+/// `thoughts_tokens`, Codex `reasoning_output_tokens`, Copilot
+/// `reasoningTokens`). When the active price level publishes
+/// `output_cost_per_reasoning_token`, reasoning is billed at that rate;
+/// otherwise it falls back to the active `output_cost_per_token` rate so
+/// providers that don't split reasoning (all Anthropic models, GPT-5.x,
+/// Grok, …) continue to bill correctly.
+///
 /// `cache_creation_5m_tokens` and `cache_creation_1h_tokens` are priced
 /// separately (5-minute default TTL vs 1-hour extended TTL). When a model
 /// doesn't publish a 1hr price (value is 0.0), the 5m price is used for both
 /// buckets — matching current behaviour for providers that don't split TTL.
+#[allow(clippy::too_many_arguments)] // pricing dispatch; grouping into a struct costs clarity here
 pub fn calculate_cost(
     input_tokens: i64,
     output_tokens: i64,
+    reasoning_tokens: i64,
     cache_read_tokens: i64,
     cache_creation_5m_tokens: i64,
     cache_creation_1h_tokens: i64,
@@ -26,44 +36,73 @@ pub fn calculate_cost(
 ) -> f64 {
     let total_cache_creation = cache_creation_5m_tokens + cache_creation_1h_tokens;
 
-    // Pick the primary price source (input/output/cache_read) based on strategy.
-    // cache_creation prices always come from base level in the range-based branch
-    // because TierRange carries no cache_creation fields (LiteLLM doesn't publish
-    // them for Qwen / doubao); for tier + flat they come from the active level.
-    let (input_price, output_price, cache_read_price, cc_5m_price, cc_1h_price_raw) =
-        if let Some(ranges) = &pricing.ranges {
-            let r = select_range(ranges, input_tokens);
-            (
-                r.map(|r| r.input_cost_per_token).unwrap_or(0.0),
-                r.map(|r| r.output_cost_per_token).unwrap_or(0.0),
-                r.map(|r| r.cache_read_input_token_cost).unwrap_or(0.0),
+    // Pick the primary price source (input/output/reasoning/cache_read)
+    // based on strategy. `reasoning_price_raw = 0.0` signals "no dedicated
+    // reasoning rate published at this level" — the fallback below maps
+    // that to the active output price so we keep billing reasoning tokens
+    // at the provider's actual output rate rather than silently pricing
+    // them at $0.
+    //
+    // cache_creation prices always come from base level in the range-based
+    // branch because `TierRange` carries no cache_creation fields (LiteLLM
+    // doesn't publish them for Qwen / doubao); for tier + flat they come
+    // from the active level.
+    let (
+        input_price,
+        output_price,
+        reasoning_price_raw,
+        cache_read_price,
+        cc_5m_price,
+        cc_1h_price_raw,
+    ) = if let Some(ranges) = &pricing.ranges {
+        let r = select_range(ranges, input_tokens);
+        (
+            r.map(|r| r.input_cost_per_token).unwrap_or(0.0),
+            r.map(|r| r.output_cost_per_token).unwrap_or(0.0),
+            // Qwen / doubao publish per-range reasoning rates directly on
+            // the `TierRange` struct; use them when available.
+            r.map(|r| r.output_cost_per_reasoning_token).unwrap_or(0.0),
+            r.map(|r| r.cache_read_input_token_cost).unwrap_or(0.0),
+            pricing.cache_creation_input_token_cost,
+            pricing.cache_creation_input_token_cost_above_1hr,
+        )
+    } else {
+        let total_input_context = input_tokens + cache_read_tokens + total_cache_creation;
+        let active_tier = pricing
+            .tiers
+            .iter()
+            .rev()
+            .find(|t| total_input_context > t.threshold_tokens);
+        match active_tier {
+            Some(t) => (
+                t.input_cost_per_token,
+                t.output_cost_per_token,
+                // LiteLLM does not publish a tier-specific
+                // `output_cost_per_reasoning_token_above_Nk_tokens` field
+                // yet, so fall back to the active tier's output price —
+                // this avoids silently billing reasoning against base
+                // rates when a prompt crosses the 200K / 272K threshold.
+                0.0,
+                t.cache_read_input_token_cost,
+                t.cache_creation_input_token_cost,
+                t.cache_creation_input_token_cost_above_1hr,
+            ),
+            None => (
+                pricing.input_cost_per_token,
+                pricing.output_cost_per_token,
+                pricing.output_cost_per_reasoning_token,
+                pricing.cache_read_input_token_cost,
                 pricing.cache_creation_input_token_cost,
                 pricing.cache_creation_input_token_cost_above_1hr,
-            )
-        } else {
-            let total_input_context = input_tokens + cache_read_tokens + total_cache_creation;
-            let active_tier = pricing
-                .tiers
-                .iter()
-                .rev()
-                .find(|t| total_input_context > t.threshold_tokens);
-            match active_tier {
-                Some(t) => (
-                    t.input_cost_per_token,
-                    t.output_cost_per_token,
-                    t.cache_read_input_token_cost,
-                    t.cache_creation_input_token_cost,
-                    t.cache_creation_input_token_cost_above_1hr,
-                ),
-                None => (
-                    pricing.input_cost_per_token,
-                    pricing.output_cost_per_token,
-                    pricing.cache_read_input_token_cost,
-                    pricing.cache_creation_input_token_cost,
-                    pricing.cache_creation_input_token_cost_above_1hr,
-                ),
-            }
-        };
+            ),
+        }
+    };
+
+    let reasoning_price = if reasoning_price_raw > 0.0 {
+        reasoning_price_raw
+    } else {
+        output_price
+    };
 
     // If the active level doesn't publish a 1hr price, bill 1h tokens at the 5m
     // rate (safer to under-bill than fabricate; also matches providers with no
@@ -76,6 +115,7 @@ pub fn calculate_cost(
 
     input_tokens as f64 * input_price
         + output_tokens as f64 * output_price
+        + reasoning_tokens as f64 * reasoning_price
         + cache_read_tokens as f64 * cache_read_price
         + cache_creation_5m_tokens as f64 * cc_5m_price
         + cache_creation_1h_tokens as f64 * cc_1h_price
@@ -136,7 +176,7 @@ mod tests {
     fn test_flat_pricing_applies_base() {
         let p = flat_pricing();
         // 200 of cache_creation goes into the 5m bucket (no TTL split available).
-        let cost = calculate_cost(1000, 500, 200, 100, 0, &p);
+        let cost = calculate_cost(1000, 500, 0, 200, 100, 0, &p);
         let expected =
             1000.0 * 0.000003 + 500.0 * 0.000015 + 200.0 * 0.0000003 + 100.0 * 0.00000375;
         assert_eq!(cost, expected);
@@ -146,7 +186,7 @@ mod tests {
     fn test_threshold_tier_below_threshold_uses_base() {
         let p = sonnet_like_pricing();
         // Total input context = 1000 + 200 + 100 = 1300 ≤ 200K → base prices
-        let cost = calculate_cost(1000, 500, 200, 100, 0, &p);
+        let cost = calculate_cost(1000, 500, 0, 200, 100, 0, &p);
         let expected =
             1000.0 * 0.000003 + 500.0 * 0.000015 + 200.0 * 0.0000003 + 100.0 * 0.00000375;
         assert_eq!(cost, expected);
@@ -156,7 +196,7 @@ mod tests {
     fn test_threshold_tier_above_threshold_applies_tier() {
         let p = sonnet_like_pricing();
         // Total input context = 250K + 250K + 250K = 750K > 200K → tier prices for ALL types
-        let cost = calculate_cost(250_000, 250_000, 250_000, 250_000, 0, &p);
+        let cost = calculate_cost(250_000, 250_000, 0, 250_000, 250_000, 0, &p);
         let expected = 250_000.0 * 0.000006
             + 250_000.0 * 0.0000225
             + 250_000.0 * 0.0000006
@@ -168,7 +208,7 @@ mod tests {
     fn test_threshold_uses_total_input_context_not_output() {
         let p = sonnet_like_pricing();
         // Small input context (50K) but massive output (500K) → still base prices
-        let cost = calculate_cost(50_000, 500_000, 0, 0, 0, &p);
+        let cost = calculate_cost(50_000, 500_000, 0, 0, 0, 0, &p);
         let expected = 50_000.0 * 0.000003 + 500_000.0 * 0.000015;
         assert_eq!(cost, expected);
     }
@@ -176,10 +216,10 @@ mod tests {
     #[test]
     fn test_exact_200k_stays_on_base() {
         let p = sonnet_like_pricing();
-        let cost_exact = calculate_cost(200_000, 50_000, 0, 0, 0, &p);
+        let cost_exact = calculate_cost(200_000, 50_000, 0, 0, 0, 0, &p);
         assert_eq!(cost_exact, 200_000.0 * 0.000003 + 50_000.0 * 0.000015);
 
-        let cost_above = calculate_cost(200_001, 50_000, 0, 0, 0, &p);
+        let cost_above = calculate_cost(200_001, 50_000, 0, 0, 0, 0, &p);
         assert_eq!(cost_above, 200_001.0 * 0.000006 + 50_000.0 * 0.0000225);
     }
 
@@ -207,15 +247,15 @@ mod tests {
         };
 
         // 100K: below both tiers → base prices
-        let c1 = calculate_cost(100_000, 10_000, 0, 0, 0, &p);
+        let c1 = calculate_cost(100_000, 10_000, 0, 0, 0, 0, &p);
         assert_eq!(c1, 100_000.0 * 0.000001 + 10_000.0 * 0.000002);
 
         // 200K: above 128k, below 272k → first tier
-        let c2 = calculate_cost(200_000, 10_000, 0, 0, 0, &p);
+        let c2 = calculate_cost(200_000, 10_000, 0, 0, 0, 0, &p);
         assert_eq!(c2, 200_000.0 * 0.000002 + 10_000.0 * 0.000004);
 
         // 300K: above both → second (highest) tier
-        let c3 = calculate_cost(300_000, 10_000, 0, 0, 0, &p);
+        let c3 = calculate_cost(300_000, 10_000, 0, 0, 0, 0, &p);
         assert_eq!(c3, 300_000.0 * 0.000004 + 10_000.0 * 0.000008);
     }
 
@@ -259,10 +299,10 @@ mod tests {
             ..Default::default()
         };
 
-        let c_low = calculate_cost(20_000, 5_000, 0, 0, 0, &p);
+        let c_low = calculate_cost(20_000, 5_000, 0, 0, 0, 0, &p);
         assert_eq!(c_low, 20_000.0 * 0.000001 + 5_000.0 * 0.000005);
 
-        let c_hi = calculate_cost(500_000, 5_000, 0, 0, 0, &p);
+        let c_hi = calculate_cost(500_000, 5_000, 0, 0, 0, 0, &p);
         assert_eq!(c_hi, 500_000.0 * 0.000006 + 5_000.0 * 0.00006);
     }
 
@@ -280,14 +320,14 @@ mod tests {
         };
 
         // 200K exceeds every defined range — fall back to the last one.
-        let cost = calculate_cost(200_000, 0, 0, 0, 0, &p);
+        let cost = calculate_cost(200_000, 0, 0, 0, 0, 0, &p);
         assert_eq!(cost, 200_000.0 * 0.000001);
     }
 
     #[test]
     fn test_zero_tokens() {
         let p = sonnet_like_pricing();
-        assert_eq!(calculate_cost(0, 0, 0, 0, 0, &p), 0.0);
+        assert_eq!(calculate_cost(0, 0, 0, 0, 0, 0, &p), 0.0);
     }
 
     #[test]
@@ -303,11 +343,11 @@ mod tests {
         };
 
         // 10_000 tokens at 1hr TTL should cost the extended rate, not the 5m rate.
-        let cost = calculate_cost(0, 0, 0, 0, 10_000, &p);
+        let cost = calculate_cost(0, 0, 0, 0, 0, 10_000, &p);
         assert_eq!(cost, 10_000.0 * 1e-5);
 
         // Mixed: 1_000 at 5m + 10_000 at 1h.
-        let cost_mixed = calculate_cost(0, 0, 0, 1_000, 10_000, &p);
+        let cost_mixed = calculate_cost(0, 0, 0, 0, 1_000, 10_000, &p);
         assert_eq!(cost_mixed, 1_000.0 * 6.25e-6 + 10_000.0 * 1e-5);
     }
 
@@ -321,7 +361,7 @@ mod tests {
             ..Default::default()
         };
 
-        let cost = calculate_cost(0, 0, 0, 0, 10_000, &p);
+        let cost = calculate_cost(0, 0, 0, 0, 0, 10_000, &p);
         assert_eq!(cost, 10_000.0 * 6.25e-6);
     }
 
@@ -344,8 +384,92 @@ mod tests {
 
         // Input context = 250K → tier applies.
         // 5_000 @ 5m tier, 5_000 @ 1hr tier.
-        let cost = calculate_cost(250_000, 0, 0, 5_000, 5_000, &p);
+        let cost = calculate_cost(250_000, 0, 0, 0, 5_000, 5_000, &p);
         let expected = 250_000.0 * 6e-6 + 5_000.0 * 7.5e-6 + 5_000.0 * 1.2e-5;
+        assert_eq!(cost, expected);
+    }
+
+    #[test]
+    fn test_reasoning_billed_at_dedicated_rate_when_published() {
+        // Gemini 2.5 flash-lite publishes a dedicated
+        // `output_cost_per_reasoning_token` that happens to match its
+        // output rate; perplexity/sonar-deep-research pays $3/M for
+        // reasoning vs $8/M for output. Use the synthetic latter shape
+        // to prove the reasoning price is not being silently coerced
+        // back to the output rate.
+        let p = ModelPricing {
+            input_cost_per_token: 1e-6,
+            output_cost_per_token: 8e-6,
+            output_cost_per_reasoning_token: 3e-6,
+            ..Default::default()
+        };
+
+        let cost = calculate_cost(1_000, 200, 500, 0, 0, 0, &p);
+        let expected = 1_000.0 * 1e-6 + 200.0 * 8e-6 + 500.0 * 3e-6;
+        assert_eq!(cost, expected);
+    }
+
+    #[test]
+    fn test_reasoning_falls_back_to_output_rate_when_not_published() {
+        // Claude has no reasoning price published at all. Sessions that
+        // still report reasoning tokens (e.g. Copilot driving a Claude
+        // model) should bill them at the output rate rather than $0.
+        let p = ModelPricing {
+            input_cost_per_token: 3e-6,
+            output_cost_per_token: 1.5e-5,
+            ..Default::default()
+        };
+
+        let cost = calculate_cost(1_000, 500, 200, 0, 0, 0, &p);
+        let expected = 1_000.0 * 3e-6 + 500.0 * 1.5e-5 + 200.0 * 1.5e-5;
+        assert_eq!(cost, expected);
+    }
+
+    #[test]
+    fn test_reasoning_uses_active_tier_output_rate_when_threshold_crossed() {
+        // When a prompt promotes the request into the 200K tier,
+        // reasoning tokens should track the tier's output rate, not the
+        // base rate. This matches current Anthropic / Google semantics
+        // where "once you're in the tier, everything is more expensive."
+        let p = ModelPricing {
+            input_cost_per_token: 3e-6,
+            output_cost_per_token: 1.5e-5,
+            output_cost_per_reasoning_token: 0.0,
+            tiers: vec![ThresholdTier {
+                threshold_tokens: 200_000,
+                input_cost_per_token: 6e-6,
+                output_cost_per_token: 2.25e-5,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        // 250K prompt → tier applies; reasoning uses tier output rate.
+        let cost = calculate_cost(250_000, 1_000, 500, 0, 0, 0, &p);
+        let expected = 250_000.0 * 6e-6 + 1_000.0 * 2.25e-5 + 500.0 * 2.25e-5;
+        assert_eq!(cost, expected);
+    }
+
+    #[test]
+    fn test_reasoning_uses_range_reasoning_rate_when_published() {
+        // dashscope qwen-plus ships a per-range reasoning rate ($4/M)
+        // that's substantially higher than the per-range output rate
+        // ($1.2/M). The range-based path must route reasoning through
+        // that field.
+        let p = ModelPricing {
+            ranges: Some(vec![TierRange {
+                min_tokens: 0,
+                max_tokens: 32_000,
+                input_cost_per_token: 8e-7,
+                output_cost_per_token: 1.2e-6,
+                output_cost_per_reasoning_token: 4e-6,
+                ..Default::default()
+            }]),
+            ..Default::default()
+        };
+
+        let cost = calculate_cost(10_000, 500, 200, 0, 0, 0, &p);
+        let expected = 10_000.0 * 8e-7 + 500.0 * 1.2e-6 + 200.0 * 4e-6;
         assert_eq!(cost, expected);
     }
 }

--- a/src/pricing/mod.rs
+++ b/src/pricing/mod.rs
@@ -50,17 +50,29 @@ pub fn fetch_model_pricing() -> Result<ModelPricingMap> {
     let raw: serde_json::Value = response
         .json()
         .context("Failed to parse model pricing JSON")?;
-    let pricing = cache::parse_litellm_pricing_map(raw);
 
-    // Filter out models with entirely zero pricing (free / unpriced entries).
-    let normalized_pricing = cache::normalize_pricing(pricing);
+    // Project the upstream JSON down to just the cost-related keys before
+    // anything else. Doing the filter first guarantees the on-disk cache
+    // and the in-memory `ModelPricing` are derived from the *same* view of
+    // the data — so nothing we price against can differ from what the
+    // cache preserves for future calculation strategies.
+    let filtered_raw = cache::build_filtered_cost_json(&raw);
 
-    // Save to cache with today's date
-    if let Err(e) = cache::save_to_cache(&normalized_pricing) {
+    // Save the filtered raw JSON to cache. We deliberately persist the raw
+    // cost keys (rather than our derived `ModelPricing` shape) so
+    // priority / flex / batch / audio / image tiers that `calculate_cost`
+    // doesn't consume yet are still available to future versions without
+    // a re-fetch.
+    if let Err(e) = cache::save_to_cache(&filtered_raw) {
         log::warn!("Failed to save pricing to cache: {}", e);
     } else {
         log::debug!("Saved model pricing to cache with today's date");
     }
+
+    let pricing = cache::parse_litellm_pricing_map(filtered_raw);
+
+    // Filter out models with entirely zero pricing (free / unpriced entries).
+    let normalized_pricing = cache::normalize_pricing(pricing);
 
     Ok(ModelPricingMap::new(normalized_pricing))
 }

--- a/src/usage/calculator.rs
+++ b/src/usage/calculator.rs
@@ -233,7 +233,7 @@ fn merge_usage_values(existing: &mut Value, new: &Value) {
     use crate::utils::{accumulate_i64_fields, accumulate_nested_object};
 
     if let (Some(existing_obj), Some(new_obj)) = (existing.as_object_mut(), new.as_object()) {
-        // Handle Claude/Gemini format (has input_tokens)
+        // Handle Claude/Gemini/Copilot format (has input_tokens)
         if existing_obj.contains_key("input_tokens") {
             accumulate_i64_fields(
                 existing_obj,
@@ -243,7 +243,14 @@ fn merge_usage_values(existing: &mut Value, new: &Value) {
                     "cache_creation_input_tokens",
                     "cache_read_input_tokens",
                     "output_tokens",
+                    // Gemini `thoughts_tokens` and Copilot's normalised
+                    // `reasoning_output_tokens` both carry the same
+                    // reasoning-budget semantics and must accumulate so
+                    // cross-provider aggregation in `usage` doesn't drop
+                    // the thinking-time tokens the model was actually
+                    // billed for.
                     "thoughts_tokens",
+                    "reasoning_output_tokens",
                     "tool_tokens",
                     "total_tokens",
                 ],

--- a/src/utils/token_extractor.rs
+++ b/src/utils/token_extractor.rs
@@ -107,9 +107,30 @@ pub fn extract_token_counts(usage: &Value) -> TokenCounts {
             .get("total_token_usage")
             .and_then(|v| v.as_object())
         {
-            if let Some(input) = total_usage.get("input_tokens").and_then(|v| v.as_i64()) {
-                counts.input_tokens = input;
-            }
+            // Codex follows OpenAI's convention: `input_tokens` is the
+            // full prompt size and `cached_input_tokens` is the subset
+            // that hit the prompt cache. LiteLLM, in contrast, prices
+            // non-cached input (`input_cost_per_token`) and cached reads
+            // (`cache_read_input_token_cost`) *separately*. Forwarding
+            // Codex's raw `input_tokens` to `calculate_cost` alongside
+            // the same `cached_input_tokens` would charge every cached
+            // token twice — once at the full input rate, then again at
+            // the cache read rate — inflating Codex cost reports by
+            // ~130% on heavy-cache sessions.
+            //
+            // Subtract cached from raw input so each token is billed
+            // exactly once, at the right rate.
+            let raw_input = total_usage
+                .get("input_tokens")
+                .and_then(|v| v.as_i64())
+                .unwrap_or(0);
+            let cached = total_usage
+                .get("cached_input_tokens")
+                .and_then(|v| v.as_i64())
+                .unwrap_or(0);
+            counts.input_tokens = (raw_input - cached).max(0);
+            counts.cache_read = cached;
+
             if let Some(output) = total_usage.get("output_tokens").and_then(|v| v.as_i64()) {
                 // Codex already accumulates across turns, so replace instead
                 // of adding — the value is the running total for the session.
@@ -121,19 +142,12 @@ pub fn extract_token_counts(usage: &Value) -> TokenCounts {
             {
                 counts.reasoning_tokens = reasoning;
             }
-            if let Some(cache_read) = total_usage
-                .get("cached_input_tokens")
-                .and_then(|v| v.as_i64())
-            {
-                counts.cache_read = cache_read;
-            }
             if let Some(total) = total_usage.get("total_tokens").and_then(|v| v.as_i64()) {
-                // Codex `total_tokens` = input + output and excludes
-                // `reasoning_output_tokens` — the provider bills reasoning
-                // separately, so the published total understates the
-                // amount of tokens the caller is actually paying for. Add
-                // reasoning here so the summary row stays consistent with
-                // what `calculate_cost` charges for.
+                // Codex `total_tokens` = input (incl. cached) + output and
+                // excludes `reasoning_output_tokens`. We already split
+                // input / cached above, so the numeric total the user sees
+                // still matches: (non_cached_input + cached) + output +
+                // reasoning == Codex's `total_tokens` + reasoning.
                 counts.total = total + counts.reasoning_tokens;
                 return counts;
             }
@@ -226,7 +240,7 @@ mod tests {
                 "input_tokens": 1000,
                 "output_tokens": 500,
                 "cached_input_tokens": 200,
-                "total_tokens": 1700
+                "total_tokens": 1500
             }
         });
         let c = extract_token_counts(&usage);
@@ -234,6 +248,51 @@ mod tests {
         assert_eq!(c.cache_creation_5m, 0);
         assert_eq!(c.cache_creation_1h, 0);
         assert_eq!(c.cache_read, 200);
+        // Codex `input_tokens` includes `cached_input_tokens`; the extractor
+        // must subtract cached so the two buckets don't overlap.
+        assert_eq!(c.input_tokens, 800);
+    }
+
+    #[test]
+    fn codex_input_tokens_excludes_cached_bucket() {
+        // Taken from a real Codex session: input=576_145 includes
+        // cached=408_832. The extractor must split the two so
+        // `calculate_cost` doesn't bill every cached token twice.
+        let usage = json!({
+            "total_token_usage": {
+                "input_tokens": 576_145,
+                "cached_input_tokens": 408_832,
+                "output_tokens": 13_156,
+                "reasoning_output_tokens": 8_591,
+                "total_tokens": 589_301
+            }
+        });
+        let c = extract_token_counts(&usage);
+        assert_eq!(c.input_tokens, 576_145 - 408_832);
+        assert_eq!(c.cache_read, 408_832);
+        assert_eq!(c.output_tokens, 13_156);
+        assert_eq!(c.reasoning_tokens, 8_591);
+        // Published total + reasoning. Equivalent to
+        // (input_tokens + cache_read) + output_tokens + reasoning_tokens.
+        assert_eq!(c.total, 589_301 + 8_591);
+    }
+
+    #[test]
+    fn codex_cached_exceeding_input_clamps_to_zero() {
+        // Defensive: never emit a negative `input_tokens` even if the
+        // provider ever misreports cached > input. Better to undercount
+        // than to panic via integer overflow downstream.
+        let usage = json!({
+            "total_token_usage": {
+                "input_tokens": 100,
+                "cached_input_tokens": 500,
+                "output_tokens": 50,
+                "total_tokens": 150
+            }
+        });
+        let c = extract_token_counts(&usage);
+        assert_eq!(c.input_tokens, 0);
+        assert_eq!(c.cache_read, 500);
     }
 
     #[test]
@@ -271,7 +330,7 @@ mod tests {
             }
         });
         let c = extract_token_counts(&usage);
-        assert_eq!(c.input_tokens, 5_645);
+        assert_eq!(c.input_tokens, 5_645 - 5_504);
         assert_eq!(c.cache_read, 5_504);
         assert_eq!(
             c.output_tokens, 810,

--- a/src/utils/token_extractor.rs
+++ b/src/utils/token_extractor.rs
@@ -10,10 +10,18 @@ use serde_json::Value;
 ///
 /// Invariant: `cache_creation == cache_creation_5m + cache_creation_1h` when
 /// the split data is available.
+///
+/// `reasoning_tokens` carries the model's "thinking" budget emitted as part
+/// of the assistant turn but billed separately from user-visible output.
+/// Populated by Gemini (`thoughts_tokens`), Codex
+/// (`reasoning_output_tokens`), and Copilot (`reasoning_output_tokens`
+/// after `copilot_analyzer` normalises it). Claude has no equivalent and
+/// leaves this at 0.
 #[derive(Debug, Default)]
 pub struct TokenCounts {
     pub input_tokens: i64,
     pub output_tokens: i64,
+    pub reasoning_tokens: i64,
     pub cache_read: i64,
     pub cache_creation: i64,
     pub cache_creation_5m: i64,
@@ -24,15 +32,22 @@ pub struct TokenCounts {
 /// Extracts token counts from usage data in any provider format
 ///
 /// Supports three formats:
-/// - Claude/Gemini: Direct fields like `input_tokens`, `output_tokens`
+/// - Claude/Gemini/Copilot: Direct fields like `input_tokens`, `output_tokens`
 /// - Codex: Nested `total_token_usage` object with different field names
+///
+/// Reasoning tokens (Gemini `thoughts_tokens`, Codex
+/// `reasoning_output_tokens`, Copilot `reasoning_output_tokens`) are no
+/// longer folded into `output_tokens`. Keeping them separate is what lets
+/// `calculate_cost` bill them at `output_cost_per_reasoning_token` for
+/// providers that publish a distinct reasoning rate (e.g. Gemini 2.5
+/// Flash, Perplexity Sonar Deep Research, dashscope/qwen-turbo).
 ///
 /// Returns normalized TokenCounts structure.
 pub fn extract_token_counts(usage: &Value) -> TokenCounts {
     let mut counts = TokenCounts::default();
 
     if let Some(usage_obj) = usage.as_object() {
-        // Claude/Gemini usage format
+        // Claude/Gemini/Copilot usage format (flat fields)
         if let Some(input) = usage_obj.get("input_tokens").and_then(|v| v.as_i64()) {
             counts.input_tokens = input;
         }
@@ -50,6 +65,20 @@ pub fn extract_token_counts(usage: &Value) -> TokenCounts {
             .and_then(|v| v.as_i64())
         {
             counts.cache_creation = cache_creation;
+        }
+
+        // Gemini writes reasoning budget as `thoughts_tokens`; Copilot's
+        // shutdown usage is normalised to `reasoning_output_tokens` by
+        // `copilot_analyzer::analyze_copilot_events`. Either key feeds the
+        // same bucket — we never see both on the same record.
+        if let Some(thoughts) = usage_obj.get("thoughts_tokens").and_then(|v| v.as_i64()) {
+            counts.reasoning_tokens = thoughts;
+        }
+        if let Some(reasoning) = usage_obj
+            .get("reasoning_output_tokens")
+            .and_then(|v| v.as_i64())
+        {
+            counts.reasoning_tokens = reasoning;
         }
 
         // Claude Code records cache_creation split by TTL:
@@ -82,13 +111,15 @@ pub fn extract_token_counts(usage: &Value) -> TokenCounts {
                 counts.input_tokens = input;
             }
             if let Some(output) = total_usage.get("output_tokens").and_then(|v| v.as_i64()) {
-                counts.output_tokens += output;
+                // Codex already accumulates across turns, so replace instead
+                // of adding — the value is the running total for the session.
+                counts.output_tokens = output;
             }
             if let Some(reasoning) = total_usage
                 .get("reasoning_output_tokens")
                 .and_then(|v| v.as_i64())
             {
-                counts.output_tokens += reasoning;
+                counts.reasoning_tokens = reasoning;
             }
             if let Some(cache_read) = total_usage
                 .get("cached_input_tokens")
@@ -97,14 +128,23 @@ pub fn extract_token_counts(usage: &Value) -> TokenCounts {
                 counts.cache_read = cache_read;
             }
             if let Some(total) = total_usage.get("total_tokens").and_then(|v| v.as_i64()) {
-                counts.total = total;
-                return counts; // If total is available, use it directly
+                // Codex `total_tokens` = input + output and excludes
+                // `reasoning_output_tokens` — the provider bills reasoning
+                // separately, so the published total understates the
+                // amount of tokens the caller is actually paying for. Add
+                // reasoning here so the summary row stays consistent with
+                // what `calculate_cost` charges for.
+                counts.total = total + counts.reasoning_tokens;
+                return counts;
             }
         }
 
         // Calculate total if not provided
-        counts.total =
-            counts.input_tokens + counts.output_tokens + counts.cache_read + counts.cache_creation;
+        counts.total = counts.input_tokens
+            + counts.output_tokens
+            + counts.reasoning_tokens
+            + counts.cache_read
+            + counts.cache_creation;
     }
 
     counts
@@ -194,5 +234,68 @@ mod tests {
         assert_eq!(c.cache_creation_5m, 0);
         assert_eq!(c.cache_creation_1h, 0);
         assert_eq!(c.cache_read, 200);
+    }
+
+    #[test]
+    fn gemini_thoughts_tokens_populate_reasoning_bucket() {
+        // Drives Gemini 2.5 flash pricing — thoughts_tokens must reach the
+        // reasoning bucket instead of being silently dropped or bundled
+        // into output.
+        let usage = json!({
+            "input_tokens": 13_906,
+            "output_tokens": 185,
+            "cache_read_input_tokens": 0,
+            "thoughts_tokens": 306,
+            "tool_tokens": 0,
+            "total_tokens": 14_397
+        });
+        let c = extract_token_counts(&usage);
+        assert_eq!(c.input_tokens, 13_906);
+        assert_eq!(c.output_tokens, 185);
+        assert_eq!(c.reasoning_tokens, 306);
+        // Our recomputed total includes reasoning (tool_tokens are not
+        // accounted for — we never bill against them).
+        assert_eq!(c.total, 13_906 + 185 + 306);
+    }
+
+    #[test]
+    fn codex_reasoning_is_separated_from_output() {
+        // Mimics a real Codex `event_msg` record mid-session.
+        let usage = json!({
+            "total_token_usage": {
+                "input_tokens": 5_645,
+                "cached_input_tokens": 5_504,
+                "output_tokens": 810,
+                "reasoning_output_tokens": 640,
+                "total_tokens": 6_455
+            }
+        });
+        let c = extract_token_counts(&usage);
+        assert_eq!(c.input_tokens, 5_645);
+        assert_eq!(c.cache_read, 5_504);
+        assert_eq!(
+            c.output_tokens, 810,
+            "reasoning must no longer fold into output_tokens"
+        );
+        assert_eq!(c.reasoning_tokens, 640);
+        // Codex `total_tokens` excludes reasoning, so `total` ≥ published total.
+        assert_eq!(c.total, 6_455 + 640);
+    }
+
+    #[test]
+    fn copilot_reasoning_output_tokens_populate_reasoning_bucket() {
+        // After `copilot_analyzer` normalisation, Copilot sessions use the
+        // same flat `reasoning_output_tokens` key as Codex's nested one.
+        let usage = json!({
+            "input_tokens": 2_000,
+            "output_tokens": 300,
+            "cache_read_input_tokens": 100,
+            "cache_creation_input_tokens": 0,
+            "reasoning_output_tokens": 150
+        });
+        let c = extract_token_counts(&usage);
+        assert_eq!(c.output_tokens, 300);
+        assert_eq!(c.reasoning_tokens, 150);
+        assert_eq!(c.total, 2_000 + 300 + 150 + 100);
     }
 }

--- a/src/utils/usage_processor.rs
+++ b/src/utils/usage_processor.rs
@@ -164,14 +164,28 @@ pub fn process_gemini_usage(
         return;
     };
 
-    // Add input tokens
+    // Gemini's `tokens.input` is the full promptTokenCount (mirrors
+    // Google's API), which already includes the cached subset reported
+    // as `tokens.cached`. LiteLLM prices the two independently — if we
+    // accumulated `tokens.input` verbatim, every cached token would be
+    // billed at both `input_cost_per_token` and
+    // `cache_read_input_token_cost`, inflating Gemini cost reports.
+    //
+    // Subtract cached from input before accumulating so downstream
+    // bookkeeping matches the Claude convention (input ⊥ cache_read).
+    // We verify this against the Gemini CLI event stream: every
+    // observed record satisfies `total == input + output + thoughts`
+    // with `cached` *not* added — i.e. cached is already folded into
+    // `input`, not stored alongside it.
+    let input_non_cached = (tokens.input - tokens.cached).max(0);
+
     let current_input = existing_obj
         .get("input_tokens")
         .and_then(|v| v.as_i64())
         .unwrap_or(0);
     existing_obj.insert(
         "input_tokens".to_string(),
-        (current_input + tokens.input).into(),
+        (current_input + input_non_cached).into(),
     );
 
     // Add cached tokens as cache_read_input_tokens
@@ -396,23 +410,50 @@ mod tests {
     fn test_process_gemini_usage_basic() {
         let mut conversation_usage = FastHashMap::default();
         let model = "gemini-2.0-flash";
+        // Use a realistic shape: `input` (300) includes `cached` (200),
+        // so non-cached input is 100.
         let tokens = crate::models::GeminiTokens {
-            input: 100,
+            input: 300,
             output: 50,
             cached: 200,
             thoughts: 10,
             tool: 5,
-            total: 365,
+            total: 360,
         };
 
         process_gemini_usage(&mut conversation_usage, model, &tokens);
 
         let result = conversation_usage.get(model).unwrap();
-        assert_eq!(result["input_tokens"].as_i64().unwrap(), 100);
+        assert_eq!(
+            result["input_tokens"].as_i64().unwrap(),
+            100,
+            "input must be stored as non-cached (input - cached) to match Claude semantics"
+        );
         assert_eq!(result["output_tokens"].as_i64().unwrap(), 50);
         assert_eq!(result["cache_read_input_tokens"].as_i64().unwrap(), 200);
         assert_eq!(result["thoughts_tokens"].as_i64().unwrap(), 10);
         assert_eq!(result["tool_tokens"].as_i64().unwrap(), 5);
-        assert_eq!(result["total_tokens"].as_i64().unwrap(), 365);
+        assert_eq!(result["total_tokens"].as_i64().unwrap(), 360);
+    }
+
+    #[test]
+    fn test_process_gemini_usage_no_cache() {
+        // Sanity check: a record with `cached: 0` must not alter input.
+        let mut conversation_usage = FastHashMap::default();
+        let model = "gemini-2.0-flash";
+        let tokens = crate::models::GeminiTokens {
+            input: 13_906,
+            output: 185,
+            cached: 0,
+            thoughts: 306,
+            tool: 0,
+            total: 14_397,
+        };
+
+        process_gemini_usage(&mut conversation_usage, model, &tokens);
+
+        let result = conversation_usage.get(model).unwrap();
+        assert_eq!(result["input_tokens"].as_i64().unwrap(), 13_906);
+        assert_eq!(result["cache_read_input_tokens"].as_i64().unwrap(), 0);
     }
 }

--- a/tests/integrations/parser_tests.rs
+++ b/tests/integrations/parser_tests.rs
@@ -364,8 +364,12 @@ fn test_gemini_parser_jsonl() {
     assert_eq!(record["taskId"], "fixture-session");
 
     // Token usage attributed to the sole assistant model in the fixture.
+    // Gemini's `tokens.input` (100) is the full prompt including the
+    // cached subset (10), so `process_gemini_usage` stores it as
+    // non-cached (90) — mirroring Claude's "input ⊥ cache_read"
+    // convention and preventing `calculate_cost` from double-billing.
     let usage = &record["conversationUsage"]["gemini-3-flash-preview"];
-    assert_eq!(usage["input_tokens"], 100);
+    assert_eq!(usage["input_tokens"], 90);
     assert_eq!(usage["output_tokens"], 50);
     assert_eq!(usage["cache_read_input_tokens"], 10);
     assert_eq!(usage["thoughts_tokens"], 5);

--- a/tests/integrations/pricing_tests.rs
+++ b/tests/integrations/pricing_tests.rs
@@ -172,8 +172,8 @@ fn test_calculate_cost_basic() {
         ..Default::default()
     };
 
-    // 2000 cache_creation tokens at default (5 minute) TTL.
-    let cost = calculate_cost(1000, 500, 10000, 2000, 0, &pricing);
+    // 2000 cache_creation tokens at default (5 minute) TTL, no reasoning tokens.
+    let cost = calculate_cost(1000, 500, 0, 10000, 2000, 0, &pricing);
     // input: 1000 * 0.000003 = 0.003
     // output: 500 * 0.000015 = 0.0075
     // cache_read: 10000 * 0.0000003 = 0.003
@@ -185,7 +185,7 @@ fn test_calculate_cost_basic() {
 #[test]
 fn test_calculate_cost_zero_tokens() {
     let pricing = ModelPricing::default();
-    let cost = calculate_cost(0, 0, 0, 0, 0, &pricing);
+    let cost = calculate_cost(0, 0, 0, 0, 0, 0, &pricing);
     assert_eq!(cost, 0.0);
 }
 
@@ -197,7 +197,7 @@ fn test_calculate_cost_no_cache() {
         ..Default::default()
     };
 
-    let cost = calculate_cost(1000, 500, 0, 0, 0, &pricing);
+    let cost = calculate_cost(1000, 500, 0, 0, 0, 0, &pricing);
     // input: 1000 * 0.000003 = 0.003
     // output: 500 * 0.000015 = 0.0075
     // total: 0.0105
@@ -215,7 +215,7 @@ fn test_calculate_cost_large_numbers() {
         ..Default::default()
     };
 
-    let cost = calculate_cost(1_000_000, 500_000, 100_000, 50_000, 0, &pricing);
+    let cost = calculate_cost(1_000_000, 500_000, 0, 100_000, 50_000, 0, &pricing);
     assert!(cost > 0.0);
     assert!(cost.is_finite());
 }
@@ -374,11 +374,11 @@ fn test_pricing_above_200k_tokens_via_tier() {
     };
 
     // Below 200K: base prices.
-    let below = calculate_cost(100_000, 50_000, 0, 0, 0, &pricing);
+    let below = calculate_cost(100_000, 50_000, 0, 0, 0, 0, &pricing);
     assert_eq!(below, 100_000.0 * 0.000001 + 50_000.0 * 0.000002);
 
     // Above 200K: tier prices for all tokens.
-    let above = calculate_cost(300_000, 50_000, 0, 0, 0, &pricing);
+    let above = calculate_cost(300_000, 50_000, 0, 0, 0, 0, &pricing);
     assert_eq!(above, 300_000.0 * 0.000002 + 50_000.0 * 0.000004);
 }
 
@@ -406,10 +406,10 @@ fn test_pricing_range_based() {
         ..Default::default()
     };
 
-    let low = calculate_cost(10_000, 1000, 0, 0, 0, &pricing);
+    let low = calculate_cost(10_000, 1000, 0, 0, 0, 0, &pricing);
     assert_eq!(low, 10_000.0 * 0.000001 + 1000.0 * 0.000005);
 
-    let high = calculate_cost(100_000, 1000, 0, 0, 0, &pricing);
+    let high = calculate_cost(100_000, 1000, 0, 0, 0, 0, &pricing);
     assert_eq!(high, 100_000.0 * 0.0000018 + 1000.0 * 0.000009);
 }
 

--- a/tests/integrations/usage_tests.rs
+++ b/tests/integrations/usage_tests.rs
@@ -74,8 +74,8 @@ fn test_usage_calculation_cost_accuracy() {
         ..Default::default()
     };
 
-    // 2000 cache_creation tokens, all default (5 minute) TTL.
-    let cost = calculate_cost(1000, 500, 10000, 2000, 0, &pricing);
+    // 2000 cache_creation tokens, all default (5 minute) TTL, no reasoning.
+    let cost = calculate_cost(1000, 500, 0, 10000, 2000, 0, &pricing);
 
     // input: 1000 * 0.000003 = 0.003
     // output: 500 * 0.000015 = 0.0075

--- a/tests/test_pricing_cache.rs
+++ b/tests/test_pricing_cache.rs
@@ -134,6 +134,7 @@ fn test_model_pricing_all_fields() {
         output_cost_per_token: 2.0,
         cache_read_input_token_cost: 3.0,
         cache_creation_input_token_cost: 4.0,
+        output_cost_per_reasoning_token: 11.0,
         tiers: vec![ThresholdTier {
             threshold_tokens: 200_000,
             input_cost_per_token: 5.0,
@@ -160,6 +161,7 @@ fn test_model_pricing_all_fields() {
     assert_eq!(deserialized.output_cost_per_token, 2.0);
     assert_eq!(deserialized.cache_read_input_token_cost, 3.0);
     assert_eq!(deserialized.cache_creation_input_token_cost, 4.0);
+    assert_eq!(deserialized.output_cost_per_reasoning_token, 11.0);
     assert_eq!(deserialized.tiers.len(), 1);
     assert_eq!(deserialized.tiers[0].threshold_tokens, 200_000);
     assert_eq!(deserialized.tiers[0].input_cost_per_token, 5.0);


### PR DESCRIPTION
## Summary

Refactors the LiteLLM pricing pipeline so every `*cost*` field from the
upstream JSON is preserved on disk, teaches `calculate_cost` to bill
reasoning tokens against `output_cost_per_reasoning_token`, and fixes two
pre-existing double-billing bugs where Codex and Gemini cached input
tokens were being charged twice.

Key changes per commit:

1. `refactor(pricing): cache the raw LiteLLM cost-field subset` — cache
   file is now a `cost`-only projection of the upstream JSON (not a
   serialised `ModelPricing`). `tiers` / `ranges` are rebuilt from the
   raw `*_above_Nk_tokens` / `tiered_pricing` keys on every load, and
   forward-looking fields (`*_priority`, `*_flex`, `*_batches`,
   `input_cost_per_audio_token`, `output_cost_per_reasoning_token`, …)
   survive for future calculation strategies without a re-fetch.

2. `feat(tokens): split reasoning tokens from output in extractor` —
   `TokenCounts` grows a `reasoning_tokens` bucket; Gemini
   `thoughts_tokens`, Codex `reasoning_output_tokens`, and Copilot
   `reasoningTokens` all feed into it instead of the flat `output`
   rate. Copilot analyser now surfaces reasoning as
   `reasoning_output_tokens` on the usage JSON.

3. `feat(pricing): bill reasoning tokens at output_cost_per_reasoning_token`
   — new argument on `calculate_cost`; range-priced models read the
   per-range reasoning rate, threshold-tier pricing falls back to the
   active tier's output rate (LiteLLM hasn't published per-tier
   reasoning overrides yet), and flat pricing uses
   `output_cost_per_reasoning_token` when non-zero. Gemini
   `thoughts_tokens` were previously billed at `$0` because the
   extractor didn't read them — Gemini sessions are now billed against
   the model's published reasoning rate (e.g. $3/M for
   `gemini-3-flash-preview`).

4. `feat(display): fold reasoning tokens into Output column` — keeps
   per-row Output + Total additions consistent in both the static and
   interactive usage tables, while the underlying cost still uses the
   separate rate.

5. `fix(codex): stop double-billing cached input tokens` — Codex
   reports `input_tokens` as the full prompt (including cached);
   LiteLLM charges cached and non-cached separately. On a real
   `gpt-5.4` session the old path produced `$3.57` against the true
   `$1.53` billed by OpenAI (~130% overcharge). Fixed by subtracting
   `cached_input_tokens` from `input_tokens` inside
   `extract_token_counts`.

6. `fix(gemini): stop double-billing cached input tokens` — Gemini's
   `tokens.input` is the full `promptTokenCount` including the cached
   subset reported as `tokens.cached`, verified against the real event
   stream where `total == input + output + thoughts` (cached *not*
   summed). Fixed by normalising inside `process_gemini_usage` so
   downstream sees the Claude-style `input ⊥ cache_read` convention.
   `gemini-3-flash-preview` drops from `$0.1669` to `$0.1220` on the
   cached-heavy fixture session.

## Impact on the common models the issue asked about

- **Claude** (Sonnet 4-5/4-6, Opus 4-6/4-7, Haiku 4-5): unchanged —
  already uses the correct convention, no reasoning pricing published.
- **Gemini 2.5 Pro / 3 Pro / Flash / Flash-Lite**: cached double-
  billing eliminated; `thoughts_tokens` now billed against
  `output_cost_per_reasoning_token` (was silently billed at `$0`).
- **GPT / GPT-5.x / o-series**: cached double-billing eliminated for
  Codex sessions; `reasoning_output_tokens` billed against the tier's
  output rate (previously folded into output — same rate today, but
  future-proofed if OpenAI publishes a separate reasoning price).
- **Grok / grok-4-fast-reasoning**: unchanged — reasoning folds into
  output at the 128K tier rate, same as before.

## Test plan

- [x] `cargo test` — 439 tests across 16 suites, all green
- [x] `cargo build --quiet` — clean build, no new warnings
- [x] `vct usage --table` on a live session mix (Claude Code, Codex,
      Copilot, Gemini) — rows reconcile (Input + Output + Cache Read +
      Cache Creation == Total), cost totals drop $2.05 vs main
      ($1353.61 → $1351.56) matching the expected Codex overcharge
      correction
- [x] Manual arithmetic check against the on-disk cache prices for
      `gpt-5.4` (tier-activated) and `gemini-3-flash-preview` (flat
      with reasoning) — computed cost matches reported `cost_usd`
- [x] Regression-tested Copilot and Gemini JSONL roundtrip against
      `examples/analysis_result_*.json`


Made with [Cursor](https://cursor.com)