### PR TITLE
feat(analysis): align output flags with usage subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,14 +239,15 @@ The tool automatically scans these directories:
 
 ### Flags
 
-| Flag                                           | Purpose                                                            |
-| ---------------------------------------------- | ------------------------------------------------------------------ |
-| *(none)*                                       | Interactive TUI dashboard over all sessions                        |
-| `--path <FILE>`                                | Analyze a single JSONL/JSON conversation file (prints JSON)        |
-| `--table`                                      | Static table with per-provider daily averages                      |
-| `--output <FILE>`                              | Save results as pretty-printed JSON                                |
-| `--by-provider`                                | Group rows by provider (claude / codex / copilot / gemini) as JSON |
-| `--daily` / `--weekly` / `--monthly` / `--all` | Time range filter (see table above)                                |
+| Flag                                           | Purpose                                                     |
+| ---------------------------------------------- | ----------------------------------------------------------- |
+| *(none)*                                       | Interactive TUI dashboard over all sessions                 |
+| `--path <FILE>`                                | Analyze a single JSONL/JSON conversation file (prints JSON) |
+| `--table`                                      | Static table with per-provider daily averages               |
+| `--text`                                       | Plain text, script-friendly                                 |
+| `--json`                                       | JSON array of aggregated rows printed to stdout             |
+| `--output <FILE>`                              | Save results as pretty-printed JSON                         |
+| `--daily` / `--weekly` / `--monthly` / `--all` | Time range filter (see table above)                         |
 
 See [`examples/`](examples/) for sample inputs and matching JSON outputs for all four providers.
 
@@ -259,22 +260,23 @@ vct analysis
 # Static table output with daily averages
 vct analysis --table
 
+# Plain text for scripts
+vct analysis --text
+
+# JSON of aggregated rows for data processing
+vct analysis --json
+
 # Analyze a single conversation file → stdout JSON
 vct analysis --path ~/.claude/projects/session.jsonl
 
 # Save results to JSON
 vct analysis --output report.json
 
-# Group results by provider
-vct analysis --by-provider
-
-# Save grouped results
-vct analysis --by-provider --output grouped_report.json
-
 # Combine time range with output format
 vct analysis --weekly
 vct analysis --table --monthly
-vct analysis --by-provider --daily --output today.json
+vct analysis --json --daily
+vct analysis --output today.json --daily
 ```
 
 ### Preview: Interactive Dashboard (`vct analysis`)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -239,14 +239,15 @@ vct usage --json --daily
 
 ### Flag 一览
 
-| Flag                                           | 用途                                                            |
-| ---------------------------------------------- | --------------------------------------------------------------- |
-| *(不带参数)*                                   | 互动式 TUI 面板，覆盖所有 session                               |
-| `--path <FILE>`                                | 分析单一 JSONL/JSON 对话文件（stdout 输出 JSON）                |
-| `--table`                                      | 静态表格，附带每日平均值                                        |
-| `--output <FILE>`                              | 将结果以格式化 JSON 保存到文件                                  |
-| `--by-provider`                                | 按 provider（claude / codex / copilot / gemini）分组并输出 JSON |
-| `--daily` / `--weekly` / `--monthly` / `--all` | 时间范围筛选（见上方表格）                                      |
+| Flag                                           | 用途                                             |
+| ---------------------------------------------- | ------------------------------------------------ |
+| *(不带参数)*                                   | 互动式 TUI 面板，覆盖所有 session                |
+| `--path <FILE>`                                | 分析单一 JSONL/JSON 对话文件（stdout 输出 JSON） |
+| `--table`                                      | 静态表格，附带每日平均值                         |
+| `--text`                                       | 纯文本，方便脚本处理                             |
+| `--json`                                       | 将聚合 row 以 JSON 数组输出到 stdout             |
+| `--output <FILE>`                              | 将结果以格式化 JSON 保存到文件                   |
+| `--daily` / `--weekly` / `--monthly` / `--all` | 时间范围筛选（见上方表格）                       |
 
 参见 [`examples/`](examples/) 目录，其中包含四种 provider 的示例输入与对应 JSON 输出。
 
@@ -259,22 +260,23 @@ vct analysis
 # Static table output with daily averages
 vct analysis --table
 
+# 纯文本输出，方便脚本处理
+vct analysis --text
+
+# 聚合数据以 JSON 输出，方便后续处理
+vct analysis --json
+
 # 分析单一对话文件 → stdout JSON
 vct analysis --path ~/.claude/projects/session.jsonl
 
 # Save results to JSON
 vct analysis --output report.json
 
-# Group results by provider
-vct analysis --by-provider
-
-# Save grouped results
-vct analysis --by-provider --output grouped_report.json
-
 # 时间范围与输出格式可自由组合
 vct analysis --weekly
 vct analysis --table --monthly
-vct analysis --by-provider --daily --output today.json
+vct analysis --json --daily
+vct analysis --output today.json --daily
 ```
 
 ### 预览：交互式面板（`vct analysis`）

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -239,14 +239,15 @@ vct usage --json --daily
 
 ### Flag 一覽
 
-| Flag                                           | 用途                                                            |
-| ---------------------------------------------- | --------------------------------------------------------------- |
-| *(不帶參數)*                                   | 互動式 TUI 儀表板，涵蓋所有 session                             |
-| `--path <FILE>`                                | 分析單一 JSONL/JSON 對話檔案（stdout 輸出 JSON）                |
-| `--table`                                      | 靜態表格，附帶每日平均值                                        |
-| `--output <FILE>`                              | 將結果以格式化 JSON 存成檔案                                    |
-| `--by-provider`                                | 依 provider（claude / codex / copilot / gemini）分組並輸出 JSON |
-| `--daily` / `--weekly` / `--monthly` / `--all` | 時間範圍篩選（見上方表格）                                      |
+| Flag                                           | 用途                                             |
+| ---------------------------------------------- | ------------------------------------------------ |
+| *(不帶參數)*                                   | 互動式 TUI 儀表板，涵蓋所有 session              |
+| `--path <FILE>`                                | 分析單一 JSONL/JSON 對話檔案（stdout 輸出 JSON） |
+| `--table`                                      | 靜態表格，附帶每日平均值                         |
+| `--text`                                       | 純文字，方便腳本處理                             |
+| `--json`                                       | 將聚合 row 以 JSON 陣列輸出到 stdout             |
+| `--output <FILE>`                              | 將結果以格式化 JSON 存成檔案                     |
+| `--daily` / `--weekly` / `--monthly` / `--all` | 時間範圍篩選（見上方表格）                       |
 
 請參考 [`examples/`](examples/) 目錄，裡面有四種 provider 的範例輸入與對應的 JSON 輸出。
 
@@ -259,22 +260,23 @@ vct analysis
 # Static table output with daily averages
 vct analysis --table
 
+# 純文字輸出，方便腳本處理
+vct analysis --text
+
+# 聚合資料以 JSON 輸出，方便後續處理
+vct analysis --json
+
 # 分析單一對話檔案 → stdout JSON
 vct analysis --path ~/.claude/projects/session.jsonl
 
 # Save results to JSON
 vct analysis --output report.json
 
-# Group results by provider
-vct analysis --by-provider
-
-# Save grouped results
-vct analysis --by-provider --output grouped_report.json
-
 # 時間範圍與輸出格式可自由組合
 vct analysis --weekly
 vct analysis --table --monthly
-vct analysis --by-provider --daily --output today.json
+vct analysis --json --daily
+vct analysis --output today.json --daily
 ```
 
 ### 預覽：互動式儀表板（`vct analysis`）

--- a/src/analysis/aggregator.rs
+++ b/src/analysis/aggregator.rs
@@ -1,4 +1,3 @@
-use crate::cache::global_cache;
 use crate::cli::TimeRange;
 use crate::constants::{FastHashMap, capacity};
 use crate::models::{CodeAnalysis, ExtensionType, ProviderActiveDays};
@@ -13,7 +12,6 @@ use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::path::Path;
-use std::sync::Arc;
 
 /// Single row of aggregated metrics grouped by model
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -60,8 +58,7 @@ pub struct PerProviderAnalysisRows {
 ///
 /// Scans Claude, Codex, Copilot, and Gemini session directories, aggregates
 /// tool-call counts and line counts by model, and returns sorted results
-/// with provider active-day counts. Complements [`collect_sessions_grouped_by_provider`]
-/// which preserves full records instead of aggregating.
+/// with provider active-day counts.
 pub fn aggregate_sessions_by_model(time_range: TimeRange) -> Result<AnalysisData> {
     let paths = crate::utils::resolve_paths()?;
     let mut aggregated: FastHashMap<String, AggregatedAnalysisRow> =
@@ -172,138 +169,6 @@ fn into_sorted_rows(map: FastHashMap<String, AggregatedAnalysisRow>) -> Vec<Aggr
     let mut v: Vec<AggregatedAnalysisRow> = map.into_values().collect();
     v.sort_unstable_by(|a, b| a.model.cmp(&b.model));
     v
-}
-
-/// Complete CodeAnalysis results organized by AI provider.
-///
-/// Each record is stored as an `Arc<CodeAnalysis>` — the same typed struct
-/// held by the global file cache — so no deep-clone happens to ferry results
-/// out of the worker pool, and no intermediate `Value` is materialised.
-/// serde's `rc` feature lets `Arc<CodeAnalysis>` serialise as the underlying
-/// struct, so the emitted JSON is unchanged. The struct is output-only, which
-/// is why it does not derive `Deserialize`.
-#[derive(Debug, Clone, Serialize)]
-pub struct ProviderGroupedAnalysis {
-    #[serde(rename = "Claude-Code")]
-    pub claude: Vec<Arc<CodeAnalysis>>,
-    #[serde(rename = "Codex")]
-    pub codex: Vec<Arc<CodeAnalysis>>,
-    #[serde(rename = "Copilot-CLI")]
-    pub copilot: Vec<Arc<CodeAnalysis>>,
-    #[serde(rename = "Gemini")]
-    pub gemini: Vec<Arc<CodeAnalysis>>,
-}
-
-/// Collect every parsed session grouped by provider, without aggregating.
-///
-/// Returns each provider's full `CodeAnalysis` records as emitted by the
-/// session parser (via the global file cache). Use
-/// [`aggregate_sessions_by_model`] when you only need per-model metrics
-/// rather than the per-session detail.
-pub fn collect_sessions_grouped_by_provider(
-    time_range: TimeRange,
-) -> Result<ProviderGroupedAnalysis> {
-    let paths = crate::utils::resolve_paths()?;
-
-    let mut claude_results: Vec<Arc<CodeAnalysis>> = Vec::new();
-    let mut codex_results: Vec<Arc<CodeAnalysis>> = Vec::new();
-    let mut copilot_results: Vec<Arc<CodeAnalysis>> = Vec::new();
-    let mut gemini_results: Vec<Arc<CodeAnalysis>> = Vec::new();
-
-    // Process Claude sessions (including subagents/ sublogs)
-    if paths.claude_session_dir.exists() {
-        collect_sessions_in_directory(
-            &paths.claude_session_dir,
-            ExtensionType::ClaudeCode,
-            &mut claude_results,
-            is_claude_session_file,
-            time_range,
-            None,
-        )?;
-    }
-
-    // Process Codex sessions
-    if paths.codex_session_dir.exists() {
-        collect_sessions_in_directory(
-            &paths.codex_session_dir,
-            ExtensionType::Codex,
-            &mut codex_results,
-            is_codex_session_file,
-            time_range,
-            None,
-        )?;
-    }
-
-    // Process Copilot sessions — bounded walk so sibling snapshot trees
-    // (`rewind-snapshots/`, `files/`, …) do not slow the scan down.
-    if paths.copilot_session_dir.exists() {
-        collect_sessions_in_directory(
-            &paths.copilot_session_dir,
-            ExtensionType::Copilot,
-            &mut copilot_results,
-            is_copilot_session_file,
-            time_range,
-            Some(COPILOT_SESSION_MAX_DEPTH),
-        )?;
-    }
-
-    // Process Gemini sessions
-    if paths.gemini_session_dir.exists() {
-        collect_sessions_in_directory(
-            &paths.gemini_session_dir,
-            ExtensionType::Gemini,
-            &mut gemini_results,
-            is_gemini_session_file,
-            time_range,
-            None,
-        )?;
-    }
-
-    Ok(ProviderGroupedAnalysis {
-        claude: claude_results,
-        codex: codex_results,
-        copilot: copilot_results,
-        gemini: gemini_results,
-    })
-}
-
-fn collect_sessions_in_directory<P, F>(
-    dir: P,
-    provider: ExtensionType,
-    results: &mut Vec<Arc<CodeAnalysis>>,
-    filter_fn: F,
-    time_range: TimeRange,
-    max_depth: Option<usize>,
-) -> Result<()>
-where
-    P: AsRef<Path>,
-    F: Copy + Fn(&Path) -> bool + Sync + Send,
-{
-    let dir = dir.as_ref();
-    let files = collect_files_with_max_depth(dir, filter_fn, time_range, max_depth)?;
-
-    // Parallel parse through the global cache. The provider is fixed by the
-    // source directory, so the cache dispatches to the right parser without
-    // re-inspecting the file's contents.
-    let analyzed: Vec<Arc<CodeAnalysis>> = files
-        .par_iter()
-        .filter_map(
-            |file_info| match global_cache().get_or_parse_as(&file_info.path, provider) {
-                Ok(analysis_arc) => Some(analysis_arc),
-                Err(e) => {
-                    eprintln!(
-                        "Warning: Failed to parse {}: {}",
-                        file_info.path.display(),
-                        e
-                    );
-                    None
-                }
-            },
-        )
-        .collect();
-
-    results.extend(analyzed);
-    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)] // per-provider helper; struct-wrapping the args would hurt readability

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -55,7 +55,7 @@ pub enum Commands {
     /// Analyze JSONL conversation files (single file or all sessions)
     Analysis {
         /// Path to the JSONL file to analyze (if not provided, analyzes all sessions)
-        #[arg(short, long)]
+        #[arg(short, long, conflicts_with_all = ["json", "text", "table"])]
         path: Option<PathBuf>,
 
         /// Optional output path to save analysis result as JSON

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -63,15 +63,15 @@ pub enum Commands {
         output: Option<PathBuf>,
 
         /// Output raw JSON instead of table view
-        #[arg(long)]
+        #[arg(long, group = "analysis_format")]
         json: bool,
 
         /// Output as plain text
-        #[arg(long)]
+        #[arg(long, group = "analysis_format")]
         text: bool,
 
         /// Output as static table (instead of interactive TUI)
-        #[arg(long)]
+        #[arg(long, group = "analysis_format")]
         table: bool,
 
         /// Show only today's data
@@ -94,15 +94,15 @@ pub enum Commands {
     /// Display token usage statistics
     Usage {
         /// Output raw JSON instead of table view
-        #[arg(long)]
+        #[arg(long, group = "usage_format")]
         json: bool,
 
         /// Output as plain text
-        #[arg(long)]
+        #[arg(long, group = "usage_format")]
         text: bool,
 
         /// Output as static table
-        #[arg(long)]
+        #[arg(long, group = "usage_format")]
         table: bool,
 
         /// Show only today's data

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -62,9 +62,13 @@ pub enum Commands {
         #[arg(short, long)]
         output: Option<PathBuf>,
 
-        /// Group results by provider (claude/codex/gemini)
+        /// Output raw JSON instead of table view
         #[arg(long)]
-        by_provider: bool,
+        json: bool,
+
+        /// Output as plain text
+        #[arg(long)]
+        text: bool,
 
         /// Output as static table (instead of interactive TUI)
         #[arg(long)]

--- a/src/display/analysis/mod.rs
+++ b/src/display/analysis/mod.rs
@@ -1,7 +1,9 @@
 mod averages;
 mod interactive;
 mod table;
+mod text;
 
 pub use averages::*;
 pub use interactive::display_analysis_interactive;
 pub use table::display_analysis_table;
+pub use text::display_analysis_text;

--- a/src/display/analysis/text.rs
+++ b/src/display/analysis/text.rs
@@ -1,0 +1,30 @@
+use crate::analysis::AnalysisData;
+
+/// Displays aggregated analysis data as plain text (one model per line, key=value pairs).
+///
+/// Output format (script-friendly, raw integers without thousand separators):
+///
+/// ```text
+/// {model}: editLines={N} readLines={N} writeLines={N} bash={N} edit={N} read={N} todoWrite={N} write={N}
+/// ```
+pub fn display_analysis_text(analysis: &AnalysisData) {
+    if analysis.rows.is_empty() {
+        println!("No analysis data found");
+        return;
+    }
+
+    for row in &analysis.rows {
+        println!(
+            "{}: editLines={} readLines={} writeLines={} bash={} edit={} read={} todoWrite={} write={}",
+            row.model,
+            row.edit_lines,
+            row.read_lines,
+            row.write_lines,
+            row.bash_count,
+            row.edit_count,
+            row.read_count,
+            row.todo_write_count,
+            row.write_count,
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,8 @@ fn main() -> Result<()> {
         Commands::Analysis {
             path,
             output,
-            by_provider,
+            json,
+            text,
             table,
             daily,
             weekly,
@@ -47,56 +48,42 @@ fn main() -> Result<()> {
         } => {
             let time_range = resolve_time_range(daily, weekly, monthly);
 
-            if by_provider {
-                // Handle --by-provider flag: group by provider and output as JSON
-                let grouped_data =
-                    vibe_coding_tracker::analysis::collect_sessions_grouped_by_provider(
-                        time_range,
-                    )?;
+            match path {
+                Some(file_path) => {
+                    let result = parse_session_file(&file_path)?;
 
-                if let Some(output_path) = output {
-                    let json_value = serde_json::to_value(&grouped_data)?;
-                    vibe_coding_tracker::utils::save_json_pretty(&output_path, &json_value)?;
-                    println!("✅ Analysis result saved to: {}", output_path.display());
-                } else {
-                    // Output as JSON by default
-                    let json_str = serde_json::to_string_pretty(&grouped_data)?;
-                    println!("{}", json_str);
-                }
-            } else {
-                match path {
-                    Some(file_path) => {
-                        let result = parse_session_file(&file_path)?;
-
-                        if let Some(output_path) = output {
-                            vibe_coding_tracker::utils::save_json_pretty(&output_path, &result)?;
-                            println!("✅ Analysis result saved to: {}", output_path.display());
-                        } else {
-                            let json_str = serde_json::to_string_pretty(&result)?;
-                            println!("{}", json_str);
-                        }
+                    if let Some(output_path) = output {
+                        vibe_coding_tracker::utils::save_json_pretty(&output_path, &result)?;
+                        println!("✅ Analysis result saved to: {}", output_path.display());
+                    } else {
+                        let json_str = serde_json::to_string_pretty(&result)?;
+                        println!("{}", json_str);
                     }
-                    None => {
-                        let analysis_data =
-                            vibe_coding_tracker::analysis::aggregate_sessions_by_model(time_range)?;
+                }
+                None => {
+                    let analysis_data =
+                        vibe_coding_tracker::analysis::aggregate_sessions_by_model(time_range)?;
 
-                        if let Some(output_path) = output {
-                            let json_value = serde_json::to_value(&analysis_data.rows)?;
-                            vibe_coding_tracker::utils::save_json_pretty(
-                                &output_path,
-                                &json_value,
-                            )?;
-                            println!("✅ Analysis result saved to: {}", output_path.display());
-                        } else if table {
-                            vibe_coding_tracker::display::analysis::display_analysis_table(
-                                &analysis_data,
-                            );
-                        } else {
-                            vibe_coding_tracker::display::analysis::display_analysis_interactive(
-                                &analysis_data,
-                                time_range,
-                            )?;
-                        }
+                    if let Some(output_path) = output {
+                        let json_value = serde_json::to_value(&analysis_data.rows)?;
+                        vibe_coding_tracker::utils::save_json_pretty(&output_path, &json_value)?;
+                        println!("✅ Analysis result saved to: {}", output_path.display());
+                    } else if json {
+                        let json_str = serde_json::to_string_pretty(&analysis_data.rows)?;
+                        println!("{}", json_str);
+                    } else if text {
+                        vibe_coding_tracker::display::analysis::display_analysis_text(
+                            &analysis_data,
+                        );
+                    } else if table {
+                        vibe_coding_tracker::display::analysis::display_analysis_table(
+                            &analysis_data,
+                        );
+                    } else {
+                        vibe_coding_tracker::display::analysis::display_analysis_interactive(
+                            &analysis_data,
+                            time_range,
+                        )?;
                     }
                 }
             }

--- a/tests/analysis.rs
+++ b/tests/analysis.rs
@@ -4,9 +4,7 @@
 
 use std::path::PathBuf;
 use tempfile::TempDir;
-use vibe_coding_tracker::analysis::aggregator::{
-    aggregate_sessions_by_model, collect_sessions_grouped_by_provider,
-};
+use vibe_coding_tracker::analysis::aggregator::aggregate_sessions_by_model;
 use vibe_coding_tracker::cli::TimeRange;
 use vibe_coding_tracker::models::ExtensionType;
 use vibe_coding_tracker::session::parser::{parse_session_file, parse_session_file_as};
@@ -302,31 +300,6 @@ fn test_batch_analysis_serialization() {
     let deserialized: AggregatedAnalysisRow = serde_json::from_str(&json).unwrap();
     assert_eq!(deserialized.model, row.model);
     assert_eq!(deserialized.edit_lines, row.edit_lines);
-}
-
-#[test]
-fn test_batch_analysis_by_provider() {
-    // Test provider-grouped analysis
-    let result = collect_sessions_grouped_by_provider(TimeRange::All);
-    assert!(result.is_ok(), "Provider-grouped analysis should not fail");
-
-    if let Ok(grouped) = result {
-        // Verify structure - check if any provider has data
-        let has_data = !grouped.claude.is_empty()
-            || !grouped.codex.is_empty()
-            || !grouped.copilot.is_empty()
-            || !grouped.gemini.is_empty();
-
-        // At least one provider should have data or all should be empty (valid states)
-        assert!(
-            has_data
-                || (grouped.claude.is_empty()
-                    && grouped.codex.is_empty()
-                    && grouped.copilot.is_empty()
-                    && grouped.gemini.is_empty()),
-            "Provider grouping should be valid"
-        );
-    }
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -285,13 +285,34 @@ fn test_invalid_command() {
 
 #[test]
 fn test_usage_multiple_output_formats() {
-    // Test that multiple output format flags can't be used together
-    // (behavior depends on CLI implementation)
-    let mut cmd = Command::cargo_bin("vibe_coding_tracker").unwrap();
-    cmd.arg("usage").arg("--json").arg("--text");
+    // --json/--text/--table belong to a single clap group and must be
+    // mutually exclusive.
+    for combo in [
+        ["--json", "--text"],
+        ["--json", "--table"],
+        ["--text", "--table"],
+    ] {
+        let mut cmd = Command::cargo_bin("vibe_coding_tracker").unwrap();
+        cmd.arg("usage").args(combo);
+        cmd.assert()
+            .failure()
+            .stderr(predicate::str::contains("cannot be used with"));
+    }
+}
 
-    // Should handle gracefully
-    let _ = cmd.output();
+#[test]
+fn test_analysis_multiple_output_formats() {
+    for combo in [
+        ["--json", "--text"],
+        ["--json", "--table"],
+        ["--text", "--table"],
+    ] {
+        let mut cmd = Command::cargo_bin("vibe_coding_tracker").unwrap();
+        cmd.arg("analysis").args(combo);
+        cmd.assert()
+            .failure()
+            .stderr(predicate::str::contains("cannot be used with"));
+    }
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -130,37 +130,51 @@ fn test_analysis_batch_mode_with_output() {
 }
 
 #[test]
-fn test_analysis_all_providers() {
-    let mut cmd = Command::cargo_bin("vibe_coding_tracker").unwrap();
-    cmd.arg("analysis").arg("--by-provider");
-
-    cmd.assert().success().stdout(
-        predicate::str::contains("Claude-Code")
-            .or(predicate::str::contains("Codex"))
-            .or(predicate::str::contains("Copilot-CLI"))
-            .or(predicate::str::contains("Gemini"))
-            .or(predicate::str::contains("{}")),
-    ); // Empty result is also valid
-}
-
-#[test]
-fn test_analysis_all_providers_with_output() {
-    let temp_dir = TempDir::new().unwrap();
-    let output_file = temp_dir.path().join("providers_output.json");
+fn test_analysis_command_json() {
+    use std::time::Duration;
 
     let mut cmd = Command::cargo_bin("vibe_coding_tracker").unwrap();
     cmd.arg("analysis")
-        .arg("--by-provider")
-        .arg("--output")
-        .arg(output_file.to_str().unwrap());
+        .arg("--json")
+        .timeout(Duration::from_secs(10));
 
-    cmd.assert().success();
+    let output = cmd.output().unwrap();
 
-    if output_file.exists() {
-        let content = std::fs::read_to_string(&output_file).unwrap();
-        let json: serde_json::Value = serde_json::from_str(&content).unwrap();
-        assert!(json.is_object(), "Provider output should be JSON object");
+    if output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        if !stdout.trim().is_empty() {
+            let json: Result<serde_json::Value, _> = serde_json::from_str(&stdout);
+            assert!(json.is_ok(), "--json output should be valid JSON");
+            assert!(
+                json.unwrap().is_array(),
+                "--json output should be a JSON array of aggregated rows"
+            );
+        }
     }
+}
+
+#[test]
+fn test_analysis_command_text() {
+    use std::time::Duration;
+
+    let mut cmd = Command::cargo_bin("vibe_coding_tracker").unwrap();
+    cmd.arg("analysis")
+        .arg("--text")
+        .timeout(Duration::from_secs(10));
+
+    let _ = cmd.output();
+}
+
+#[test]
+fn test_analysis_command_table() {
+    use std::time::Duration;
+
+    let mut cmd = Command::cargo_bin("vibe_coding_tracker").unwrap();
+    cmd.arg("analysis")
+        .arg("--table")
+        .timeout(Duration::from_secs(10));
+
+    let _ = cmd.output();
 }
 
 #[test]
@@ -249,20 +263,6 @@ fn test_invalid_command() {
     cmd.assert()
         .failure()
         .stderr(predicate::str::contains("error").or(predicate::str::contains("unrecognized")));
-}
-
-#[test]
-fn test_analysis_conflicting_flags() {
-    // Test that --path and --by-provider are mutually exclusive
-    let mut cmd = Command::cargo_bin("vibe_coding_tracker").unwrap();
-    cmd.arg("analysis")
-        .arg("--path")
-        .arg("test.jsonl")
-        .arg("--by-provider");
-
-    // Should either succeed (if validation is lax) or fail
-    // The behavior depends on CLI implementation
-    let _ = cmd.output();
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -138,19 +138,26 @@ fn test_analysis_command_json() {
         .arg("--json")
         .timeout(Duration::from_secs(10));
 
-    let output = cmd.output().unwrap();
+    let output = cmd.output().expect("failed to spawn vct binary");
 
-    if output.status.success() {
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        if !stdout.trim().is_empty() {
-            let json: Result<serde_json::Value, _> = serde_json::from_str(&stdout);
-            assert!(json.is_ok(), "--json output should be valid JSON");
-            assert!(
-                json.unwrap().is_array(),
-                "--json output should be a JSON array of aggregated rows"
-            );
-        }
+    // Allow timeout (env-dependent on session-directory size) but not other
+    // failures — a non-zero exit means a regression in the --json path.
+    if output.status.code().is_none() {
+        return;
     }
+    assert!(
+        output.status.success(),
+        "vct analysis --json failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("--json output should be valid JSON");
+    assert!(
+        json.is_array(),
+        "--json output should be a JSON array of aggregated rows"
+    );
 }
 
 #[test]
@@ -162,7 +169,12 @@ fn test_analysis_command_text() {
         .arg("--text")
         .timeout(Duration::from_secs(10));
 
-    let _ = cmd.output();
+    let output = cmd.output().expect("failed to spawn vct binary");
+    assert!(
+        output.status.success() || output.status.code().is_none(),
+        "vct analysis --text failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 }
 
 #[test]
@@ -174,7 +186,12 @@ fn test_analysis_command_table() {
         .arg("--table")
         .timeout(Duration::from_secs(10));
 
-    let _ = cmd.output();
+    let output = cmd.output().expect("failed to spawn vct binary");
+    assert!(
+        output.status.success() || output.status.code().is_none(),
+        "vct analysis --table failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 }
 
 #[test]
@@ -182,16 +199,17 @@ fn test_usage_command_json() {
     let mut cmd = Command::cargo_bin("vibe_coding_tracker").unwrap();
     cmd.arg("usage").arg("--json");
 
-    // Should succeed and output valid JSON
-    let output = cmd.output().unwrap();
+    let output = cmd.output().expect("failed to spawn vct binary");
+    assert!(
+        output.status.success(),
+        "vct usage --json failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 
-    if output.status.success() {
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        if !stdout.trim().is_empty() {
-            let json: Result<serde_json::Value, _> = serde_json::from_str(&stdout);
-            assert!(json.is_ok(), "Output should be valid JSON");
-        }
-    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("--json output should be valid JSON");
+    assert!(json.is_array(), "--json output should be a JSON array");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add `--text` and `--json` output modes to `vct analysis`, so it mirrors the TUI / table / text / json structure already used by `vct usage`.
- Drop `--by-provider` (and the corresponding `collect_sessions_grouped_by_provider` / `ProviderGroupedAnalysis` code path). Per-session raw dump is still available via `--path <FILE>`.
- `--text` output uses script-friendly raw integers, one model per line: `model: editLines=N readLines=N writeLines=N bash=N edit=N read=N todoWrite=N write=N`.
- `--json` prints the aggregated rows as a JSON array to stdout. `--output <FILE>` continues to write the same JSON to a file.
- READMEs (en / zh-CN / zh-TW) updated in lock-step.

### Resulting CLI

\`\`\`text
vct analysis                  # interactive TUI (default)
vct analysis --table          # static table
vct analysis --text           # plain text, script-friendly
vct analysis --json           # stdout JSON of aggregated rows
vct analysis --output a.json  # save to file
vct analysis --path FILE      # single-file analysis
\`\`\`

## Test plan

- [x] \`cargo build\` / \`cargo build --tests\` / \`cargo build --release\`
- [x] \`make fmt\` (rustfmt + clippy --fix + clippy -D warnings)
- [x] \`uvx pre-commit run -a\`
- [x] \`cargo test --all\` (380 passed, 0 failed)
- [x] CLI smoke: \`--help\`, \`--text\`, \`--json\`, \`--output\`, \`--path\`, and \`--by-provider\` correctly rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)