### PR TITLE
feat: add OpenCode provider support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Rust CLI (`vibe_coding_tracker`, short alias `vct`) that scans on-disk JSONL session logs written by four AI coding assistants — Claude Code, OpenAI Codex, GitHub Copilot CLI, and Gemini CLI — and aggregates them into two views:
+Rust CLI (`vibe_coding_tracker`, short alias `vct`) that scans on-disk session logs written by five AI coding assistants — Claude Code, OpenAI Codex, GitHub Copilot CLI, and Gemini CLI (JSONL files), plus OpenCode (a SQLite database) — and aggregates them into two views:
 
 - **`usage`** — per-model token counts and LiteLLM-priced cost
 - **`analysis`** — per-model file-operation and tool-call metrics (read/write/edit lines, Bash/Edit/Read/Write/TodoWrite call counts)
@@ -73,6 +73,8 @@ Four parser entry points live in `src/session/parser.rs`:
 
 `classify_records()` is the streaming-friendly variant that returns `None` on indeterminate records and lets callers keep peeking until a marker arrives — there is **no fixed peek window**, which is critical because a Claude metadata preamble (`permission-mode`, `file-history-snapshot`, …) can be arbitrarily long.
 
+OpenCode does **not** flow through the detector or `parse_session_file_*`: it lives in a single SQLite database, so `src/session/opencode.rs` reads it directly (`read_opencode_usage` from the `session` table, `read_opencode_analysis` from `session` + `part`) and produces the same `CodeAnalysis` shape, which the `usage` / `analysis` aggregators fold in alongside the file-based providers. The DB is opened read-only (with a temp-copy fallback) so the user's database is never mutated.
+
 ### `ParseMode`
 
 `src/session/state.rs` defines `ParseMode::Full` vs `ParseMode::UsageOnly`. The usage path uses `UsageOnly` to skip allocating the large `write_file_details` / `edit_file_details` bodies — this is a major part of why the TUI sits at ~30–50 MB RSS even on 200+ session directories. Preserve this distinction when adding new fields to `CodeAnalysisRecord`.
@@ -87,6 +89,7 @@ Resolved by `src/utils/paths.rs` (`resolve_paths`):
 | Codex         | `~/.codex/sessions/**/*.jsonl`                                                                                                                 |
 | Copilot CLI   | `~/.copilot/session-state/<sessionId>/events.jsonl` (depth-bounded walk via `COPILOT_SESSION_MAX_DEPTH` to skip per-session snapshot subtrees) |
 | Gemini CLI    | `~/.gemini/tmp/<project_hash>/chats/*.jsonl`                                                                                                   |
+| OpenCode      | `~/.local/share/opencode/opencode.db` (SQLite database, read via `rusqlite`; honors `$XDG_DATA_HOME`)                                          |
 | Pricing cache | `~/.vibe_coding_tracker/model_pricing_YYYY-MM-DD.json`                                                                                         |
 
 ### Pricing (`src/pricing/`)
@@ -126,4 +129,4 @@ Global singleton `GLOBAL_FILE_CACHE` (capacity = 5 in `constants::capacity::FILE
     - `tests/usage.rs` — `get_usage_from_directories` aggregation
     - `tests/pricing.rs` — `ModelPricingMap` lookup priority + tiered pricing math
     - `tests/cache.rs` — LRU file cache + pricing cache invalidation
-- Sample fixtures and golden outputs for all four providers live in `examples/` (one `test_conversation_<provider>.jsonl` plus one `analysis_result_<provider>.json` per provider).
+- Sample fixtures and golden outputs for the four JSONL providers live in `examples/` (one `test_conversation_<provider>.jsonl` plus one `analysis_result_<provider>.json` per provider). OpenCode has no JSONL fixture; its SQLite reader is covered by inline unit tests in `src/session/opencode.rs` that build a temp database.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,8 @@ Four parser entry points live in `src/session/parser.rs`:
 
 OpenCode does **not** flow through the detector or `parse_session_file_*`: it lives in a single SQLite database, so `src/session/opencode.rs` reads it directly (`read_opencode_usage` from the `session` table, `read_opencode_analysis` from `session` + `part`) and produces the same `CodeAnalysis` shape, which the `usage` / `analysis` aggregators fold in alongside the file-based providers. The DB is opened read-only (with a temp-copy fallback) so the user's database is never mutated.
 
+OpenCode cost is a special case: `usage::resolve_model_cost` prices an OpenCode model from tokens only on an **exact** LiteLLM match (`ModelPricingMap::get_exact`); with no exact match it uses the stored `session.cost` carried in `UsageData::opencode_costs` rather than the normalized/substring/fuzzy fallback the other providers use. This keeps a novel model like `deepseek-v4-pro` from being mis-priced against a loosely-similar name.
+
 ### `ParseMode`
 
 `src/session/state.rs` defines `ParseMode::Full` vs `ParseMode::UsageOnly`. The usage path uses `UsageOnly` to skip allocating the large `write_file_details` / `edit_file_details` bodies — this is a major part of why the TUI sits at ~30–50 MB RSS even on 200+ session directories. Preserve this distinction when adding new fields to `CodeAnalysisRecord`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,9 +73,9 @@ Four parser entry points live in `src/session/parser.rs`:
 
 `classify_records()` is the streaming-friendly variant that returns `None` on indeterminate records and lets callers keep peeking until a marker arrives — there is **no fixed peek window**, which is critical because a Claude metadata preamble (`permission-mode`, `file-history-snapshot`, …) can be arbitrarily long.
 
-OpenCode does **not** flow through the detector or `parse_session_file_*`: it lives in a single SQLite database, so `src/session/opencode.rs` reads it directly (`read_opencode_usage` from the `session` table, `read_opencode_analysis` from `session` + `part`) and produces the same `CodeAnalysis` shape, which the `usage` / `analysis` aggregators fold in alongside the file-based providers. The DB is opened read-only (with a temp-copy fallback) so the user's database is never mutated.
+OpenCode does **not** flow through the detector or `parse_session_file_*`: it lives in a single SQLite database, so `src/session/opencode.rs` reads it directly (`read_opencode_usage` from assistant messages with a legacy `session` fallback, `read_opencode_analysis` from `message` + `part`) and produces the same `CodeAnalysis` shape, which the `usage` / `analysis` aggregators fold in alongside the file-based providers. The DB is opened read-only (with a temp-copy fallback) so the user's database is never mutated.
 
-OpenCode cost is a special case: `usage::resolve_model_cost` prices an OpenCode model from tokens only on an **exact** LiteLLM match (`ModelPricingMap::get_exact`); with no exact match it uses the stored `session.cost` carried in `UsageData::opencode_costs` rather than the normalized/substring/fuzzy fallback the other providers use. This keeps a novel model like `deepseek-v4-pro` from being mis-priced against a loosely-similar name.
+OpenCode cost is a special case: `usage::resolve_model_cost` prices an OpenCode model from tokens only on an **exact** LiteLLM match (`ModelPricingMap::get_exact`); with no exact match it uses the stored assistant-message cost carried in `UsageData::opencode_costs` rather than the normalized/substring/fuzzy fallback the other providers use. This keeps a novel model like `deepseek-v4-pro` from being mis-priced against a loosely-similar name.
 
 ### `ParseMode`
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -761,6 +761,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -973,6 +985,9 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashbrown"
@@ -983,6 +998,15 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5081f264ed7adee96ea4b4778b6bb9da0a7228b084587aa3bd3ff05da7c5a3b"
+dependencies = [
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -1462,6 +1486,17 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.7.3",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.38.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2092,6 +2127,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsqlite-vfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+ "sqlite-wasm-rs",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2441,6 +2501,18 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2837,6 +2909,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2872,6 +2950,7 @@ dependencies = [
  "rayon",
  "regex",
  "reqwest",
+ "rusqlite",
  "semver",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ serde_json = "1.0.149"
 strsim = "0.11.1"
 sysinfo = "0.36.1"
 tar = "0.4.46"
+tempfile = "3.27.0"
 walkdir = "2.5.0"
 zip = "7.2.0"
 
@@ -58,7 +59,6 @@ assert_cmd = "2.2.1"
 criterion = { version = "0.7.0", features = ["html_reports"] }
 predicates = "3.1.4"
 serial_test = "3.4.0"
-tempfile = "3.27.0"
 
 [[bench]]
 name = "benchmarks"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ ratatui = "0.29.0"
 rayon = "1.12.0"
 regex = "1.12.3"
 reqwest = { version = "0.13.2", default-features = false, features = ["blocking", "json", "rustls"] }
+rusqlite = { version = "0.40.1", features = ["bundled"] }
 semver = "1.0.28"
 serde = { version = "1.0.228", features = ["derive", "rc"] }
 serde_json = "1.0.149"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 </div>
 
-**Track your AI coding costs in real-time.** Vibe Coding Tracker is a lightweight, high-performance CLI tool built in Rust that monitors and analyzes your Claude Code, Codex, Copilot, and Gemini usage — with detailed cost breakdowns, token statistics, and code operation insights, all while keeping the memory footprint minimal.
+**Track your AI coding costs in real-time.** Vibe Coding Tracker is a lightweight, high-performance CLI tool built in Rust that monitors and analyzes your Claude Code, Codex, Copilot, Gemini, and OpenCode usage — with detailed cost breakdowns, token statistics, and code operation insights, all while keeping the memory footprint minimal.
 
 [English](README.md) | [繁體中文](README.zh-TW.md) | [简体中文](README.zh-CN.md)
 
@@ -48,7 +48,7 @@ Choose your preferred view:
 
 ### Zero Configuration
 
-Automatically detects and processes logs from Claude Code, Codex, Copilot, and Gemini. No setup required — just run and analyze.
+Automatically detects and processes logs from Claude Code, Codex, Copilot, Gemini, and OpenCode. No setup required — just run and analyze.
 
 ### Rich Insights
 
@@ -232,6 +232,7 @@ The tool automatically scans these directories:
 - `~/.codex/sessions/**/*.jsonl` (Codex — recursive, includes daily subdirectories)
 - `~/.copilot/session-state/<sessionId>/events.jsonl` (Copilot CLI)
 - `~/.gemini/tmp/<project_hash>/chats/*.jsonl` (Gemini CLI)
+- `~/.local/share/opencode/opencode.db` (OpenCode — SQLite database; honors `$XDG_DATA_HOME`)
 
 ---
 
@@ -386,5 +387,6 @@ docker run --rm \
     -v ~/.codex:/root/.codex \
     -v ~/.copilot:/root/.copilot \
     -v ~/.gemini:/root/.gemini \
+    -v ~/.local/share/opencode:/root/.local/share/opencode \
     vibe_coding_tracker:latest usage
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -19,7 +19,7 @@
 
 </div>
 
-**实时追踪你的 AI 编程开销。** Vibe Coding Tracker 是一款基于 Rust 构建的轻量级高性能 CLI 工具，用于监控和分析你在 Claude Code、Codex、Copilot 和 Gemini 上的使用情况——提供详细的费用明细、token 统计和代码操作洞察，同时保持极低的内存占用。
+**实时追踪你的 AI 编程开销。** Vibe Coding Tracker 是一款基于 Rust 构建的轻量级高性能 CLI 工具，用于监控和分析你在 Claude Code、Codex、Copilot、Gemini 和 OpenCode 上的使用情况——提供详细的费用明细、token 统计和代码操作洞察，同时保持极低的内存占用。
 
 [English](README.md) | [繁體中文](README.zh-TW.md) | [简体中文](README.zh-CN.md)
 
@@ -48,7 +48,7 @@
 
 ### 零配置
 
-自动检测并处理来自 Claude Code、Codex、Copilot 和 Gemini 的日志。无需任何设置——直接运行即可分析。
+自动检测并处理来自 Claude Code、Codex、Copilot、Gemini 和 OpenCode 的日志。无需任何设置——直接运行即可分析。
 
 ### 丰富的洞察
 
@@ -62,15 +62,15 @@
 
 ## 核心特性
 
-| 特性             | 说明                                                     |
-| ---------------- | -------------------------------------------------------- |
-| **多供应商支持** | Claude Code、Codex、Copilot 和 Gemini——一站式管理        |
-| **智能定价**     | 模糊模型匹配 + 从 LiteLLM 每日缓存更新                   |
-| **4 种显示模式** | 交互式 TUI、静态表格、纯文本和 JSON                      |
-| **双维度分析**   | token/费用统计（`usage`）+ 代码操作统计（`analysis`）    |
-| **超轻量级**     | TUI 常驻内存 50 MB 以内、流式 JSONL 解析——基于 Rust 构建 |
-| **实时更新**     | 面板每秒自动刷新                                         |
-| **高效缓存**     | 智能每日缓存，减少 API 调用次数                          |
+| 特性             | 说明                                                        |
+| ---------------- | ----------------------------------------------------------- |
+| **多供应商支持** | Claude Code、Codex、Copilot、Gemini 和 OpenCode——一站式管理 |
+| **智能定价**     | 模糊模型匹配 + 从 LiteLLM 每日缓存更新                      |
+| **4 种显示模式** | 交互式 TUI、静态表格、纯文本和 JSON                         |
+| **双维度分析**   | token/费用统计（`usage`）+ 代码操作统计（`analysis`）       |
+| **超轻量级**     | TUI 常驻内存 50 MB 以内、流式 JSONL 解析——基于 Rust 构建    |
+| **实时更新**     | 面板每秒自动刷新                                            |
+| **高效缓存**     | 智能每日缓存，减少 API 调用次数                             |
 
 ---
 
@@ -232,6 +232,7 @@ vct usage --json --daily
 - `~/.codex/sessions/**/*.jsonl`（Codex，递归包含每日子目录）
 - `~/.copilot/session-state/<sessionId>/events.jsonl`（Copilot CLI）
 - `~/.gemini/tmp/<project_hash>/chats/*.jsonl`（Gemini CLI）
+- `~/.local/share/opencode/opencode.db`（OpenCode，SQLite 数据库；遵循 `$XDG_DATA_HOME`）
 
 ---
 
@@ -386,5 +387,6 @@ docker run --rm \
     -v ~/.codex:/root/.codex \
     -v ~/.copilot:/root/.copilot \
     -v ~/.gemini:/root/.gemini \
+    -v ~/.local/share/opencode:/root/.local/share/opencode \
     vibe_coding_tracker:latest usage
 ```

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -19,7 +19,7 @@
 
 </div>
 
-**即時追蹤你的 AI 程式設計花費。** Vibe Coding Tracker 是一款以 Rust 打造的輕量、高效能 CLI 工具，能監控與分析你在 Claude Code、Codex、Copilot 及 Gemini 的使用狀況——提供詳細的費用明細、token 統計資料與程式碼操作分析，同時維持極低的記憶體使用量。
+**即時追蹤你的 AI 程式設計花費。** Vibe Coding Tracker 是一款以 Rust 打造的輕量、高效能 CLI 工具，能監控與分析你在 Claude Code、Codex、Copilot、Gemini 及 OpenCode 的使用狀況——提供詳細的費用明細、token 統計資料與程式碼操作分析，同時維持極低的記憶體使用量。
 
 [English](README.md) | [繁體中文](README.zh-TW.md) | [简体中文](README.zh-CN.md)
 
@@ -48,7 +48,7 @@
 
 ### 零設定
 
-自動偵測並處理 Claude Code、Codex、Copilot 及 Gemini 的日誌檔。不需要任何設定——直接執行就能分析。
+自動偵測並處理 Claude Code、Codex、Copilot、Gemini 及 OpenCode 的日誌檔。不需要任何設定——直接執行就能分析。
 
 ### 豐富洞察
 
@@ -64,7 +64,7 @@
 
 | 功能             | 說明                                                      |
 | ---------------- | --------------------------------------------------------- |
-| **多供應商支援** | Claude Code、Codex、Copilot 及 Gemini——一站整合           |
+| **多供應商支援** | Claude Code、Codex、Copilot、Gemini 及 OpenCode——一站整合 |
 | **智慧定價**     | 模糊模型比對 + 每日從 LiteLLM cache 更新                  |
 | **4 種顯示模式** | 互動式 TUI、靜態表格、純文字及 JSON                       |
 | **雙重分析**     | Token / 費用統計（`usage`）+ 程式碼操作統計（`analysis`） |
@@ -232,6 +232,7 @@ vct usage --json --daily
 - `~/.codex/sessions/**/*.jsonl`（Codex，遞迴包含每日子目錄）
 - `~/.copilot/session-state/<sessionId>/events.jsonl`（Copilot CLI）
 - `~/.gemini/tmp/<project_hash>/chats/*.jsonl`（Gemini CLI）
+- `~/.local/share/opencode/opencode.db`（OpenCode，SQLite 資料庫；遵循 `$XDG_DATA_HOME`）
 
 ---
 
@@ -386,5 +387,6 @@ docker run --rm \
     -v ~/.codex:/root/.codex \
     -v ~/.copilot:/root/.copilot \
     -v ~/.gemini:/root/.gemini \
+    -v ~/.local/share/opencode:/root/.local/share/opencode \
     vibe_coding_tracker:latest usage
 ```

--- a/src/analysis/aggregator.rs
+++ b/src/analysis/aggregator.rs
@@ -319,8 +319,9 @@ where
 ///
 /// Mirrors [`aggregate_sessions_in_directory`] but sources sessions from the
 /// database (via [`read_opencode_analysis`] in [`ParseMode::UsageOnly`]) instead
-/// of a directory walk. Each session's `time_updated` date is recorded in
-/// `unique_dates` for the active-day count.
+/// of a directory walk. Each row's date comes from the assistant message
+/// timestamp (falling back to `session.time_updated` on legacy schemas) and is
+/// recorded in `unique_dates` for the active-day count.
 ///
 /// # Errors
 ///

--- a/src/analysis/aggregator.rs
+++ b/src/analysis/aggregator.rs
@@ -2,6 +2,7 @@ use crate::cli::TimeRange;
 use crate::constants::{FastHashMap, capacity};
 use crate::models::{CodeAnalysis, ExtensionType, ProviderActiveDays};
 use crate::session::parser::parse_session_file_as;
+use crate::session::read_opencode_analysis;
 use crate::session::state::ParseMode;
 use crate::utils::{
     COPILOT_SESSION_MAX_DEPTH, collect_files_with_max_depth, is_claude_session_file,
@@ -75,6 +76,8 @@ pub struct PerProviderAnalysisRows {
     pub copilot: Vec<AggregatedAnalysisRow>,
     /// Rows from the Gemini CLI session directory.
     pub gemini: Vec<AggregatedAnalysisRow>,
+    /// Rows from the OpenCode database.
+    pub opencode: Vec<AggregatedAnalysisRow>,
 }
 
 /// Aggregate file-operation metrics across every provider's session files,
@@ -119,10 +122,14 @@ pub fn aggregate_sessions_by_model(time_range: TimeRange) -> Result<AnalysisData
     let mut gemini_aggregated: FastHashMap<String, AggregatedAnalysisRow> =
         FastHashMap::with_capacity(capacity::MODELS_PER_SESSION);
 
+    let mut opencode_aggregated: FastHashMap<String, AggregatedAnalysisRow> =
+        FastHashMap::with_capacity(capacity::MODELS_PER_SESSION);
+
     let mut claude_dates: HashSet<String> = HashSet::new();
     let mut codex_dates: HashSet<String> = HashSet::new();
     let mut copilot_dates: HashSet<String> = HashSet::new();
     let mut gemini_dates: HashSet<String> = HashSet::new();
+    let mut opencode_dates: HashSet<String> = HashSet::new();
 
     if paths.claude_session_dir.exists() {
         // Walks the projects tree recursively, so top-level `<session>.jsonl` logs
@@ -180,17 +187,31 @@ pub fn aggregate_sessions_by_model(time_range: TimeRange) -> Result<AnalysisData
         )?;
     }
 
+    // OpenCode lives in a single SQLite database rather than a session
+    // directory, so it is read directly instead of walked.
+    if paths.opencode_db.exists() {
+        aggregate_opencode_sessions(
+            &paths.opencode_db,
+            &mut aggregated,
+            &mut opencode_aggregated,
+            &mut opencode_dates,
+            time_range,
+        )?;
+    }
+
     let mut all_dates: HashSet<&String> = HashSet::new();
     all_dates.extend(claude_dates.iter());
     all_dates.extend(codex_dates.iter());
     all_dates.extend(copilot_dates.iter());
     all_dates.extend(gemini_dates.iter());
+    all_dates.extend(opencode_dates.iter());
 
     let provider_days = ProviderActiveDays {
         claude: claude_dates.len(),
         codex: codex_dates.len(),
         copilot: copilot_dates.len(),
         gemini: gemini_dates.len(),
+        opencode: opencode_dates.len(),
         total: all_dates.len(),
     };
 
@@ -202,6 +223,7 @@ pub fn aggregate_sessions_by_model(time_range: TimeRange) -> Result<AnalysisData
         codex: into_sorted_rows(codex_aggregated),
         copilot: into_sorted_rows(copilot_aggregated),
         gemini: into_sorted_rows(gemini_aggregated),
+        opencode: into_sorted_rows(opencode_aggregated),
     };
 
     Ok(AnalysisData {
@@ -278,6 +300,35 @@ where
     // the display layer does not have to infer provenance from the
     // model name.
     for (date, analysis) in file_aggregations {
+        unique_dates.insert(date);
+        aggregate_analysis_result(aggregated, &analysis);
+        aggregate_analysis_result(provider_aggregated, &analysis);
+    }
+
+    Ok(())
+}
+
+/// Reads OpenCode's SQLite database and folds each session's metrics into both
+/// the cross-provider and OpenCode-scoped aggregation maps.
+///
+/// Mirrors [`aggregate_sessions_in_directory`] but sources sessions from the
+/// database (via [`read_opencode_analysis`] in [`ParseMode::UsageOnly`]) instead
+/// of a directory walk. Each session's `time_updated` date is recorded in
+/// `unique_dates` for the active-day count.
+///
+/// # Errors
+///
+/// Returns an error if the database cannot be opened or queried.
+fn aggregate_opencode_sessions(
+    db_path: &Path,
+    aggregated: &mut FastHashMap<String, AggregatedAnalysisRow>,
+    provider_aggregated: &mut FastHashMap<String, AggregatedAnalysisRow>,
+    unique_dates: &mut HashSet<String>,
+    time_range: TimeRange,
+) -> Result<()> {
+    let sessions = read_opencode_analysis(db_path, time_range, ParseMode::UsageOnly)?;
+
+    for (date, analysis) in sessions {
         unique_dates.insert(date);
         aggregate_analysis_result(aggregated, &analysis);
         aggregate_analysis_result(provider_aggregated, &analysis);

--- a/src/analysis/aggregator.rs
+++ b/src/analysis/aggregator.rs
@@ -88,7 +88,8 @@ pub struct PerProviderAnalysisRows {
 /// rows sorted by model name alongside per-provider active-day counts. Each
 /// file is parsed in [`ParseMode::UsageOnly`] and dropped immediately, so the
 /// global file cache is bypassed. Missing provider directories are skipped, and
-/// files that fail to parse are logged to stderr rather than aborting the scan.
+/// files or the OpenCode database that fail to parse are logged to stderr rather
+/// than aborting the scan.
 ///
 /// # Errors
 ///
@@ -190,13 +191,18 @@ pub fn aggregate_sessions_by_model(time_range: TimeRange) -> Result<AnalysisData
     // OpenCode lives in a single SQLite database rather than a session
     // directory, so it is read directly instead of walked.
     if paths.opencode_db.exists() {
-        aggregate_opencode_sessions(
+        if let Err(err) = aggregate_opencode_sessions(
             &paths.opencode_db,
             &mut aggregated,
             &mut opencode_aggregated,
             &mut opencode_dates,
             time_range,
-        )?;
+        ) {
+            eprintln!(
+                "Warning: Failed to read OpenCode DB {}: {err}",
+                paths.opencode_db.display()
+            );
+        }
     }
 
     let mut all_dates: HashSet<&String> = HashSet::new();

--- a/src/analysis/aggregator.rs
+++ b/src/analysis/aggregator.rs
@@ -190,19 +190,19 @@ pub fn aggregate_sessions_by_model(time_range: TimeRange) -> Result<AnalysisData
 
     // OpenCode lives in a single SQLite database rather than a session
     // directory, so it is read directly instead of walked.
-    if paths.opencode_db.exists() {
-        if let Err(err) = aggregate_opencode_sessions(
+    if paths.opencode_db.exists()
+        && let Err(err) = aggregate_opencode_sessions(
             &paths.opencode_db,
             &mut aggregated,
             &mut opencode_aggregated,
             &mut opencode_dates,
             time_range,
-        ) {
-            eprintln!(
-                "Warning: Failed to read OpenCode DB {}: {err}",
-                paths.opencode_db.display()
-            );
-        }
+        )
+    {
+        eprintln!(
+            "Warning: Failed to read OpenCode DB {}: {err}",
+            paths.opencode_db.display()
+        );
     }
 
     let mut all_dates: HashSet<&String> = HashSet::new();

--- a/src/display/analysis/averages.rs
+++ b/src/display/analysis/averages.rs
@@ -89,12 +89,14 @@ pub fn calculate_analysis_provider_totals_from_per_provider(
     totals.codex.days_count = provider_days.codex;
     totals.copilot.days_count = provider_days.copilot;
     totals.gemini.days_count = provider_days.gemini;
+    totals.opencode.days_count = provider_days.opencode;
     totals.overall.days_count = provider_days.total;
 
     accumulate_analysis_provider(&mut totals.claude, &per_provider.claude);
     accumulate_analysis_provider(&mut totals.codex, &per_provider.codex);
     accumulate_analysis_provider(&mut totals.copilot, &per_provider.copilot);
     accumulate_analysis_provider(&mut totals.gemini, &per_provider.gemini);
+    accumulate_analysis_provider(&mut totals.opencode, &per_provider.opencode);
 
     // "All Providers" row is the sum of every provider's totals, matching
     // the usage command. Summing per-provider stats keeps the overall
@@ -103,35 +105,43 @@ pub fn calculate_analysis_provider_totals_from_per_provider(
     totals.overall.total_edit_lines = totals.claude.total_edit_lines
         + totals.codex.total_edit_lines
         + totals.copilot.total_edit_lines
-        + totals.gemini.total_edit_lines;
+        + totals.gemini.total_edit_lines
+        + totals.opencode.total_edit_lines;
     totals.overall.total_read_lines = totals.claude.total_read_lines
         + totals.codex.total_read_lines
         + totals.copilot.total_read_lines
-        + totals.gemini.total_read_lines;
+        + totals.gemini.total_read_lines
+        + totals.opencode.total_read_lines;
     totals.overall.total_write_lines = totals.claude.total_write_lines
         + totals.codex.total_write_lines
         + totals.copilot.total_write_lines
-        + totals.gemini.total_write_lines;
+        + totals.gemini.total_write_lines
+        + totals.opencode.total_write_lines;
     totals.overall.total_bash_count = totals.claude.total_bash_count
         + totals.codex.total_bash_count
         + totals.copilot.total_bash_count
-        + totals.gemini.total_bash_count;
+        + totals.gemini.total_bash_count
+        + totals.opencode.total_bash_count;
     totals.overall.total_edit_count = totals.claude.total_edit_count
         + totals.codex.total_edit_count
         + totals.copilot.total_edit_count
-        + totals.gemini.total_edit_count;
+        + totals.gemini.total_edit_count
+        + totals.opencode.total_edit_count;
     totals.overall.total_read_count = totals.claude.total_read_count
         + totals.codex.total_read_count
         + totals.copilot.total_read_count
-        + totals.gemini.total_read_count;
+        + totals.gemini.total_read_count
+        + totals.opencode.total_read_count;
     totals.overall.total_todo_write_count = totals.claude.total_todo_write_count
         + totals.codex.total_todo_write_count
         + totals.copilot.total_todo_write_count
-        + totals.gemini.total_todo_write_count;
+        + totals.gemini.total_todo_write_count
+        + totals.opencode.total_todo_write_count;
     totals.overall.total_write_count = totals.claude.total_write_count
         + totals.codex.total_write_count
         + totals.copilot.total_write_count
-        + totals.gemini.total_write_count;
+        + totals.gemini.total_write_count
+        + totals.opencode.total_write_count;
 
     totals
 }
@@ -153,7 +163,7 @@ fn accumulate_analysis_provider(stats: &mut AnalysisProviderStats, rows: &[Aggre
 pub fn build_analysis_provider_rows(
     totals: &AnalysisProviderTotals,
 ) -> Vec<ProviderTotal<'_, AnalysisProviderStats>> {
-    let mut rows = Vec::with_capacity(5); // max 4 providers + overall
+    let mut rows = Vec::with_capacity(6); // max 5 providers + overall
 
     if totals.claude.days_count > 0 {
         rows.push(ProviderTotal::new(
@@ -177,6 +187,14 @@ pub fn build_analysis_provider_rows(
 
     if totals.gemini.days_count > 0 {
         rows.push(ProviderTotal::new(Provider::Gemini, &totals.gemini, false));
+    }
+
+    if totals.opencode.days_count > 0 {
+        rows.push(ProviderTotal::new(
+            Provider::OpenCode,
+            &totals.opencode,
+            false,
+        ));
     }
 
     if totals.overall.days_count > 0 || rows.is_empty() {

--- a/src/display/common/averages.rs
+++ b/src/display/common/averages.rs
@@ -18,6 +18,8 @@ pub struct ProviderTotals<S> {
     pub copilot: S,
     /// Totals for Gemini CLI sessions.
     pub gemini: S,
+    /// Totals for OpenCode sessions.
+    pub opencode: S,
     /// Sum across every provider (the "All Providers" bucket).
     pub overall: S,
 }
@@ -29,6 +31,7 @@ impl<S: Default> Default for ProviderTotals<S> {
             codex: S::default(),
             copilot: S::default(),
             gemini: S::default(),
+            opencode: S::default(),
             overall: S::default(),
         }
     }
@@ -45,6 +48,7 @@ impl<S> ProviderTotals<S> {
             Provider::Codex => &self.codex,
             Provider::Copilot => &self.copilot,
             Provider::Gemini => &self.gemini,
+            Provider::OpenCode => &self.opencode,
             Provider::Unknown => &self.overall,
         }
     }
@@ -59,6 +63,7 @@ impl<S> ProviderTotals<S> {
             Provider::Codex => &mut self.codex,
             Provider::Copilot => &mut self.copilot,
             Provider::Gemini => &mut self.gemini,
+            Provider::OpenCode => &mut self.opencode,
             Provider::Unknown => &mut self.overall,
         }
     }

--- a/src/display/common/provider.rs
+++ b/src/display/common/provider.rs
@@ -52,6 +52,11 @@ impl<'a, T> ProviderTotal<'a, T> {
                 RatatuiColor::LightBlue,
                 TableColor::Blue,
             ),
+            Provider::OpenCode => (
+                Provider::OpenCode.display_name(),
+                RatatuiColor::Red,
+                TableColor::Red,
+            ),
             Provider::Unknown => ("Unknown", RatatuiColor::Gray, TableColor::Grey),
         };
 

--- a/src/display/usage/averages.rs
+++ b/src/display/usage/averages.rs
@@ -131,6 +131,7 @@ pub fn calculate_provider_totals_from_per_provider(
     per_provider: &PerProviderUsage,
     provider_days: &ProviderActiveDays,
     pricing_map: &crate::pricing::ModelPricingMap,
+    opencode_costs: &crate::constants::FastHashMap<String, f64>,
 ) -> UsageProviderTotals {
     let mut totals = UsageProviderTotals::default();
 
@@ -141,11 +142,21 @@ pub fn calculate_provider_totals_from_per_provider(
     totals.opencode.days_count = provider_days.opencode;
     totals.overall.days_count = provider_days.total;
 
-    accumulate_provider(&mut totals.claude, &per_provider.claude, pricing_map);
-    accumulate_provider(&mut totals.codex, &per_provider.codex, pricing_map);
-    accumulate_provider(&mut totals.copilot, &per_provider.copilot, pricing_map);
-    accumulate_provider(&mut totals.gemini, &per_provider.gemini, pricing_map);
-    accumulate_provider(&mut totals.opencode, &per_provider.opencode, pricing_map);
+    accumulate_provider(&mut totals.claude, &per_provider.claude, pricing_map, None);
+    accumulate_provider(&mut totals.codex, &per_provider.codex, pricing_map, None);
+    accumulate_provider(
+        &mut totals.copilot,
+        &per_provider.copilot,
+        pricing_map,
+        None,
+    );
+    accumulate_provider(&mut totals.gemini, &per_provider.gemini, pricing_map, None);
+    accumulate_provider(
+        &mut totals.opencode,
+        &per_provider.opencode,
+        pricing_map,
+        Some(opencode_costs),
+    );
 
     // "All Providers" row sums every provider's totals directly rather
     // than reusing the cross-provider merged `UsageData.models` map.
@@ -171,13 +182,18 @@ pub fn calculate_provider_totals_from_per_provider(
 }
 
 /// Prices every model in `usage` and folds the results into `stats`.
+///
+/// `opencode_costs` is `Some` only when accumulating the OpenCode provider, so
+/// that its models price by exact match or fall back to OpenCode's stored cost.
 fn accumulate_provider(
     stats: &mut ProviderStats,
     usage: &UsageResult,
     pricing_map: &crate::pricing::ModelPricingMap,
+    opencode_costs: Option<&crate::constants::FastHashMap<String, f64>>,
 ) {
     for (model, raw_usage) in usage {
-        let row = extract_usage_row(model, raw_usage, pricing_map);
+        let opencode_cost = opencode_costs.map(|m| m.get(model).copied().unwrap_or(0.0));
+        let row = extract_usage_row(model, raw_usage, pricing_map, opencode_cost);
         stats.accumulate_row(&row);
     }
 }
@@ -239,6 +255,7 @@ pub fn build_usage_summary(
     per_provider: &PerProviderUsage,
     provider_days: &ProviderActiveDays,
     pricing_map: &crate::pricing::ModelPricingMap,
+    opencode_costs: &crate::constants::FastHashMap<String, f64>,
 ) -> UsageSummary {
     if usage_data.is_empty() {
         return UsageSummary::default();
@@ -251,7 +268,12 @@ pub fn build_usage_summary(
 
     // Extract rows first so we can sort by cost
     for (model, usage) in usage_data.iter() {
-        let row = extract_usage_row(model, usage, pricing_map);
+        let row = extract_usage_row(
+            model,
+            usage,
+            pricing_map,
+            opencode_costs.get(model).copied(),
+        );
         summary.rows.push(row);
     }
 
@@ -267,43 +289,39 @@ pub fn build_usage_summary(
         summary.totals.accumulate(row);
     }
 
-    summary.provider_totals =
-        calculate_provider_totals_from_per_provider(per_provider, provider_days, pricing_map);
+    summary.provider_totals = calculate_provider_totals_from_per_provider(
+        per_provider,
+        provider_days,
+        pricing_map,
+        opencode_costs,
+    );
     summary
 }
 
 /// Builds one priced [`UsageRow`] from a model's raw usage `Value`.
 ///
 /// Token counts come from [`extract_token_counts`](crate::utils::extract_token_counts);
-/// cost is computed against the pricing entry `pricing_map` resolves for
-/// `model`. When that lookup was a fuzzy match, the matched model name is
-/// appended to `display_model` in parentheses.
+/// cost is resolved by [`resolve_model_cost`](crate::usage::resolve_model_cost).
+/// `opencode_cost` is `Some` only for OpenCode-sourced usage, in which case a
+/// model with no exact LiteLLM price falls back to OpenCode's stored cost
+/// instead of a fuzzy match. When a non-exact LiteLLM key was used, the matched
+/// model name is appended to `display_model` in parentheses.
 fn extract_usage_row(
     model: &str,
     usage: &Value,
     pricing_map: &crate::pricing::ModelPricingMap,
+    opencode_cost: Option<f64>,
 ) -> UsageRow {
-    use crate::pricing::calculate_cost;
+    use crate::usage::resolve_model_cost;
     use crate::utils::extract_token_counts;
 
     // Extract token counts using utility function
     let counts = extract_token_counts(usage);
 
-    // Direct call - no local cache needed (uses global MATCH_CACHE)
-    let pricing_result = pricing_map.get(model);
+    let (cost, matched_model) = resolve_model_cost(model, &counts, pricing_map, opencode_cost);
 
-    let cost = calculate_cost(
-        counts.input_tokens,
-        counts.output_tokens,
-        counts.reasoning_tokens,
-        counts.cache_read,
-        counts.cache_creation_5m,
-        counts.cache_creation_1h,
-        &pricing_result.pricing,
-    );
-
-    // Use Cow<str> for display_model to avoid allocation when no fuzzy match
-    let display_model = if let Some(matched) = &pricing_result.matched_model {
+    // Use Cow<str> for display_model to avoid allocation when no annotation
+    let display_model = if let Some(matched) = &matched_model {
         Cow::Owned(format!("{} ({})", model, matched))
     } else {
         Cow::Borrowed(model)

--- a/src/display/usage/averages.rs
+++ b/src/display/usage/averages.rs
@@ -138,12 +138,14 @@ pub fn calculate_provider_totals_from_per_provider(
     totals.codex.days_count = provider_days.codex;
     totals.copilot.days_count = provider_days.copilot;
     totals.gemini.days_count = provider_days.gemini;
+    totals.opencode.days_count = provider_days.opencode;
     totals.overall.days_count = provider_days.total;
 
     accumulate_provider(&mut totals.claude, &per_provider.claude, pricing_map);
     accumulate_provider(&mut totals.codex, &per_provider.codex, pricing_map);
     accumulate_provider(&mut totals.copilot, &per_provider.copilot, pricing_map);
     accumulate_provider(&mut totals.gemini, &per_provider.gemini, pricing_map);
+    accumulate_provider(&mut totals.opencode, &per_provider.opencode, pricing_map);
 
     // "All Providers" row sums every provider's totals directly rather
     // than reusing the cross-provider merged `UsageData.models` map.
@@ -157,11 +159,13 @@ pub fn calculate_provider_totals_from_per_provider(
     totals.overall.total_tokens = totals.claude.total_tokens
         + totals.codex.total_tokens
         + totals.copilot.total_tokens
-        + totals.gemini.total_tokens;
+        + totals.gemini.total_tokens
+        + totals.opencode.total_tokens;
     totals.overall.total_cost = totals.claude.total_cost
         + totals.codex.total_cost
         + totals.copilot.total_cost
-        + totals.gemini.total_cost;
+        + totals.gemini.total_cost
+        + totals.opencode.total_cost;
 
     totals
 }
@@ -182,7 +186,7 @@ fn accumulate_provider(
 pub fn build_provider_total_rows(
     totals: &UsageProviderTotals,
 ) -> Vec<ProviderTotal<'_, ProviderStats>> {
-    let mut rows = Vec::with_capacity(5); // max 4 providers + overall
+    let mut rows = Vec::with_capacity(6); // max 5 providers + overall
 
     if totals.claude.days_count > 0 {
         rows.push(ProviderTotal::new(
@@ -206,6 +210,14 @@ pub fn build_provider_total_rows(
 
     if totals.gemini.days_count > 0 {
         rows.push(ProviderTotal::new(Provider::Gemini, &totals.gemini, false));
+    }
+
+    if totals.opencode.days_count > 0 {
+        rows.push(ProviderTotal::new(
+            Provider::OpenCode,
+            &totals.opencode,
+            false,
+        ));
     }
 
     if totals.overall.days_count > 0 || rows.is_empty() {

--- a/src/display/usage/averages.rs
+++ b/src/display/usage/averages.rs
@@ -268,12 +268,10 @@ pub fn build_usage_summary(
 
     // Extract rows first so we can sort by cost
     for (model, usage) in usage_data.iter() {
-        let row = extract_usage_row(
-            model,
-            usage,
-            pricing_map,
-            opencode_costs.get(model).copied(),
-        );
+        let (cost, matched_model) =
+            resolve_merged_row_cost(model, per_provider, pricing_map, opencode_costs)
+                .unwrap_or_else(|| price_usage(model, usage, pricing_map, None));
+        let row = build_usage_row(model, usage, cost, matched_model);
         summary.rows.push(row);
     }
 
@@ -312,13 +310,74 @@ fn extract_usage_row(
     pricing_map: &crate::pricing::ModelPricingMap,
     opencode_cost: Option<f64>,
 ) -> UsageRow {
+    let (cost, matched_model) = price_usage(model, usage, pricing_map, opencode_cost);
+    build_usage_row(model, usage, cost, matched_model)
+}
+
+/// Prices one raw usage value.
+fn price_usage(
+    model: &str,
+    usage: &Value,
+    pricing_map: &crate::pricing::ModelPricingMap,
+    opencode_cost: Option<f64>,
+) -> (f64, Option<String>) {
     use crate::usage::resolve_model_cost;
     use crate::utils::extract_token_counts;
 
-    // Extract token counts using utility function
     let counts = extract_token_counts(usage);
+    resolve_model_cost(model, &counts, pricing_map, opencode_cost)
+}
 
-    let (cost, matched_model) = resolve_model_cost(model, &counts, pricing_map, opencode_cost);
+/// Prices a merged per-model row from provider-scoped usage pieces.
+fn resolve_merged_row_cost(
+    model: &str,
+    per_provider: &PerProviderUsage,
+    pricing_map: &crate::pricing::ModelPricingMap,
+    opencode_costs: &crate::constants::FastHashMap<String, f64>,
+) -> Option<(f64, Option<String>)> {
+    let mut total_cost = 0.0;
+    let mut matched_model = None;
+    let mut found = false;
+
+    for usage in [
+        &per_provider.claude,
+        &per_provider.codex,
+        &per_provider.copilot,
+        &per_provider.gemini,
+    ] {
+        if let Some(raw_usage) = usage.get(model) {
+            found = true;
+            let (cost, matched) = price_usage(model, raw_usage, pricing_map, None);
+            total_cost += cost;
+            if matched_model.is_none() {
+                matched_model = matched;
+            }
+        }
+    }
+
+    if let Some(raw_usage) = per_provider.opencode.get(model) {
+        found = true;
+        let opencode_cost = opencode_costs.get(model).copied().unwrap_or(0.0);
+        let (cost, matched) = price_usage(model, raw_usage, pricing_map, Some(opencode_cost));
+        total_cost += cost;
+        if matched_model.is_none() {
+            matched_model = matched;
+        }
+    }
+
+    found.then_some((total_cost, matched_model))
+}
+
+/// Builds one display row using an already-resolved cost.
+fn build_usage_row(
+    model: &str,
+    usage: &Value,
+    cost: f64,
+    matched_model: Option<String>,
+) -> UsageRow {
+    use crate::utils::extract_token_counts;
+
+    let counts = extract_token_counts(usage);
 
     // Use Cow<str> for display_model to avoid allocation when no annotation
     let display_model = if let Some(matched) = &matched_model {
@@ -337,5 +396,53 @@ fn extract_usage_row(
         cache_creation: counts.cache_creation,
         total: counts.total,
         cost,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pricing::{ModelPricing, ModelPricingMap, clear_pricing_cache};
+    use serde_json::json;
+
+    #[test]
+    fn merged_rows_price_opencode_fallback_only_for_opencode_tokens() {
+        clear_pricing_cache();
+
+        let mut raw_pricing = std::collections::HashMap::new();
+        raw_pricing.insert(
+            "shared".to_string(),
+            ModelPricing {
+                input_cost_per_token: 0.01,
+                ..Default::default()
+            },
+        );
+        let pricing_map = ModelPricingMap::new(raw_pricing);
+
+        let mut usage_data = UsageResult::default();
+        usage_data.insert("shared-pro".to_string(), json!({"input_tokens": 200}));
+
+        let mut per_provider = PerProviderUsage::default();
+        per_provider
+            .claude
+            .insert("shared-pro".to_string(), json!({"input_tokens": 100}));
+        per_provider
+            .opencode
+            .insert("shared-pro".to_string(), json!({"input_tokens": 100}));
+
+        let mut opencode_costs = crate::constants::FastHashMap::default();
+        opencode_costs.insert("shared-pro".to_string(), 7.0);
+
+        let summary = build_usage_summary(
+            &usage_data,
+            &per_provider,
+            &ProviderActiveDays::default(),
+            &pricing_map,
+            &opencode_costs,
+        );
+
+        assert_eq!(summary.rows.len(), 1);
+        assert!((summary.rows[0].cost - 8.0).abs() < 1e-9);
+        assert_eq!(summary.rows[0].display_model, "shared-pro (shared)");
     }
 }

--- a/src/display/usage/interactive.rs
+++ b/src/display/usage/interactive.rs
@@ -79,6 +79,7 @@ pub fn display_usage_interactive(time_range: crate::cli::TimeRange) -> anyhow::R
     let mut usage_data = UsageResult::default();
     let mut per_provider_usage = PerProviderUsage::default();
     let mut provider_days = ProviderActiveDays::default();
+    let mut opencode_costs: crate::constants::FastHashMap<String, f64> = Default::default();
     let mut has_usage_data = false;
 
     // Pricing map is large (~500 KB / ~400 models) but changes at most once
@@ -120,6 +121,7 @@ pub fn display_usage_interactive(time_range: crate::cli::TimeRange) -> anyhow::R
                     usage_data = data.models;
                     per_provider_usage = data.per_provider;
                     provider_days = data.provider_days;
+                    opencode_costs = data.opencode_costs;
                     has_usage_data = true;
                 }
                 Err(e) => {
@@ -127,6 +129,7 @@ pub fn display_usage_interactive(time_range: crate::cli::TimeRange) -> anyhow::R
                     if !has_usage_data {
                         usage_data.clear();
                         per_provider_usage = PerProviderUsage::default();
+                        opencode_costs = Default::default();
                     }
                 }
             }
@@ -149,6 +152,7 @@ pub fn display_usage_interactive(time_range: crate::cli::TimeRange) -> anyhow::R
                 &per_provider_usage,
                 &provider_days,
                 &pricing_map,
+                &opencode_costs,
             );
 
             // Cache the rendered display state so a resize can redraw without

--- a/src/display/usage/table.rs
+++ b/src/display/usage/table.rs
@@ -43,6 +43,7 @@ pub fn display_usage_table(usage_data: &UsageData) {
         &usage_data.per_provider,
         &usage_data.provider_days,
         &pricing_map,
+        &usage_data.opencode_costs,
     );
 
     if summary.rows.is_empty() {

--- a/src/display/usage/text.rs
+++ b/src/display/usage/text.rs
@@ -25,6 +25,7 @@ pub fn display_usage_text(usage_data: &UsageData) {
         &usage_data.per_provider,
         &usage_data.provider_days,
         &pricing_map,
+        &usage_data.opencode_costs,
     );
 
     if summary.rows.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,12 +25,13 @@ use vibe_coding_tracker::cli::{Cli, Commands, resolve_time_range};
 #[cfg(feature = "mimalloc")]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+use vibe_coding_tracker::constants::FastHashMap;
 use vibe_coding_tracker::display::usage::{
     display_usage_interactive, display_usage_table, display_usage_text,
 };
 use vibe_coding_tracker::models::UsageResult;
-use vibe_coding_tracker::pricing::{ModelPricingMap, calculate_cost, fetch_model_pricing};
-use vibe_coding_tracker::usage::get_usage_from_directories;
+use vibe_coding_tracker::pricing::{ModelPricingMap, fetch_model_pricing};
+use vibe_coding_tracker::usage::{get_usage_from_directories, resolve_model_cost};
 use vibe_coding_tracker::utils::extract_token_counts;
 use vibe_coding_tracker::{get_version_info, parse_session_file};
 
@@ -147,7 +148,11 @@ fn main() -> Result<()> {
                             ModelPricingMap::new(HashMap::new())
                         }
                     };
-                    let enriched_data = build_enriched_json(&usage_data.models, &pricing_map)?;
+                    let enriched_data = build_enriched_json(
+                        &usage_data.models,
+                        &usage_data.opencode_costs,
+                        &pricing_map,
+                    )?;
                     let json_str = serde_json::to_string_pretty(&enriched_data)?;
                     println!("{}", json_str);
                 } else if text {
@@ -226,10 +231,12 @@ fn main() -> Result<()> {
 /// Builds the `usage --json` payload, joining each model's token counts with
 /// its priced cost.
 ///
-/// For every model in `usage_data` it looks the model up in `pricing_map`,
-/// computes the USD cost from the extracted token counts, and emits a JSON
-/// object with `model`, `usage`, `cost_usd`, and (when the price came from a
-/// fuzzy match rather than an exact key) `matched_model`.
+/// For every model it resolves the USD cost via
+/// [`resolve_model_cost`](vibe_coding_tracker::usage::resolve_model_cost) and
+/// emits a JSON object with `model`, `usage`, `cost_usd`, and (when a non-exact
+/// LiteLLM key was used) `matched_model`. OpenCode models without an exact
+/// price report OpenCode's own stored cost from `opencode_costs` rather than a
+/// fuzzy match.
 ///
 /// # Errors
 ///
@@ -237,6 +244,7 @@ fn main() -> Result<()> {
 /// resulting JSON object.
 fn build_enriched_json(
     usage_data: &UsageResult,
+    opencode_costs: &FastHashMap<String, f64>,
     pricing_map: &ModelPricingMap,
 ) -> Result<Vec<Value>> {
     let mut enriched_data = Vec::with_capacity(usage_data.len());
@@ -244,16 +252,11 @@ fn build_enriched_json(
     for (model, usage) in usage_data.iter() {
         let counts = extract_token_counts(usage);
 
-        let pricing_result = pricing_map.get(model);
-
-        let cost = calculate_cost(
-            counts.input_tokens,
-            counts.output_tokens,
-            counts.reasoning_tokens,
-            counts.cache_read,
-            counts.cache_creation_5m,
-            counts.cache_creation_1h,
-            &pricing_result.pricing,
+        let (cost, matched_model) = resolve_model_cost(
+            model,
+            &counts,
+            pricing_map,
+            opencode_costs.get(model).copied(),
         );
 
         let mut entry = json!({
@@ -262,7 +265,7 @@ fn build_enriched_json(
             "cost_usd": cost
         });
 
-        if let Some(matched) = &pricing_result.matched_model {
+        if let Some(matched) = &matched_model {
             entry["matched_model"] = json!(matched);
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,11 +25,9 @@ use vibe_coding_tracker::cli::{Cli, Commands, resolve_time_range};
 #[cfg(feature = "mimalloc")]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-use vibe_coding_tracker::constants::FastHashMap;
 use vibe_coding_tracker::display::usage::{
     display_usage_interactive, display_usage_table, display_usage_text,
 };
-use vibe_coding_tracker::models::UsageResult;
 use vibe_coding_tracker::pricing::{ModelPricingMap, fetch_model_pricing};
 use vibe_coding_tracker::usage::{get_usage_from_directories, resolve_model_cost};
 use vibe_coding_tracker::utils::extract_token_counts;
@@ -148,11 +146,7 @@ fn main() -> Result<()> {
                             ModelPricingMap::new(HashMap::new())
                         }
                     };
-                    let enriched_data = build_enriched_json(
-                        &usage_data.models,
-                        &usage_data.opencode_costs,
-                        &pricing_map,
-                    )?;
+                    let enriched_data = build_enriched_json(&usage_data, &pricing_map)?;
                     let json_str = serde_json::to_string_pretty(&enriched_data)?;
                     println!("{}", json_str);
                 } else if text {
@@ -235,29 +229,22 @@ fn main() -> Result<()> {
 /// [`resolve_model_cost`](vibe_coding_tracker::usage::resolve_model_cost) and
 /// emits a JSON object with `model`, `usage`, `cost_usd`, and (when a non-exact
 /// LiteLLM key was used) `matched_model`. OpenCode models without an exact
-/// price report OpenCode's own stored cost from `opencode_costs` rather than a
-/// fuzzy match.
+/// price report OpenCode's own stored cost only for the OpenCode portion of a
+/// merged row rather than applying it to other providers with the same model.
 ///
 /// # Errors
 ///
 /// Returns an error only if a usage value cannot be serialized into the
 /// resulting JSON object.
 fn build_enriched_json(
-    usage_data: &UsageResult,
-    opencode_costs: &FastHashMap<String, f64>,
+    usage_data: &vibe_coding_tracker::UsageData,
     pricing_map: &ModelPricingMap,
 ) -> Result<Vec<Value>> {
-    let mut enriched_data = Vec::with_capacity(usage_data.len());
+    let mut enriched_data = Vec::with_capacity(usage_data.models.len());
 
-    for (model, usage) in usage_data.iter() {
-        let counts = extract_token_counts(usage);
-
-        let (cost, matched_model) = resolve_model_cost(
-            model,
-            &counts,
-            pricing_map,
-            opencode_costs.get(model).copied(),
-        );
+    for (model, usage) in usage_data.models.iter() {
+        let (cost, matched_model) = resolve_enriched_model_cost(model, usage_data, pricing_map)
+            .unwrap_or_else(|| price_usage_value(model, usage, pricing_map, None));
 
         let mut entry = json!({
             "model": model,
@@ -273,4 +260,102 @@ fn build_enriched_json(
     }
 
     Ok(enriched_data)
+}
+
+/// Resolves cost for one merged JSON row from provider-scoped usage pieces.
+fn resolve_enriched_model_cost(
+    model: &str,
+    usage_data: &vibe_coding_tracker::UsageData,
+    pricing_map: &ModelPricingMap,
+) -> Option<(f64, Option<String>)> {
+    let mut total_cost = 0.0;
+    let mut matched_model = None;
+    let mut found = false;
+
+    for usage in [
+        &usage_data.per_provider.claude,
+        &usage_data.per_provider.codex,
+        &usage_data.per_provider.copilot,
+        &usage_data.per_provider.gemini,
+    ] {
+        if let Some(raw_usage) = usage.get(model) {
+            found = true;
+            let (cost, matched) = price_usage_value(model, raw_usage, pricing_map, None);
+            total_cost += cost;
+            if matched_model.is_none() {
+                matched_model = matched;
+            }
+        }
+    }
+
+    if let Some(raw_usage) = usage_data.per_provider.opencode.get(model) {
+        found = true;
+        let opencode_cost = usage_data.opencode_costs.get(model).copied().unwrap_or(0.0);
+        let (cost, matched) = price_usage_value(model, raw_usage, pricing_map, Some(opencode_cost));
+        total_cost += cost;
+        if matched_model.is_none() {
+            matched_model = matched;
+        }
+    }
+
+    found.then_some((total_cost, matched_model))
+}
+
+/// Prices one raw usage value.
+fn price_usage_value(
+    model: &str,
+    usage: &Value,
+    pricing_map: &ModelPricingMap,
+    opencode_cost: Option<f64>,
+) -> (f64, Option<String>) {
+    let counts = extract_token_counts(usage);
+    resolve_model_cost(model, &counts, pricing_map, opencode_cost)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vibe_coding_tracker::models::{PerProviderUsage, ProviderActiveDays, UsageResult};
+    use vibe_coding_tracker::pricing::{ModelPricing, clear_pricing_cache};
+
+    #[test]
+    fn json_rows_price_opencode_fallback_only_for_opencode_tokens() {
+        clear_pricing_cache();
+
+        let mut raw_pricing = HashMap::new();
+        raw_pricing.insert(
+            "shared".to_string(),
+            ModelPricing {
+                input_cost_per_token: 0.01,
+                ..Default::default()
+            },
+        );
+        let pricing_map = ModelPricingMap::new(raw_pricing);
+
+        let mut models = UsageResult::default();
+        models.insert("shared-pro".to_string(), json!({"input_tokens": 200}));
+
+        let mut per_provider = PerProviderUsage::default();
+        per_provider
+            .claude
+            .insert("shared-pro".to_string(), json!({"input_tokens": 100}));
+        per_provider
+            .opencode
+            .insert("shared-pro".to_string(), json!({"input_tokens": 100}));
+
+        let mut opencode_costs = vibe_coding_tracker::constants::FastHashMap::default();
+        opencode_costs.insert("shared-pro".to_string(), 7.0);
+
+        let usage_data = vibe_coding_tracker::UsageData {
+            models,
+            per_provider,
+            provider_days: ProviderActiveDays::default(),
+            opencode_costs,
+        };
+
+        let rows = build_enriched_json(&usage_data, &pricing_map).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["cost_usd"].as_f64().unwrap(), 8.0);
+        assert_eq!(rows[0]["matched_model"].as_str().unwrap(), "shared");
+    }
 }

--- a/src/models/analysis.rs
+++ b/src/models/analysis.rs
@@ -196,6 +196,8 @@ pub enum ExtensionType {
     Copilot,
     /// Google Gemini CLI.
     Gemini,
+    /// OpenCode.
+    OpenCode,
 }
 
 impl std::fmt::Display for ExtensionType {
@@ -205,6 +207,7 @@ impl std::fmt::Display for ExtensionType {
             ExtensionType::Codex => write!(f, "Codex"),
             ExtensionType::Copilot => write!(f, "Copilot-CLI"),
             ExtensionType::Gemini => write!(f, "Gemini"),
+            ExtensionType::OpenCode => write!(f, "OpenCode"),
         }
     }
 }

--- a/src/models/provider.rs
+++ b/src/models/provider.rs
@@ -24,6 +24,8 @@ pub enum Provider {
     Copilot,
     /// Google Gemini CLI.
     Gemini,
+    /// OpenCode.
+    OpenCode,
     /// Model name matched no known provider prefix.
     Unknown,
 }
@@ -109,6 +111,7 @@ impl Provider {
             Self::Codex => "OpenAI Codex",
             Self::Copilot => "GitHub Copilot",
             Self::Gemini => "Gemini",
+            Self::OpenCode => "OpenCode",
             Self::Unknown => "Unknown",
         }
     }
@@ -160,6 +163,7 @@ mod tests {
         assert_eq!(Provider::Codex.display_name(), "OpenAI Codex");
         assert_eq!(Provider::Copilot.display_name(), "GitHub Copilot");
         assert_eq!(Provider::Gemini.display_name(), "Gemini");
+        assert_eq!(Provider::OpenCode.display_name(), "OpenCode");
         assert_eq!(Provider::Unknown.display_name(), "Unknown");
     }
 }

--- a/src/models/usage.rs
+++ b/src/models/usage.rs
@@ -27,6 +27,8 @@ pub struct ProviderActiveDays {
     pub copilot: usize,
     /// Distinct active days observed for Gemini CLI.
     pub gemini: usize,
+    /// Distinct active days observed for OpenCode.
+    pub opencode: usize,
     /// Distinct active days across all providers combined.
     pub total: usize,
 }
@@ -56,6 +58,8 @@ pub struct PerProviderUsage {
     pub copilot: UsageResult,
     /// Per-model usage attributed to Gemini CLI.
     pub gemini: UsageResult,
+    /// Per-model usage attributed to OpenCode.
+    pub opencode: UsageResult,
 }
 
 impl PerProviderUsage {
@@ -66,6 +70,7 @@ impl PerProviderUsage {
             Provider::Codex => Some(&self.codex),
             Provider::Copilot => Some(&self.copilot),
             Provider::Gemini => Some(&self.gemini),
+            Provider::OpenCode => Some(&self.opencode),
             Provider::Unknown => None,
         }
     }
@@ -78,6 +83,7 @@ impl PerProviderUsage {
             Provider::Codex => Some(&mut self.codex),
             Provider::Copilot => Some(&mut self.copilot),
             Provider::Gemini => Some(&mut self.gemini),
+            Provider::OpenCode => Some(&mut self.opencode),
             Provider::Unknown => None,
         }
     }

--- a/src/pricing/matching.rs
+++ b/src/pricing/matching.rs
@@ -223,6 +223,18 @@ impl ModelPricingMap {
         result
     }
 
+    /// Returns the pricing for an **exact** model-name match only.
+    ///
+    /// Unlike [`get`](Self::get), this performs no normalization, substring, or
+    /// fuzzy matching: it returns `Some` only when `model_name` is a verbatim
+    /// key in the pricing table, and `None` otherwise. This is the lookup used
+    /// for providers (OpenCode) that carry their own authoritative cost and
+    /// should fall back to that stored cost rather than guess a price from a
+    /// loosely-similar model name.
+    pub fn get_exact(&self, model_name: &str) -> Option<ModelPricing> {
+        self.raw.get(model_name).cloned()
+    }
+
     /// Returns whether the pricing map contains no models.
     pub fn is_empty(&self) -> bool {
         self.raw.is_empty()
@@ -406,6 +418,20 @@ mod tests {
         // This might or might not match depending on Jaro-Winkler score
         // Just verify it returns a result
         assert!(result.pricing.input_cost_per_token >= 0.0);
+    }
+
+    #[test]
+    fn test_get_exact_only_matches_verbatim() {
+        // get_exact must NOT normalize, substring, or fuzzy match.
+        let mut raw = HashMap::new();
+        raw.insert("gpt-4".to_string(), create_test_pricing());
+        let map = ModelPricingMap::new(raw);
+
+        assert!(map.get_exact("gpt-4").is_some());
+        // These all resolve via get() (substring/fuzzy) but must miss get_exact.
+        assert!(map.get_exact("gpt-4-turbo").is_none());
+        assert!(map.get_exact("deepseek-v4-pro").is_none());
+        assert!(map.get_exact("GPT-4").is_none());
     }
 
     #[test]

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -12,10 +12,12 @@ pub mod codex;
 pub mod copilot;
 pub mod detector;
 pub mod gemini;
+pub mod opencode;
 pub mod parser;
 pub mod state;
 
 pub use detector::{classify_records, detect_extension_type};
+pub use opencode::{read_opencode_analysis, read_opencode_usage};
 pub use parser::{
     parse_session_file, parse_session_file_as, parse_session_file_typed,
     parse_session_file_typed_with_mode,

--- a/src/session/opencode.rs
+++ b/src/session/opencode.rs
@@ -37,9 +37,9 @@ use std::path::{Path, PathBuf};
 /// Each returned tuple is `(local YYYY-MM-DD date, CodeAnalysis, stored_cost)`
 /// where the `CodeAnalysis` holds one assistant message's
 /// `conversation_usage`, keyed by that message's provider-qualified model id,
-/// and `stored_cost` is OpenCode's own cost for that message. The date comes from
-/// `session.time_updated` and is filtered by `time_range`, matching the
-/// file-walker semantics.
+/// and `stored_cost` is OpenCode's own cost for that message. The date comes
+/// from the assistant message timestamp and is filtered by `time_range`,
+/// matching the file-walker semantics.
 ///
 /// # Errors
 ///
@@ -178,7 +178,11 @@ fn collect_message_usage(
              FROM message \
              JOIN session ON session.id = message.session_id \
              WHERE json_extract(message.data, '$.role') = 'assistant' \
-               AND session.time_updated >= ?1"
+               AND COALESCE( \
+                   json_extract(message.data, '$.time.completed'), \
+                   json_extract(message.data, '$.time.created'), \
+                   session.time_updated \
+               ) >= ?1"
         }
         None => {
             "SELECT session.time_updated, message.data \
@@ -197,21 +201,22 @@ fn collect_message_usage(
     while let Some(row) = rows.next()? {
         let session_ts = row.get::<_, i64>(0)?;
         let data_text = row.get::<_, String>(1)?;
-        let Some(date) = ms_to_local_date(session_ts) else {
+        let Some(message) = parse_message_usage(&data_text) else {
+            continue;
+        };
+        let message_ts = message.timestamp.unwrap_or(session_ts);
+        let Some(date) = ms_to_local_date(message_ts) else {
             continue;
         };
         if is_before_cutoff(&date, &cutoff) {
             continue;
         }
-        let Some(message) = parse_message_usage(&data_text) else {
-            continue;
-        };
 
         let mut map = FastHashMap::default();
         map.insert(message.model_id, message.usage);
 
         let mut state = SessionParseState::with_mode(ParseMode::UsageOnly);
-        state.last_ts = message.timestamp.unwrap_or(session_ts);
+        state.last_ts = message_ts;
         out.push((
             date,
             wrap_record(state.into_record(map), &user, &machine),
@@ -376,7 +381,11 @@ fn collect_message_analysis(
                  FROM message \
                  JOIN session ON session.id = message.session_id \
                  WHERE json_extract(message.data, '$.role') = 'assistant' \
-                   AND session.time_updated >= ?1"
+                   AND COALESCE( \
+                       json_extract(message.data, '$.time.completed'), \
+                       json_extract(message.data, '$.time.created'), \
+                       session.time_updated \
+                   ) >= ?1"
             }
             None => {
                 "SELECT message.id, message.session_id, message.data, session.directory, session.time_updated \
@@ -397,20 +406,21 @@ fn collect_message_analysis(
             let data_text = row.get::<_, String>(2)?;
             let directory = row.get::<_, String>(3)?;
             let session_ts = row.get::<_, i64>(4)?;
-            let Some(date) = ms_to_local_date(session_ts) else {
+            let Some(message) = parse_message_usage(&data_text) else {
+                continue;
+            };
+            let message_ts = message.timestamp.unwrap_or(session_ts);
+            let Some(date) = ms_to_local_date(message_ts) else {
                 continue;
             };
             if is_before_cutoff(&date, &cutoff) {
                 continue;
             }
-            let Some(message) = parse_message_usage(&data_text) else {
-                continue;
-            };
 
             let mut state = SessionParseState::with_mode(mode);
             state.folder_path = directory;
             state.task_id = session_id;
-            state.last_ts = message.timestamp.unwrap_or(session_ts);
+            state.last_ts = message_ts;
 
             messages.insert(
                 message_id,
@@ -433,7 +443,11 @@ fn collect_message_analysis(
                  JOIN session ON session.id = part.session_id \
                  WHERE json_extract(message.data, '$.role') = 'assistant' \
                    AND json_extract(part.data, '$.type') = 'tool' \
-                   AND session.time_updated >= ?1"
+                   AND COALESCE( \
+                       json_extract(message.data, '$.time.completed'), \
+                       json_extract(message.data, '$.time.created'), \
+                       session.time_updated \
+                   ) >= ?1"
             }
             None => {
                 "SELECT part.message_id, part.data \
@@ -1019,6 +1033,8 @@ fn append_suffix(path: &Path, suffix: &str) -> PathBuf {
 mod tests {
     use super::*;
 
+    const DEFAULT_MESSAGE_TS: i64 = 1780757089000;
+
     fn make_db() -> (tempfile::TempDir, PathBuf) {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("opencode.db");
@@ -1077,9 +1093,58 @@ mod tests {
     }
 
     #[allow(clippy::too_many_arguments)]
+    fn assistant_message_at(
+        model: &str,
+        timestamp: i64,
+        input: i64,
+        output: i64,
+        reasoning: i64,
+        cache_read: i64,
+        cache_write: i64,
+        cost: f64,
+    ) -> String {
+        assistant_message_with_provider_at(
+            model,
+            None,
+            timestamp,
+            input,
+            output,
+            reasoning,
+            cache_read,
+            cache_write,
+            cost,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
     fn assistant_message_with_provider(
         model: &str,
         provider: Option<&str>,
+        input: i64,
+        output: i64,
+        reasoning: i64,
+        cache_read: i64,
+        cache_write: i64,
+        cost: f64,
+    ) -> String {
+        assistant_message_with_provider_at(
+            model,
+            provider,
+            DEFAULT_MESSAGE_TS,
+            input,
+            output,
+            reasoning,
+            cache_read,
+            cache_write,
+            cost,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn assistant_message_with_provider_at(
+        model: &str,
+        provider: Option<&str>,
+        timestamp: i64,
         input: i64,
         output: i64,
         reasoning: i64,
@@ -1101,8 +1166,8 @@ mod tests {
                 },
             },
             "time": {
-                "created": 1780757088080i64,
-                "completed": 1780757089000i64,
+                "created": timestamp.saturating_sub(1000),
+                "completed": timestamp,
             },
         });
         if let Some(provider) = provider {
@@ -1217,7 +1282,7 @@ mod tests {
 	        .unwrap();
         conn.execute(
             "INSERT INTO message (id, session_id, data) VALUES ('recent-msg', 'recent', ?1)",
-            [assistant_message("m1", 10, 0, 0, 0, 0, 0.01)],
+            [assistant_message_at("m1", now_ms, 10, 0, 0, 0, 0, 0.01)],
         )
         .unwrap();
         conn.execute(
@@ -1227,7 +1292,16 @@ mod tests {
 	        .unwrap();
         conn.execute(
             "INSERT INTO message (id, session_id, data) VALUES ('old-msg', 'old', ?1)",
-            [assistant_message("m1", 10, 0, 0, 0, 0, 0.01)],
+            [assistant_message_at(
+                "m1",
+                1000000000000,
+                10,
+                0,
+                0,
+                0,
+                0,
+                0.01,
+            )],
         )
         .unwrap();
         drop(conn);
@@ -1237,6 +1311,73 @@ mod tests {
 
         let daily = read_opencode_usage(&db_path, TimeRange::Daily).unwrap();
         assert_eq!(daily.len(), 1);
+    }
+
+    #[test]
+    fn test_message_time_range_filters_resumed_sessions() {
+        let (_dir, db_path) = make_db();
+        let conn = Connection::open(&db_path).unwrap();
+        let now_ms = chrono::Local::now().timestamp_millis();
+        conn.execute(
+            "INSERT INTO session (id, model, directory, time_updated, tokens_input) VALUES ('resumed', '{\"id\":\"m1\"}', '/repo', ?1, 10)",
+            rusqlite::params![now_ms],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES ('old-msg', 'resumed', ?1)",
+            [assistant_message_at(
+                "old-model",
+                1000000000000,
+                10,
+                0,
+                0,
+                0,
+                0,
+                0.01,
+            )],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES ('recent-msg', 'resumed', ?1)",
+            [assistant_message_at(
+                "recent-model",
+                now_ms,
+                20,
+                0,
+                0,
+                0,
+                0,
+                0.02,
+            )],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO part (id, message_id, session_id, data) VALUES ('old-part', 'old-msg', 'resumed', ?1)",
+            [r#"{"type":"tool","tool":"read","state":{"status":"completed","input":{"filePath":"/repo/old.py"},"output":"<content>\n1: old\n</content>"}}"#],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO part (id, message_id, session_id, data) VALUES ('recent-part', 'recent-msg', 'resumed', ?1)",
+            [r#"{"type":"tool","tool":"read","state":{"status":"completed","input":{"filePath":"/repo/recent.py"},"output":"<content>\n1: recent\n</content>"}}"#],
+        )
+        .unwrap();
+        drop(conn);
+
+        let usage_rows = read_opencode_usage(&db_path, TimeRange::Daily).unwrap();
+        assert_eq!(usage_rows.len(), 1);
+        assert!(
+            usage_rows[0].1.records[0]
+                .conversation_usage
+                .contains_key("recent-model")
+        );
+
+        let analysis_rows =
+            read_opencode_analysis(&db_path, TimeRange::Daily, ParseMode::UsageOnly).unwrap();
+        assert_eq!(analysis_rows.len(), 1);
+        let record = &analysis_rows[0].1.records[0];
+        assert!(record.conversation_usage.contains_key("recent-model"));
+        assert_eq!(record.tool_call_counts.read, 1);
+        assert_eq!(record.total_read_lines, 1);
     }
 
     #[test]

--- a/src/session/opencode.rs
+++ b/src/session/opencode.rs
@@ -424,12 +424,13 @@ fn with_connection<T>(db_path: &Path, f: impl FnOnce(&Connection) -> Result<T>) 
 
     // Fallback: read from a throwaway copy that includes the WAL sidecars.
     let copy = TempDbCopy::new(db_path)?;
-    let conn = Connection::open(&copy.db_path).with_context(|| {
-        format!(
-            "Failed to open OpenCode DB copy at {}",
-            copy.db_path.display()
-        )
-    })?;
+    let conn = Connection::open_with_flags(&copy.db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .with_context(|| {
+            format!(
+                "Failed to open OpenCode DB copy at {}",
+                copy.db_path.display()
+            )
+        })?;
     f(&conn)
 }
 

--- a/src/session/opencode.rs
+++ b/src/session/opencode.rs
@@ -481,9 +481,9 @@ fn collect_message_analysis(
 /// Dispatches a single `part` (type `tool`) onto the session parse state.
 ///
 /// Only the tools the analyzer tracks across providers are folded in
-/// (`read`, `edit`, `write`, `bash`, `todowrite`); auxiliary tools such as
-/// `task`, `grep`, `glob`, `webfetch`, and `question` are ignored to stay
-/// consistent with the other providers' tool-count semantics.
+/// (`read`, `edit`, `write`, `bash`, `todowrite`, `apply_patch`); auxiliary
+/// tools such as `task`, `grep`, `glob`, `webfetch`, and `question` are ignored
+/// to stay consistent with the other providers' tool-count semantics.
 fn apply_tool_part(state: &mut SessionParseState, data: &Value) {
     let tool = data.get("tool").and_then(|v| v.as_str()).unwrap_or("");
     let st = data.get("state");
@@ -534,8 +534,124 @@ fn apply_tool_part(state: &mut SessionParseState, data: &Value) {
         "todowrite" => {
             state.tool_counts.todo_write += 1;
         }
+        "apply_patch" => {
+            apply_patch_text(state, str_in("patchText"), ts);
+        }
         _ => {}
     }
+}
+
+/// Folds an OpenCode `apply_patch` tool input into file-operation counts.
+fn apply_patch_text(state: &mut SessionParseState, patch_text: &str, ts: i64) {
+    for patch in parse_apply_patch_text(patch_text) {
+        let (old_str, new_str) = extract_patch_strings(&patch.lines);
+
+        match patch.action.as_str() {
+            "add" => state.add_write_detail(&patch.file_path, &new_str, ts),
+            "delete" => state.add_edit_detail(&patch.file_path, &old_str, "", ts),
+            _ => state.add_edit_detail(&patch.file_path, &old_str, &new_str, ts),
+        }
+    }
+}
+
+/// One file hunk extracted from an OpenCode `apply_patch` tool call.
+struct OpenCodePatch {
+    action: String,
+    file_path: String,
+    lines: Vec<String>,
+}
+
+/// Parses the `*** Begin Patch` format carried by `state.input.patchText`.
+fn parse_apply_patch_text(patch_text: &str) -> Vec<OpenCodePatch> {
+    let start = match patch_text.find("*** Begin Patch") {
+        Some(idx) => idx,
+        None => return Vec::new(),
+    };
+
+    let mut patches = Vec::with_capacity(3);
+    let mut current: Option<OpenCodePatch> = None;
+    for line in patch_text[start..].lines() {
+        let line = line.trim_end_matches('\r');
+
+        if line.starts_with("*** End Patch") {
+            if let Some(patch) = current.take() {
+                patches.push(patch);
+            }
+            break;
+        } else if line.starts_with("*** Begin Patch") {
+            continue;
+        } else if line.starts_with("*** Update File:") {
+            if let Some(patch) = current.take() {
+                patches.push(patch);
+            }
+            current = Some(OpenCodePatch {
+                action: "update".to_string(),
+                file_path: line
+                    .trim_start_matches("*** Update File:")
+                    .trim()
+                    .to_string(),
+                lines: Vec::with_capacity(20),
+            });
+        } else if line.starts_with("*** Add File:") {
+            if let Some(patch) = current.take() {
+                patches.push(patch);
+            }
+            current = Some(OpenCodePatch {
+                action: "add".to_string(),
+                file_path: line.trim_start_matches("*** Add File:").trim().to_string(),
+                lines: Vec::with_capacity(20),
+            });
+        } else if line.starts_with("*** Delete File:") {
+            if let Some(patch) = current.take() {
+                patches.push(patch);
+            }
+            current = Some(OpenCodePatch {
+                action: "delete".to_string(),
+                file_path: line
+                    .trim_start_matches("*** Delete File:")
+                    .trim()
+                    .to_string(),
+                lines: Vec::with_capacity(20),
+            });
+        } else if let Some(ref mut patch) = current {
+            patch.lines.push(line.to_string());
+        }
+    }
+
+    if let Some(patch) = current {
+        patches.push(patch);
+    }
+    patches
+}
+
+/// Splits diff lines into old and new text, skipping hunk headers.
+fn extract_patch_strings(lines: &[String]) -> (String, String) {
+    let estimated_size = lines.iter().map(|l| l.len()).sum::<usize>();
+    let mut old_str = String::with_capacity(estimated_size / 2);
+    let mut new_str = String::with_capacity(estimated_size / 2);
+
+    for line in lines {
+        if line.is_empty() || line.starts_with("@@") {
+            continue;
+        }
+
+        match line.as_bytes()[0] {
+            b'+' => {
+                new_str.push_str(&line[1..]);
+                new_str.push('\n');
+            }
+            b'-' => {
+                old_str.push_str(&line[1..]);
+                old_str.push('\n');
+            }
+            b'\\' => continue,
+            _ => {}
+        }
+    }
+
+    old_str.truncate(old_str.trim_end_matches('\n').len());
+    new_str.truncate(new_str.trim_end_matches('\n').len());
+    (old_str, new_str)
 }
 
 /// Builds the Claude-style flat usage value from a session's token columns.
@@ -1164,6 +1280,36 @@ mod tests {
         assert_eq!(record.total_edit_lines, 2);
         // grep / text parts are not tracked.
         assert_eq!(record.tool_call_counts.write, 0);
+    }
+
+    #[test]
+    fn test_read_analysis_counts_apply_patch_tool() {
+        let (_dir, db_path) = make_db();
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute(
+            "INSERT INTO session (id, model, directory, time_updated) VALUES ('s1', '{\"id\":\"m1\"}', '/repo', 1780757088080)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES ('m1', 's1', ?1)",
+            [assistant_message("m1", 1, 1, 0, 0, 0, 0.01)],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO part (id, message_id, session_id, data) VALUES ('p1', 'm1', 's1', ?1)",
+            [r#"{"type":"tool","tool":"apply_patch","state":{"status":"completed","input":{"patchText":"*** Begin Patch\n*** Update File: src/main.rs\n@@\n-old\n+new\n+line\n*** Add File: src/new.rs\n+created\n*** End Patch"}}}"#],
+        )
+        .unwrap();
+        drop(conn);
+
+        let rows = read_opencode_analysis(&db_path, TimeRange::All, ParseMode::UsageOnly).unwrap();
+        assert_eq!(rows.len(), 1);
+        let record = &rows[0].1.records[0];
+        assert_eq!(record.tool_call_counts.edit, 1);
+        assert_eq!(record.tool_call_counts.write, 1);
+        assert_eq!(record.total_edit_lines, 2);
+        assert_eq!(record.total_write_lines, 1);
     }
 
     #[test]

--- a/src/session/opencode.rs
+++ b/src/session/opencode.rs
@@ -982,8 +982,12 @@ fn with_connection<T>(db_path: &Path, f: impl FnOnce(&Connection) -> Result<T>) 
 
 /// A private temp-directory copy of the OpenCode database (plus WAL sidecars),
 /// removed on drop.
+///
+/// The directory comes from [`tempfile::TempDir`], so it has an unguessable
+/// name and owner-only permissions: the copied chat database is never exposed
+/// to other local users.
 struct TempDbCopy {
-    dir: PathBuf,
+    _dir: tempfile::TempDir,
     db_path: PathBuf,
 }
 
@@ -992,16 +996,12 @@ impl TempDbCopy {
         let file_name = src
             .file_name()
             .ok_or_else(|| anyhow!("Invalid OpenCode DB path: {}", src.display()))?;
-        let nanos = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0);
-        let dir =
-            std::env::temp_dir().join(format!("vct-opencode-{}-{}", std::process::id(), nanos));
-        std::fs::create_dir_all(&dir)
-            .with_context(|| format!("Failed to create temp dir {}", dir.display()))?;
+        let dir = tempfile::Builder::new()
+            .prefix("vct-opencode-")
+            .tempdir()
+            .context("Failed to create temp dir for OpenCode DB copy")?;
 
-        let db_path = dir.join(file_name);
+        let db_path = dir.path().join(file_name);
         std::fs::copy(src, &db_path)
             .with_context(|| format!("Failed to copy OpenCode DB from {}", src.display()))?;
 
@@ -1014,13 +1014,7 @@ impl TempDbCopy {
             }
         }
 
-        Ok(Self { dir, db_path })
-    }
-}
-
-impl Drop for TempDbCopy {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_dir_all(&self.dir);
+        Ok(Self { _dir: dir, db_path })
     }
 }
 

--- a/src/session/opencode.rs
+++ b/src/session/opencode.rs
@@ -11,7 +11,7 @@
 //! - [`read_opencode_usage`] reads assistant messages for per-model tokens and
 //!   cost, with an older `session`-table fallback.
 //! - [`read_opencode_analysis`] additionally folds the `part` table's tool
-//!   calls (`read`, `edit`, `write`, `bash`, `todowrite`, `patch`) into
+//!   calls (`read`, `edit`, `write`, `bash`, `todowrite`) into
 //!   per-message file-operation metrics.
 //!
 //! Token columns map onto the Claude-style flat usage shape so the existing
@@ -307,18 +307,18 @@ fn collect_session_analysis(
     {
         let sql = match cutoff_ms {
             Some(_) => {
-                "SELECT part.session_id, part.data, part.time_updated \
+                "SELECT part.session_id, part.data \
                  FROM part \
                  JOIN session ON session.id = part.session_id \
-                 WHERE json_extract(part.data, '$.type') IN ('tool', 'patch') \
+                 WHERE json_extract(part.data, '$.type') = 'tool' \
                    AND session.model IS NOT NULL \
                    AND session.model != '' \
                    AND session.time_updated >= ?1"
             }
             None => {
-                "SELECT session_id, data, time_updated \
+                "SELECT session_id, data \
                  FROM part \
-                 WHERE json_extract(data, '$.type') IN ('tool', 'patch')"
+                 WHERE json_extract(data, '$.type') = 'tool'"
             }
         };
         let mut stmt = conn.prepare(sql)?;
@@ -330,7 +330,6 @@ fn collect_session_analysis(
         while let Some(row) = rows.next()? {
             let session_id = row.get::<_, String>(0)?;
             let data_text = row.get::<_, String>(1)?;
-            let part_ts = row.get::<_, i64>(2)?;
             let Some(accum) = sessions.get_mut(&session_id) else {
                 continue;
             };
@@ -339,7 +338,6 @@ fn collect_session_analysis(
             };
             match data.get("type").and_then(|v| v.as_str()) {
                 Some("tool") => apply_tool_part(&mut accum.state, &data),
-                Some("patch") => apply_patch_part(&mut accum.state, &data, part_ts),
                 _ => {}
             }
         }
@@ -430,20 +428,20 @@ fn collect_message_analysis(
     {
         let sql = match cutoff_ms {
             Some(_) => {
-                "SELECT part.message_id, part.data, part.time_updated \
+                "SELECT part.message_id, part.data \
                  FROM part \
                  JOIN message ON message.id = part.message_id \
                  JOIN session ON session.id = part.session_id \
                  WHERE json_extract(message.data, '$.role') = 'assistant' \
-                   AND json_extract(part.data, '$.type') IN ('tool', 'patch') \
+                   AND json_extract(part.data, '$.type') = 'tool' \
                    AND session.time_updated >= ?1"
             }
             None => {
-                "SELECT part.message_id, part.data, part.time_updated \
+                "SELECT part.message_id, part.data \
                  FROM part \
                  JOIN message ON message.id = part.message_id \
                  WHERE json_extract(message.data, '$.role') = 'assistant' \
-                   AND json_extract(part.data, '$.type') IN ('tool', 'patch')"
+                   AND json_extract(part.data, '$.type') = 'tool'"
             }
         };
         let mut stmt = conn.prepare(sql)?;
@@ -455,7 +453,6 @@ fn collect_message_analysis(
         while let Some(row) = rows.next()? {
             let message_id = row.get::<_, String>(0)?;
             let data_text = row.get::<_, String>(1)?;
-            let part_ts = row.get::<_, i64>(2)?;
             let Some(accum) = messages.get_mut(&message_id) else {
                 continue;
             };
@@ -464,7 +461,6 @@ fn collect_message_analysis(
             };
             match data.get("type").and_then(|v| v.as_str()) {
                 Some("tool") => apply_tool_part(&mut accum.state, &data),
-                Some("patch") => apply_patch_part(&mut accum.state, &data, part_ts),
                 _ => {}
             }
         }
@@ -541,17 +537,6 @@ fn apply_tool_part(state: &mut SessionParseState, data: &Value) {
             state.tool_counts.todo_write += 1;
         }
         _ => {}
-    }
-}
-
-/// Records an OpenCode `patch` part as edit work for each touched file.
-fn apply_patch_part(state: &mut SessionParseState, data: &Value, ts: i64) {
-    let Some(files) = data.get("files").and_then(|v| v.as_array()) else {
-        return;
-    };
-
-    for path in files.iter().filter_map(|v| v.as_str()) {
-        state.add_edit_detail(path, "", "", ts);
     }
 }
 
@@ -1184,7 +1169,7 @@ mod tests {
     }
 
     #[test]
-    fn test_read_analysis_counts_patch_files() {
+    fn test_read_analysis_ignores_patch_snapshots() {
         let (_dir, db_path) = make_db();
         let conn = Connection::open(&db_path).unwrap();
         conn.execute(
@@ -1207,7 +1192,7 @@ mod tests {
         let rows = read_opencode_analysis(&db_path, TimeRange::All, ParseMode::UsageOnly).unwrap();
         assert_eq!(rows.len(), 1);
         let record = &rows[0].1.records[0];
-        assert_eq!(record.tool_call_counts.edit, 2);
+        assert_eq!(record.tool_call_counts.edit, 0);
         assert_eq!(record.total_edit_lines, 0);
     }
 }

--- a/src/session/opencode.rs
+++ b/src/session/opencode.rs
@@ -627,6 +627,11 @@ fn parse_apply_patch_text(patch_text: &str) -> Vec<OpenCodePatch> {
                     .to_string(),
                 lines: Vec::with_capacity(20),
             });
+        } else if line.starts_with("*** Move to:") {
+            // Rename/move marker: attribute the hunk to the destination path.
+            if let Some(ref mut patch) = current {
+                patch.file_path = line.trim_start_matches("*** Move to:").trim().to_string();
+            }
         } else if let Some(ref mut patch) = current {
             patch.lines.push(line.to_string());
         }
@@ -1538,6 +1543,19 @@ mod tests {
         assert_eq!(record.tool_call_counts.write, 1);
         assert_eq!(record.total_edit_lines, 2);
         assert_eq!(record.total_write_lines, 1);
+    }
+
+    #[test]
+    fn test_parse_apply_patch_text_handles_move_marker() {
+        let patches = parse_apply_patch_text(
+            "*** Begin Patch\n*** Update File: src/old.rs\n*** Move to: src/new.rs\n@@\n-a\n+b\n*** End Patch",
+        );
+        assert_eq!(patches.len(), 1);
+        assert_eq!(patches[0].action, "update");
+        assert_eq!(patches[0].file_path, "src/new.rs");
+        let (old_str, new_str) = extract_patch_strings(&patches[0].lines);
+        assert_eq!(old_str, "a");
+        assert_eq!(new_str, "b");
     }
 
     #[test]

--- a/src/session/opencode.rs
+++ b/src/session/opencode.rs
@@ -106,28 +106,36 @@ fn collect_session_usage(
     let user = get_current_user();
     let machine = get_machine_id().to_string();
     let cutoff = cutoff_string(time_range);
+    let cutoff_ms = cutoff_millis(time_range);
 
-    let mut stmt = conn.prepare(
-        "SELECT model, tokens_input, tokens_output, tokens_reasoning, \
-                tokens_cache_read, tokens_cache_write, time_updated, cost \
-         FROM session WHERE model IS NOT NULL AND model != ''",
-    )?;
-    let rows = stmt.query_map([], |row| {
-        Ok((
-            row.get::<_, String>(0)?,
-            row.get::<_, i64>(1)?,
-            row.get::<_, i64>(2)?,
-            row.get::<_, i64>(3)?,
-            row.get::<_, i64>(4)?,
-            row.get::<_, i64>(5)?,
-            row.get::<_, i64>(6)?,
-            row.get::<_, f64>(7)?,
-        ))
-    })?;
+    let sql = match cutoff_ms {
+        Some(_) => {
+            "SELECT model, tokens_input, tokens_output, tokens_reasoning, \
+                    tokens_cache_read, tokens_cache_write, time_updated, cost \
+             FROM session WHERE model IS NOT NULL AND model != '' AND time_updated >= ?1"
+        }
+        None => {
+            "SELECT model, tokens_input, tokens_output, tokens_reasoning, \
+                    tokens_cache_read, tokens_cache_write, time_updated, cost \
+             FROM session WHERE model IS NOT NULL AND model != ''"
+        }
+    };
+    let mut stmt = conn.prepare(sql)?;
+    let mut rows = match cutoff_ms {
+        Some(cutoff_ms) => stmt.query([cutoff_ms])?,
+        None => stmt.query([])?,
+    };
 
     let mut out = Vec::new();
-    for row in rows {
-        let (model, input, output, reasoning, cache_read, cache_write, time_updated, cost) = row?;
+    while let Some(row) = rows.next()? {
+        let model = row.get::<_, String>(0)?;
+        let input = row.get::<_, i64>(1)?;
+        let output = row.get::<_, i64>(2)?;
+        let reasoning = row.get::<_, i64>(3)?;
+        let cache_read = row.get::<_, i64>(4)?;
+        let cache_write = row.get::<_, i64>(5)?;
+        let time_updated = row.get::<_, i64>(6)?;
+        let cost = row.get::<_, f64>(7)?;
         let Some(model_id) = parse_model_id(&model) else {
             continue;
         };
@@ -994,6 +1002,31 @@ mod tests {
 
         let daily = read_opencode_usage(&db_path, TimeRange::Daily).unwrap();
         assert_eq!(daily.len(), 1);
+    }
+
+    #[test]
+    fn test_legacy_session_usage_filters_old_sessions() {
+        let (_dir, db_path) = make_db();
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute("DROP TABLE message", []).unwrap();
+        conn.execute("DROP TABLE part", []).unwrap();
+
+        let now_ms = chrono::Local::now().timestamp_millis();
+        conn.execute(
+            "INSERT INTO session (id, model, directory, time_updated, cost, tokens_input) VALUES ('recent', '{\"id\":\"m1\"}', '/repo', ?1, 0.01, 10)",
+            rusqlite::params![now_ms],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO session (id, model, directory, time_updated, cost, tokens_input) VALUES ('old', '{\"id\":\"m2\"}', '/repo', 1000000000000, 0.02, 20)",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+
+        let daily = read_opencode_usage(&db_path, TimeRange::Daily).unwrap();
+        assert_eq!(daily.len(), 1);
+        assert!(daily[0].1.records[0].conversation_usage.contains_key("m1"));
     }
 
     #[test]

--- a/src/session/opencode.rs
+++ b/src/session/opencode.rs
@@ -863,6 +863,7 @@ fn extract_plain_read_content(output: &str) -> String {
 
     let mut content = Vec::new();
     let mut saw_separator = false;
+    let mut saw_content = false;
     for line in lines {
         if !saw_separator {
             if line.trim_end_matches('\r').is_empty() {
@@ -870,7 +871,13 @@ fn extract_plain_read_content(output: &str) -> String {
             }
             continue;
         }
-        content.push(line);
+        let line = line.strip_suffix('\r').unwrap_or(line);
+        if has_line_number_prefix(line) {
+            content.push(line);
+            saw_content = true;
+        } else if saw_content {
+            break;
+        }
     }
 
     if saw_separator {
@@ -897,18 +904,24 @@ fn strip_numbered_content_lines_from_iter(lines: Vec<&str>) -> String {
     lines.join("\n")
 }
 
-/// Strips a leading `"<digits>: "` line-number prefix, if present.
-fn strip_line_number_prefix(line: &str) -> &str {
+/// Returns whether a line starts with OpenCode's `N: ` read-output prefix.
+fn has_line_number_prefix(line: &str) -> bool {
     let bytes = line.as_bytes();
     let mut i = 0;
     while i < bytes.len() && bytes[i].is_ascii_digit() {
         i += 1;
     }
-    if i > 0 && i + 1 < bytes.len() && bytes[i] == b':' && bytes[i + 1] == b' ' {
-        &line[i + 2..]
-    } else {
-        line
-    }
+    i > 0 && i + 1 < bytes.len() && bytes[i] == b':' && bytes[i + 1] == b' '
+}
+
+/// Strips a leading `"<digits>: "` line-number prefix, if present.
+fn strip_line_number_prefix(line: &str) -> &str {
+    let Some((prefix, content)) = line.split_once(": ") else {
+        return line;
+    };
+    (!prefix.is_empty() && prefix.chars().all(|c| c.is_ascii_digit()))
+        .then_some(content)
+        .unwrap_or(line)
 }
 
 /// Wraps a single record into a fully-populated [`CodeAnalysis`].
@@ -1129,6 +1142,13 @@ mod tests {
 
         let plain_output = "/a/b.py\nfile\n\n1: import os\n2: \n3: print(1)";
         assert_eq!(extract_read_content(plain_output), "import os\n\nprint(1)");
+
+        let plain_output_with_footer =
+            "/a/b.py\nfile\n\n1: import os\n2: \n3: print(1)\n\n(End of file - total 3 lines)";
+        assert_eq!(
+            extract_read_content(plain_output_with_footer),
+            "import os\n\nprint(1)"
+        );
 
         // Directory listing has no <content> block.
         let dir_output = "<path>/a</path>\n<type>directory</type>\n<entries>\nx.py\n</entries>";

--- a/src/session/opencode.rs
+++ b/src/session/opencode.rs
@@ -701,14 +701,9 @@ fn table_exists(conn: &Connection, table: &str) -> Result<bool> {
 }
 
 /// Extracts the file body from an OpenCode `read` tool output.
-///
-/// The output wraps file contents as `<content>\n1: line\n2: line\n</content>`,
-/// each line prefixed with `N: `. This returns the joined lines with the
-/// line-number prefixes stripped. Directory listings (no `<content>` block)
-/// yield an empty string.
 fn extract_read_content(output: &str) -> String {
     let Some(start) = output.find("<content>") else {
-        return String::new();
+        return extract_plain_read_content(output);
     };
     let after = &output[start + "<content>".len()..];
     let inner = match after.find("</content>") {
@@ -717,8 +712,52 @@ fn extract_read_content(output: &str) -> String {
     };
     let inner = inner.strip_prefix('\n').unwrap_or(inner);
 
-    let mut lines: Vec<&str> = inner.split('\n').map(strip_line_number_prefix).collect();
-    // Drop the trailing empty element produced by the newline before </content>.
+    strip_numbered_content_lines(inner)
+}
+
+/// Extracts current OpenCode plain read output: `path\nfile\n\n1: line`.
+fn extract_plain_read_content(output: &str) -> String {
+    let mut lines = output.split('\n');
+    let Some(_path) = lines.next() else {
+        return String::new();
+    };
+    let Some(kind) = lines.next() else {
+        return String::new();
+    };
+    if kind.trim_end_matches('\r') != "file" {
+        return String::new();
+    }
+
+    let mut content = Vec::new();
+    let mut saw_separator = false;
+    for line in lines {
+        if !saw_separator {
+            if line.trim_end_matches('\r').is_empty() {
+                saw_separator = true;
+            }
+            continue;
+        }
+        content.push(line);
+    }
+
+    if saw_separator {
+        strip_numbered_content_lines_from_iter(content)
+    } else {
+        String::new()
+    }
+}
+
+fn strip_numbered_content_lines(inner: &str) -> String {
+    strip_numbered_content_lines_from_iter(inner.split('\n').collect())
+}
+
+fn strip_numbered_content_lines_from_iter(lines: Vec<&str>) -> String {
+    let mut lines: Vec<&str> = lines
+        .into_iter()
+        .map(|line| line.strip_suffix('\r').unwrap_or(line))
+        .map(strip_line_number_prefix)
+        .collect();
+
     if lines.last().is_some_and(|l| l.is_empty()) {
         lines.pop();
     }
@@ -919,9 +958,15 @@ mod tests {
         let output = "<path>/a/b.py</path>\n<type>file</type>\n<content>\n1: import os\n2: \n3: print(1)\n</content>";
         assert_eq!(extract_read_content(output), "import os\n\nprint(1)");
 
+        let plain_output = "/a/b.py\nfile\n\n1: import os\n2: \n3: print(1)";
+        assert_eq!(extract_read_content(plain_output), "import os\n\nprint(1)");
+
         // Directory listing has no <content> block.
         let dir_output = "<path>/a</path>\n<type>directory</type>\n<entries>\nx.py\n</entries>";
         assert_eq!(extract_read_content(dir_output), "");
+
+        let plain_dir_output = "/a\ndirectory\n\nx.py";
+        assert_eq!(extract_read_content(plain_dir_output), "");
     }
 
     #[test]

--- a/src/session/opencode.rs
+++ b/src/session/opencode.rs
@@ -8,16 +8,16 @@
 //!
 //! Two entry points keep the work proportional to what each command needs:
 //!
-//! - [`read_opencode_usage`] reads only the `session` table (model, tokens,
-//!   timestamps). It is enough for the per-model token / cost view.
+//! - [`read_opencode_usage`] reads assistant messages for per-model tokens and
+//!   cost, with an older `session`-table fallback.
 //! - [`read_opencode_analysis`] additionally folds the `part` table's tool
-//!   calls (`read`, `edit`, `write`, `bash`, `todowrite`) into per-session
-//!   file-operation metrics.
+//!   calls (`read`, `edit`, `write`, `bash`, `todowrite`, `patch`) into
+//!   per-message file-operation metrics.
 //!
 //! Token columns map onto the Claude-style flat usage shape so the existing
 //! `merge_usage_values` / `extract_token_counts` / LiteLLM cost path works
-//! unchanged. Sessions are single-model in practice, so each session's totals
-//! are attributed to `session.model.id`.
+//! unchanged. Assistant messages carry their own `modelID`, so sessions that
+//! switch model mid-stream are split before aggregation.
 
 use crate::VERSION;
 use crate::cli::TimeRange;
@@ -35,9 +35,9 @@ use std::path::{Path, PathBuf};
 /// Reads per-session token usage from the OpenCode database.
 ///
 /// Each returned tuple is `(local YYYY-MM-DD date, CodeAnalysis, stored_cost)`
-/// where the `CodeAnalysis` holds exactly one record whose `conversation_usage`
-/// is keyed by the session's model id, and `stored_cost` is OpenCode's own
-/// `session.cost` (USD) for that session. The date comes from
+/// where the `CodeAnalysis` holds one assistant message's
+/// `conversation_usage`, keyed by that message's model id, and `stored_cost`
+/// is OpenCode's own cost for that message. The date comes from
 /// `session.time_updated` and is filtered by `time_range`, matching the
 /// file-walker semantics.
 ///
@@ -70,16 +70,36 @@ pub fn read_opencode_analysis(
     with_connection(db_path, |conn| collect_analysis(conn, time_range, mode))
 }
 
-/// Per-session accumulator used while folding tool parts.
-struct SessionAccum {
+/// Parsed usage for one OpenCode assistant message.
+struct MessageUsage {
+    model_id: String,
+    usage: Value,
+    cost: f64,
+    timestamp: Option<i64>,
+}
+
+/// Per-record accumulator used while folding tool parts.
+struct AnalysisAccum {
     model_id: String,
     date: String,
     usage: Value,
     state: SessionParseState,
 }
 
-/// Collects the `usage` view from the `session` table only.
+/// Collects the `usage` view from assistant messages when available.
 fn collect_usage(
+    conn: &Connection,
+    time_range: TimeRange,
+) -> Result<Vec<(String, CodeAnalysis, f64)>> {
+    if table_exists(conn, "message")? {
+        return collect_message_usage(conn, time_range);
+    }
+
+    collect_session_usage(conn, time_range)
+}
+
+/// Collects the `usage` view from the legacy `session` columns.
+fn collect_session_usage(
     conn: &Connection,
     time_range: TimeRange,
 ) -> Result<Vec<(String, CodeAnalysis, f64)>> {
@@ -134,8 +154,81 @@ fn collect_usage(
     Ok(out)
 }
 
-/// Collects the `analysis` view from `session` + `part`.
+/// Collects the `usage` view from assistant messages.
+fn collect_message_usage(
+    conn: &Connection,
+    time_range: TimeRange,
+) -> Result<Vec<(String, CodeAnalysis, f64)>> {
+    let user = get_current_user();
+    let machine = get_machine_id().to_string();
+    let cutoff = cutoff_string(time_range);
+    let cutoff_ms = cutoff_millis(time_range);
+
+    let sql = match cutoff_ms {
+        Some(_) => {
+            "SELECT session.time_updated, message.data \
+             FROM message \
+             JOIN session ON session.id = message.session_id \
+             WHERE json_extract(message.data, '$.role') = 'assistant' \
+               AND session.time_updated >= ?1"
+        }
+        None => {
+            "SELECT session.time_updated, message.data \
+             FROM message \
+             JOIN session ON session.id = message.session_id \
+             WHERE json_extract(message.data, '$.role') = 'assistant'"
+        }
+    };
+    let mut stmt = conn.prepare(sql)?;
+    let mut rows = match cutoff_ms {
+        Some(cutoff_ms) => stmt.query([cutoff_ms])?,
+        None => stmt.query([])?,
+    };
+
+    let mut out = Vec::new();
+    while let Some(row) = rows.next()? {
+        let session_ts = row.get::<_, i64>(0)?;
+        let data_text = row.get::<_, String>(1)?;
+        let Some(date) = ms_to_local_date(session_ts) else {
+            continue;
+        };
+        if is_before_cutoff(&date, &cutoff) {
+            continue;
+        }
+        let Some(message) = parse_message_usage(&data_text) else {
+            continue;
+        };
+
+        let mut map = FastHashMap::default();
+        map.insert(message.model_id, message.usage);
+
+        let mut state = SessionParseState::with_mode(ParseMode::UsageOnly);
+        state.last_ts = message.timestamp.unwrap_or(session_ts);
+        out.push((
+            date,
+            wrap_record(state.into_record(map), &user, &machine),
+            message.cost,
+        ));
+    }
+
+    Ok(out)
+}
+
+/// Collects the `analysis` view from assistant messages + parts when available.
 fn collect_analysis(
+    conn: &Connection,
+    time_range: TimeRange,
+    mode: ParseMode,
+) -> Result<Vec<(String, CodeAnalysis)>> {
+    if table_exists(conn, "message")? {
+        return collect_message_analysis(conn, time_range, mode);
+    }
+
+    collect_session_analysis(conn, time_range, mode)
+}
+
+/// Collects the legacy `analysis` view from `session` + `part`.
+fn collect_session_analysis(
     conn: &Connection,
     time_range: TimeRange,
     mode: ParseMode,
@@ -146,7 +239,7 @@ fn collect_analysis(
     let cutoff_ms = cutoff_millis(time_range);
 
     // 1. Load session metadata and seed one parse state per session.
-    let mut sessions: HashMap<String, SessionAccum> = HashMap::new();
+    let mut sessions: HashMap<String, AnalysisAccum> = HashMap::new();
     {
         let sql = match cutoff_ms {
             Some(_) => {
@@ -192,7 +285,7 @@ fn collect_analysis(
 
             sessions.insert(
                 id,
-                SessionAccum {
+                AnalysisAccum {
                     model_id,
                     date,
                     usage,
@@ -247,6 +340,130 @@ fn collect_analysis(
     // 3. Convert each session into a CodeAnalysis, honouring the time filter.
     let mut out = Vec::with_capacity(sessions.len());
     for (_id, accum) in sessions {
+        if is_before_cutoff(&accum.date, &cutoff) {
+            continue;
+        }
+        let mut usage_map = FastHashMap::default();
+        usage_map.insert(accum.model_id, accum.usage);
+        let record = accum.state.into_record(usage_map);
+        out.push((accum.date, wrap_record(record, &user, &machine)));
+    }
+
+    Ok(out)
+}
+
+/// Collects the `analysis` view from assistant messages and their parts.
+fn collect_message_analysis(
+    conn: &Connection,
+    time_range: TimeRange,
+    mode: ParseMode,
+) -> Result<Vec<(String, CodeAnalysis)>> {
+    let user = get_current_user();
+    let machine = get_machine_id().to_string();
+    let cutoff = cutoff_string(time_range);
+    let cutoff_ms = cutoff_millis(time_range);
+
+    let mut messages: HashMap<String, AnalysisAccum> = HashMap::new();
+    {
+        let sql = match cutoff_ms {
+            Some(_) => {
+                "SELECT message.id, message.session_id, message.data, session.directory, session.time_updated \
+                 FROM message \
+                 JOIN session ON session.id = message.session_id \
+                 WHERE json_extract(message.data, '$.role') = 'assistant' \
+                   AND session.time_updated >= ?1"
+            }
+            None => {
+                "SELECT message.id, message.session_id, message.data, session.directory, session.time_updated \
+                 FROM message \
+                 JOIN session ON session.id = message.session_id \
+                 WHERE json_extract(message.data, '$.role') = 'assistant'"
+            }
+        };
+        let mut stmt = conn.prepare(sql)?;
+        let mut rows = match cutoff_ms {
+            Some(cutoff_ms) => stmt.query([cutoff_ms])?,
+            None => stmt.query([])?,
+        };
+
+        while let Some(row) = rows.next()? {
+            let message_id = row.get::<_, String>(0)?;
+            let session_id = row.get::<_, String>(1)?;
+            let data_text = row.get::<_, String>(2)?;
+            let directory = row.get::<_, String>(3)?;
+            let session_ts = row.get::<_, i64>(4)?;
+            let Some(date) = ms_to_local_date(session_ts) else {
+                continue;
+            };
+            if is_before_cutoff(&date, &cutoff) {
+                continue;
+            }
+            let Some(message) = parse_message_usage(&data_text) else {
+                continue;
+            };
+
+            let mut state = SessionParseState::with_mode(mode);
+            state.folder_path = directory;
+            state.task_id = session_id;
+            state.last_ts = message.timestamp.unwrap_or(session_ts);
+
+            messages.insert(
+                message_id,
+                AnalysisAccum {
+                    model_id: message.model_id,
+                    date,
+                    usage: message.usage,
+                    state,
+                },
+            );
+        }
+    }
+
+    {
+        let sql = match cutoff_ms {
+            Some(_) => {
+                "SELECT part.message_id, part.data, part.time_updated \
+                 FROM part \
+                 JOIN message ON message.id = part.message_id \
+                 JOIN session ON session.id = part.session_id \
+                 WHERE json_extract(message.data, '$.role') = 'assistant' \
+                   AND json_extract(part.data, '$.type') IN ('tool', 'patch') \
+                   AND session.time_updated >= ?1"
+            }
+            None => {
+                "SELECT part.message_id, part.data, part.time_updated \
+                 FROM part \
+                 JOIN message ON message.id = part.message_id \
+                 WHERE json_extract(message.data, '$.role') = 'assistant' \
+                   AND json_extract(part.data, '$.type') IN ('tool', 'patch')"
+            }
+        };
+        let mut stmt = conn.prepare(sql)?;
+        let mut rows = match cutoff_ms {
+            Some(cutoff_ms) => stmt.query([cutoff_ms])?,
+            None => stmt.query([])?,
+        };
+
+        while let Some(row) = rows.next()? {
+            let message_id = row.get::<_, String>(0)?;
+            let data_text = row.get::<_, String>(1)?;
+            let part_ts = row.get::<_, i64>(2)?;
+            let Some(accum) = messages.get_mut(&message_id) else {
+                continue;
+            };
+            let Ok(data) = serde_json::from_str::<Value>(&data_text) else {
+                continue;
+            };
+            match data.get("type").and_then(|v| v.as_str()) {
+                Some("tool") => apply_tool_part(&mut accum.state, &data),
+                Some("patch") => apply_patch_part(&mut accum.state, &data, part_ts),
+                _ => {}
+            }
+        }
+    }
+
+    let mut out = Vec::with_capacity(messages.len());
+    for (_id, accum) in messages {
         if is_before_cutoff(&accum.date, &cutoff) {
             continue;
         }
@@ -377,6 +594,61 @@ fn parse_model_id(raw: &str) -> Option<String> {
     }
 }
 
+/// Parses one assistant `message.data` payload into usage and cost.
+fn parse_message_usage(raw: &str) -> Option<MessageUsage> {
+    let data = serde_json::from_str::<Value>(raw).ok()?;
+    if data.get("role").and_then(|v| v.as_str()) != Some("assistant") {
+        return None;
+    }
+
+    let model_id = message_model_id(&data)?;
+    let tokens = data.get("tokens")?;
+    let cache = tokens.get("cache");
+    let usage = session_usage_value(
+        tokens.get("input").and_then(|v| v.as_i64()).unwrap_or(0),
+        tokens.get("output").and_then(|v| v.as_i64()).unwrap_or(0),
+        tokens
+            .get("reasoning")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0),
+        cache
+            .and_then(|v| v.get("read"))
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0),
+        cache
+            .and_then(|v| v.get("write"))
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0),
+    );
+    let cost = data.get("cost").and_then(|v| v.as_f64()).unwrap_or(0.0);
+    let timestamp = data
+        .get("time")
+        .and_then(|v| v.get("completed").or_else(|| v.get("created")))
+        .and_then(|v| v.as_i64());
+
+    Some(MessageUsage {
+        model_id,
+        usage,
+        cost,
+        timestamp,
+    })
+}
+
+/// Resolves the model from an assistant message payload.
+fn message_model_id(data: &Value) -> Option<String> {
+    data.get("modelID")
+        .or_else(|| data.get("model_id"))
+        .and_then(|v| v.as_str())
+        .or_else(|| {
+            data.get("model")
+                .and_then(|v| v.get("modelID").or_else(|| v.get("id")))
+                .and_then(|v| v.as_str())
+        })
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
 /// Converts a millisecond epoch timestamp into a local `YYYY-MM-DD` date.
 fn ms_to_local_date(ms: i64) -> Option<String> {
     chrono::DateTime::from_timestamp_millis(ms).map(|dt| {
@@ -408,6 +680,16 @@ fn cutoff_millis(time_range: TimeRange) -> Option<i64> {
 /// Returns `true` when `date` is strictly before the cutoff (should be skipped).
 fn is_before_cutoff(date: &str, cutoff: &Option<String>) -> bool {
     matches!(cutoff, Some(c) if date < c.as_str())
+}
+
+/// Returns whether a table exists in the OpenCode database.
+fn table_exists(conn: &Connection, table: &str) -> Result<bool> {
+    conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?1)",
+        [table],
+        |row| row.get(0),
+    )
+    .map_err(Into::into)
 }
 
 /// Extracts the file body from an OpenCode `read` tool output.
@@ -557,19 +839,57 @@ mod tests {
                  cost REAL NOT NULL DEFAULT 0,
                  tokens_input INTEGER NOT NULL DEFAULT 0,
                  tokens_output INTEGER NOT NULL DEFAULT 0,
-                 tokens_reasoning INTEGER NOT NULL DEFAULT 0,
-                 tokens_cache_read INTEGER NOT NULL DEFAULT 0,
-                 tokens_cache_write INTEGER NOT NULL DEFAULT 0
-             );
-	             CREATE TABLE part (
+	                 tokens_reasoning INTEGER NOT NULL DEFAULT 0,
+	                 tokens_cache_read INTEGER NOT NULL DEFAULT 0,
+	                 tokens_cache_write INTEGER NOT NULL DEFAULT 0
+	             );
+	             CREATE TABLE message (
 	                 id TEXT PRIMARY KEY,
 	                 session_id TEXT NOT NULL,
+	                 time_created INTEGER NOT NULL DEFAULT 0,
 	                 time_updated INTEGER NOT NULL DEFAULT 0,
 	                 data TEXT NOT NULL
-	             );",
+	             );
+		             CREATE TABLE part (
+		                 id TEXT PRIMARY KEY,
+		                 message_id TEXT NOT NULL DEFAULT '',
+		                 session_id TEXT NOT NULL,
+		                 time_updated INTEGER NOT NULL DEFAULT 0,
+		                 data TEXT NOT NULL
+		             );",
         )
         .unwrap();
         (dir, db_path)
+    }
+
+    fn assistant_message(
+        model: &str,
+        input: i64,
+        output: i64,
+        reasoning: i64,
+        cache_read: i64,
+        cache_write: i64,
+        cost: f64,
+    ) -> String {
+        serde_json::json!({
+            "role": "assistant",
+            "modelID": model,
+            "cost": cost,
+            "tokens": {
+                "input": input,
+                "output": output,
+                "reasoning": reasoning,
+                "cache": {
+                    "read": cache_read,
+                    "write": cache_write,
+                },
+            },
+            "time": {
+                "created": 1780757088080i64,
+                "completed": 1780757089000i64,
+            },
+        })
+        .to_string()
     }
 
     #[test]
@@ -608,9 +928,22 @@ mod tests {
         let (_dir, db_path) = make_db();
         let conn = Connection::open(&db_path).unwrap();
         conn.execute(
-            "INSERT INTO session (id, model, directory, time_updated, cost, tokens_input, tokens_output, tokens_reasoning, tokens_cache_read, tokens_cache_write)
-             VALUES ('s1', '{\"id\":\"deepseek-v4-pro\"}', '/repo', 1780757088080, 0.0375, 100, 50, 7, 200, 25)",
-            [],
+	            "INSERT INTO session (id, model, directory, time_updated, cost, tokens_input, tokens_output, tokens_reasoning, tokens_cache_read, tokens_cache_write)
+	             VALUES ('s1', '{\"id\":\"deepseek-v4-pro\"}', '/repo', 1780757088080, 0.0375, 100, 50, 7, 200, 25)",
+	            [],
+	        )
+	        .unwrap();
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES ('m1', 's1', ?1)",
+            [assistant_message(
+                "deepseek-v4-pro",
+                100,
+                50,
+                7,
+                200,
+                25,
+                0.0375,
+            )],
         )
         .unwrap();
         drop(conn);
@@ -635,13 +968,23 @@ mod tests {
         let now_ms = chrono::Local::now().timestamp_millis();
         // One session today, one well in the past.
         conn.execute(
-            "INSERT INTO session (id, model, directory, time_updated, tokens_input) VALUES ('recent', '{\"id\":\"m1\"}', '/repo', ?1, 10)",
-            rusqlite::params![now_ms],
+	            "INSERT INTO session (id, model, directory, time_updated, tokens_input) VALUES ('recent', '{\"id\":\"m1\"}', '/repo', ?1, 10)",
+	            rusqlite::params![now_ms],
+	        )
+	        .unwrap();
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES ('recent-msg', 'recent', ?1)",
+            [assistant_message("m1", 10, 0, 0, 0, 0, 0.01)],
         )
         .unwrap();
         conn.execute(
-            "INSERT INTO session (id, model, directory, time_updated, tokens_input) VALUES ('old', '{\"id\":\"m1\"}', '/repo', 1000000000000, 10)",
-            [],
+	            "INSERT INTO session (id, model, directory, time_updated, tokens_input) VALUES ('old', '{\"id\":\"m1\"}', '/repo', 1000000000000, 10)",
+	            [],
+	        )
+	        .unwrap();
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES ('old-msg', 'old', ?1)",
+            [assistant_message("m1", 10, 0, 0, 0, 0, 0.01)],
         )
         .unwrap();
         drop(conn);
@@ -654,12 +997,81 @@ mod tests {
     }
 
     #[test]
+    fn test_messages_split_usage_and_analysis_by_model() {
+        let (_dir, db_path) = make_db();
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute(
+	            "INSERT INTO session (id, model, directory, time_updated) VALUES ('s1', '{\"id\":\"m2\"}', '/repo', 1780757088080)",
+	            [],
+	        )
+	        .unwrap();
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES ('m1', 's1', ?1)",
+            [assistant_message("m1", 10, 2, 0, 3, 4, 0.01)],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES ('m2', 's1', ?1)",
+            [assistant_message("m2", 20, 4, 1, 6, 8, 0.02)],
+        )
+        .unwrap();
+        conn.execute(
+	            "INSERT INTO part (id, message_id, session_id, data) VALUES ('p1', 'm1', 's1', ?1)",
+	            [r#"{"type":"tool","tool":"read","state":{"status":"completed","input":{"filePath":"/repo/a.py"},"output":"<content>\n1: one\n</content>"}}"#],
+	        )
+	        .unwrap();
+        conn.execute(
+	            "INSERT INTO part (id, message_id, session_id, data) VALUES ('p2', 'm2', 's1', ?1)",
+	            [r#"{"type":"tool","tool":"edit","state":{"status":"completed","input":{"filePath":"/repo/b.py","oldString":"old","newString":"new\nline"}}}"#],
+	        )
+	        .unwrap();
+        drop(conn);
+
+        let usage_rows = read_opencode_usage(&db_path, TimeRange::All).unwrap();
+        assert_eq!(usage_rows.len(), 2);
+        let mut usage_by_model: HashMap<String, (i64, f64)> = HashMap::new();
+        for (_date, analysis, cost) in usage_rows {
+            let (model, usage) = analysis.records[0]
+                .conversation_usage
+                .iter()
+                .next()
+                .unwrap();
+            usage_by_model.insert(
+                model.clone(),
+                (usage["input_tokens"].as_i64().unwrap(), cost),
+            );
+        }
+        assert_eq!(usage_by_model["m1"], (10, 0.01));
+        assert_eq!(usage_by_model["m2"], (20, 0.02));
+
+        let analysis_rows =
+            read_opencode_analysis(&db_path, TimeRange::All, ParseMode::UsageOnly).unwrap();
+        assert_eq!(analysis_rows.len(), 2);
+        let mut counts_by_model: HashMap<String, (usize, usize)> = HashMap::new();
+        for (_date, analysis) in analysis_rows {
+            let record = &analysis.records[0];
+            let model = record.conversation_usage.keys().next().unwrap().clone();
+            counts_by_model.insert(
+                model,
+                (record.tool_call_counts.read, record.tool_call_counts.edit),
+            );
+        }
+        assert_eq!(counts_by_model["m1"], (1, 0));
+        assert_eq!(counts_by_model["m2"], (0, 1));
+    }
+
+    #[test]
     fn test_read_analysis_counts_tools() {
         let (_dir, db_path) = make_db();
         let conn = Connection::open(&db_path).unwrap();
         conn.execute(
-            "INSERT INTO session (id, model, directory, time_updated) VALUES ('s1', '{\"id\":\"m1\"}', '/repo', 1780757088080)",
-            [],
+	            "INSERT INTO session (id, model, directory, time_updated) VALUES ('s1', '{\"id\":\"m1\"}', '/repo', 1780757088080)",
+	            [],
+	        )
+	        .unwrap();
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES ('m1', 's1', ?1)",
+            [assistant_message("m1", 1, 1, 0, 0, 0, 0.01)],
         )
         .unwrap();
         let parts = [
@@ -673,7 +1085,7 @@ mod tests {
         ];
         for (i, p) in parts.iter().enumerate() {
             conn.execute(
-                "INSERT INTO part (id, session_id, data) VALUES (?1, 's1', ?2)",
+                "INSERT INTO part (id, message_id, session_id, data) VALUES (?1, 'm1', 's1', ?2)",
                 rusqlite::params![format!("p{i}"), p],
             )
             .unwrap();
@@ -698,14 +1110,19 @@ mod tests {
         let (_dir, db_path) = make_db();
         let conn = Connection::open(&db_path).unwrap();
         conn.execute(
-            "INSERT INTO session (id, model, directory, time_updated) VALUES ('s1', '{\"id\":\"m1\"}', '/repo', 1780757088080)",
-            [],
+	            "INSERT INTO session (id, model, directory, time_updated) VALUES ('s1', '{\"id\":\"m1\"}', '/repo', 1780757088080)",
+	            [],
+	        )
+	        .unwrap();
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES ('m1', 's1', ?1)",
+            [assistant_message("m1", 1, 1, 0, 0, 0, 0.01)],
         )
         .unwrap();
         conn.execute(
-            "INSERT INTO part (id, session_id, time_updated, data) VALUES ('p1', 's1', 1780757089000, ?1)",
-            [r#"{"type":"patch","files":["/repo/a.py","/repo/b.py"]}"#],
-        )
+	            "INSERT INTO part (id, message_id, session_id, time_updated, data) VALUES ('p1', 'm1', 's1', 1780757089000, ?1)",
+	            [r#"{"type":"patch","files":["/repo/a.py","/repo/b.py"]}"#],
+	        )
         .unwrap();
         drop(conn);
 

--- a/src/session/opencode.rs
+++ b/src/session/opencode.rs
@@ -336,9 +336,8 @@ fn collect_session_analysis(
             let Ok(data) = serde_json::from_str::<Value>(&data_text) else {
                 continue;
             };
-            match data.get("type").and_then(|v| v.as_str()) {
-                Some("tool") => apply_tool_part(&mut accum.state, &data),
-                _ => {}
+            if let Some("tool") = data.get("type").and_then(|v| v.as_str()) {
+                apply_tool_part(&mut accum.state, &data)
             }
         }
     }
@@ -459,9 +458,8 @@ fn collect_message_analysis(
             let Ok(data) = serde_json::from_str::<Value>(&data_text) else {
                 continue;
             };
-            match data.get("type").and_then(|v| v.as_str()) {
-                Some("tool") => apply_tool_part(&mut accum.state, &data),
-                _ => {}
+            if let Some("tool") = data.get("type").and_then(|v| v.as_str()) {
+                apply_tool_part(&mut accum.state, &data)
             }
         }
     }

--- a/src/session/opencode.rs
+++ b/src/session/opencode.rs
@@ -263,6 +263,9 @@ fn collect_analysis(
 fn apply_tool_part(state: &mut SessionParseState, data: &Value) {
     let tool = data.get("tool").and_then(|v| v.as_str()).unwrap_or("");
     let st = data.get("state");
+    if st.and_then(|s| s.get("status")).and_then(|v| v.as_str()) != Some("completed") {
+        return;
+    }
     let input = st.and_then(|s| s.get("input"));
     let ts = st
         .and_then(|s| s.get("time"))
@@ -647,6 +650,7 @@ mod tests {
             r#"{"type":"tool","tool":"edit","state":{"status":"completed","input":{"filePath":"/repo/a.py","oldString":"one","newString":"uno\ndos"}}}"#,
             r#"{"type":"tool","tool":"bash","state":{"status":"completed","input":{"command":"ls -la","description":"list"}}}"#,
             r#"{"type":"tool","tool":"todowrite","state":{"status":"completed","input":{"todos":[]}}}"#,
+            r#"{"type":"tool","tool":"edit","state":{"status":"error","input":{"filePath":"/repo/a.py","oldString":"one","newString":"failed\nchange"}}}"#,
             r#"{"type":"tool","tool":"grep","state":{"status":"completed","input":{"pattern":"x"}}}"#,
             r#"{"type":"text","text":"ignored"}"#,
         ];

--- a/src/session/opencode.rs
+++ b/src/session/opencode.rs
@@ -933,9 +933,11 @@ fn strip_line_number_prefix(line: &str) -> &str {
     let Some((prefix, content)) = line.split_once(": ") else {
         return line;
     };
-    (!prefix.is_empty() && prefix.chars().all(|c| c.is_ascii_digit()))
-        .then_some(content)
-        .unwrap_or(line)
+    if !prefix.is_empty() && prefix.chars().all(|c| c.is_ascii_digit()) {
+        content
+    } else {
+        line
+    }
 }
 
 /// Wraps a single record into a fully-populated [`CodeAnalysis`].

--- a/src/session/opencode.rs
+++ b/src/session/opencode.rs
@@ -563,7 +563,8 @@ fn apply_patch_text(state: &mut SessionParseState, patch_text: &str, ts: i64) {
         match patch.action.as_str() {
             "add" => state.add_write_detail(&patch.file_path, &new_str, ts),
             "delete" => state.add_edit_detail(&patch.file_path, &old_str, "", ts),
-            _ => state.add_edit_detail(&patch.file_path, &old_str, &new_str, ts),
+            // Updates target existing files, so insert-only hunks stay edits.
+            _ => state.add_edit_detail_raw(&patch.file_path, &old_str, &new_str, ts),
         }
     }
 }
@@ -1543,6 +1544,38 @@ mod tests {
         assert_eq!(record.tool_call_counts.write, 1);
         assert_eq!(record.total_edit_lines, 2);
         assert_eq!(record.total_write_lines, 1);
+    }
+
+    #[test]
+    fn test_read_analysis_keeps_patch_insertions_as_edits() {
+        let (_dir, db_path) = make_db();
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute(
+            "INSERT INTO session (id, model, directory, time_updated) VALUES ('s1', '{\"id\":\"m1\"}', '/repo', 1780757088080)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES ('m1', 's1', ?1)",
+            [assistant_message("m1", 1, 1, 0, 0, 0, 0.01)],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO part (id, message_id, session_id, data) VALUES ('p1', 'm1', 's1', ?1)",
+            [r#"{"type":"tool","tool":"apply_patch","state":{"status":"completed","input":{"patchText":"*** Begin Patch\n*** Update File: src/main.rs\n@@\n+inserted\n+lines\n*** End Patch"}}}"#],
+        )
+        .unwrap();
+        drop(conn);
+
+        let rows = read_opencode_analysis(&db_path, TimeRange::All, ParseMode::UsageOnly).unwrap();
+        assert_eq!(rows.len(), 1);
+        let record = &rows[0].1.records[0];
+        // An insert-only update hunk targets an existing file: it must stay an
+        // edit instead of being reclassified as a write.
+        assert_eq!(record.tool_call_counts.edit, 1);
+        assert_eq!(record.tool_call_counts.write, 0);
+        assert_eq!(record.total_edit_lines, 2);
+        assert_eq!(record.total_write_lines, 0);
     }
 
     #[test]

--- a/src/session/opencode.rs
+++ b/src/session/opencode.rs
@@ -16,8 +16,8 @@
 //!
 //! Token columns map onto the Claude-style flat usage shape so the existing
 //! `merge_usage_values` / `extract_token_counts` / LiteLLM cost path works
-//! unchanged. Assistant messages carry their own `modelID`, so sessions that
-//! switch model mid-stream are split before aggregation.
+//! unchanged. Assistant messages carry their own `providerID` + `modelID`, so
+//! sessions that switch model mid-stream are split before aggregation.
 
 use crate::VERSION;
 use crate::cli::TimeRange;
@@ -36,8 +36,8 @@ use std::path::{Path, PathBuf};
 ///
 /// Each returned tuple is `(local YYYY-MM-DD date, CodeAnalysis, stored_cost)`
 /// where the `CodeAnalysis` holds one assistant message's
-/// `conversation_usage`, keyed by that message's model id, and `stored_cost`
-/// is OpenCode's own cost for that message. The date comes from
+/// `conversation_usage`, keyed by that message's provider-qualified model id,
+/// and `stored_cost` is OpenCode's own cost for that message. The date comes from
 /// `session.time_updated` and is filtered by `time_range`, matching the
 /// file-walker semantics.
 ///
@@ -677,21 +677,29 @@ fn session_usage_value(
 
 /// Resolves the model name from the `session.model` column.
 ///
-/// Modern OpenCode stores it as a JSON object `{"id", "providerID", ...}`; we
-/// key everything off `id`. Older builds may store a bare model string, which
-/// is used verbatim. Returns `None` when no usable model name is present.
+/// Modern OpenCode stores it as a JSON object `{"id", "providerID", ...}`. When
+/// `providerID` is present, the returned key is `providerID/id` so same-named
+/// models from different backends do not merge. Older builds may store a bare
+/// model string, which is used verbatim. Returns `None` when no usable model
+/// name is present.
 fn parse_model_id(raw: &str) -> Option<String> {
     let raw = raw.trim();
     if raw.is_empty() {
         return None;
     }
     match serde_json::from_str::<Value>(raw) {
-        Ok(Value::Object(map)) => map
-            .get("id")
-            .and_then(|v| v.as_str())
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .map(str::to_string),
+        Ok(Value::Object(map)) => {
+            let model = map.get("id").and_then(|v| v.as_str())?.trim();
+            if model.is_empty() {
+                return None;
+            }
+            Some(provider_qualified_model_id(
+                map.get("providerID")
+                    .or_else(|| map.get("provider_id"))
+                    .and_then(|v| v.as_str()),
+                model,
+            ))
+        }
         Ok(Value::String(s)) => {
             let s = s.trim();
             (!s.is_empty()).then(|| s.to_string())
@@ -743,17 +751,43 @@ fn parse_message_usage(raw: &str) -> Option<MessageUsage> {
 
 /// Resolves the model from an assistant message payload.
 fn message_model_id(data: &Value) -> Option<String> {
-    data.get("modelID")
+    let model = data
+        .get("modelID")
         .or_else(|| data.get("model_id"))
         .and_then(|v| v.as_str())
         .or_else(|| {
             data.get("model")
                 .and_then(|v| v.get("modelID").or_else(|| v.get("id")))
                 .and_then(|v| v.as_str())
-        })
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(str::to_string)
+        })?
+        .trim();
+    if model.is_empty() {
+        return None;
+    }
+
+    Some(provider_qualified_model_id(
+        data.get("providerID")
+            .or_else(|| data.get("provider_id"))
+            .and_then(|v| v.as_str())
+            .or_else(|| {
+                data.get("model")
+                    .and_then(|v| v.get("providerID").or_else(|| v.get("provider_id")))
+                    .and_then(|v| v.as_str())
+            }),
+        model,
+    ))
+}
+
+/// Keeps OpenCode model keys provider-qualified when the payload has provider metadata.
+fn provider_qualified_model_id(provider: Option<&str>, model: &str) -> String {
+    let Some(provider) = provider.map(str::trim).filter(|s| !s.is_empty()) else {
+        return model.to_string();
+    };
+    if model.starts_with(&format!("{provider}/")) {
+        model.to_string()
+    } else {
+        format!("{provider}/{model}")
+    }
 }
 
 /// Converts a millisecond epoch timestamp into a local `YYYY-MM-DD` date.
@@ -1017,7 +1051,30 @@ mod tests {
         cache_write: i64,
         cost: f64,
     ) -> String {
-        serde_json::json!({
+        assistant_message_with_provider(
+            model,
+            None,
+            input,
+            output,
+            reasoning,
+            cache_read,
+            cache_write,
+            cost,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn assistant_message_with_provider(
+        model: &str,
+        provider: Option<&str>,
+        input: i64,
+        output: i64,
+        reasoning: i64,
+        cache_read: i64,
+        cache_write: i64,
+        cost: f64,
+    ) -> String {
+        let mut message = serde_json::json!({
             "role": "assistant",
             "modelID": model,
             "cost": cost,
@@ -1034,15 +1091,18 @@ mod tests {
                 "created": 1780757088080i64,
                 "completed": 1780757089000i64,
             },
-        })
-        .to_string()
+        });
+        if let Some(provider) = provider {
+            message["providerID"] = serde_json::Value::String(provider.to_string());
+        }
+        message.to_string()
     }
 
     #[test]
     fn test_parse_model_id() {
         assert_eq!(
             parse_model_id(r#"{"id":"deepseek-v4-pro","providerID":"deepseek"}"#).as_deref(),
-            Some("deepseek-v4-pro")
+            Some("deepseek/deepseek-v4-pro")
         );
         assert_eq!(
             parse_model_id("gemini-3.5-flash").as_deref(),
@@ -1050,6 +1110,16 @@ mod tests {
         );
         assert_eq!(parse_model_id(r#"{"providerID":"x"}"#), None);
         assert_eq!(parse_model_id("   "), None);
+    }
+
+    #[test]
+    fn test_message_model_id_preserves_provider() {
+        let message = serde_json::json!({
+            "role": "assistant",
+            "modelID": "gpt-4.1",
+            "providerID": "azure",
+        });
+        assert_eq!(message_model_id(&message).as_deref(), Some("azure/gpt-4.1"));
     }
 
     #[test]
@@ -1087,8 +1157,9 @@ mod tests {
 	        .unwrap();
         conn.execute(
             "INSERT INTO message (id, session_id, data) VALUES ('m1', 's1', ?1)",
-            [assistant_message(
+            [assistant_message_with_provider(
                 "deepseek-v4-pro",
+                Some("deepseek"),
                 100,
                 50,
                 7,
@@ -1105,7 +1176,7 @@ mod tests {
         let (_date, analysis, cost) = &rows[0];
         assert_eq!(analysis.extension_name, "OpenCode");
         assert!((cost - 0.0375).abs() < 1e-9);
-        let usage = &analysis.records[0].conversation_usage["deepseek-v4-pro"];
+        let usage = &analysis.records[0].conversation_usage["deepseek/deepseek-v4-pro"];
         assert_eq!(usage["input_tokens"], 100);
         assert_eq!(usage["output_tokens"], 50);
         assert_eq!(usage["reasoning_output_tokens"], 7);

--- a/src/session/opencode.rs
+++ b/src/session/opencode.rs
@@ -206,18 +206,18 @@ fn collect_analysis(
     {
         let sql = match cutoff_ms {
             Some(_) => {
-                "SELECT part.session_id, part.data \
+                "SELECT part.session_id, part.data, part.time_updated \
                  FROM part \
                  JOIN session ON session.id = part.session_id \
-                 WHERE json_extract(part.data, '$.type') = 'tool' \
+                 WHERE json_extract(part.data, '$.type') IN ('tool', 'patch') \
                    AND session.model IS NOT NULL \
                    AND session.model != '' \
                    AND session.time_updated >= ?1"
             }
             None => {
-                "SELECT session_id, data \
+                "SELECT session_id, data, time_updated \
                  FROM part \
-                 WHERE json_extract(data, '$.type') = 'tool'"
+                 WHERE json_extract(data, '$.type') IN ('tool', 'patch')"
             }
         };
         let mut stmt = conn.prepare(sql)?;
@@ -229,13 +229,18 @@ fn collect_analysis(
         while let Some(row) = rows.next()? {
             let session_id = row.get::<_, String>(0)?;
             let data_text = row.get::<_, String>(1)?;
+            let part_ts = row.get::<_, i64>(2)?;
             let Some(accum) = sessions.get_mut(&session_id) else {
                 continue;
             };
             let Ok(data) = serde_json::from_str::<Value>(&data_text) else {
                 continue;
             };
-            apply_tool_part(&mut accum.state, &data);
+            match data.get("type").and_then(|v| v.as_str()) {
+                Some("tool") => apply_tool_part(&mut accum.state, &data),
+                Some("patch") => apply_patch_part(&mut accum.state, &data, part_ts),
+                _ => {}
+            }
         }
     }
 
@@ -311,6 +316,17 @@ fn apply_tool_part(state: &mut SessionParseState, data: &Value) {
             state.tool_counts.todo_write += 1;
         }
         _ => {}
+    }
+}
+
+/// Records an OpenCode `patch` part as edit work for each touched file.
+fn apply_patch_part(state: &mut SessionParseState, data: &Value, ts: i64) {
+    let Some(files) = data.get("files").and_then(|v| v.as_array()) else {
+        return;
+    };
+
+    for path in files.iter().filter_map(|v| v.as_str()) {
+        state.add_edit_detail(path, "", "", ts);
     }
 }
 
@@ -545,11 +561,12 @@ mod tests {
                  tokens_cache_read INTEGER NOT NULL DEFAULT 0,
                  tokens_cache_write INTEGER NOT NULL DEFAULT 0
              );
-             CREATE TABLE part (
-                 id TEXT PRIMARY KEY,
-                 session_id TEXT NOT NULL,
-                 data TEXT NOT NULL
-             );",
+	             CREATE TABLE part (
+	                 id TEXT PRIMARY KEY,
+	                 session_id TEXT NOT NULL,
+	                 time_updated INTEGER NOT NULL DEFAULT 0,
+	                 data TEXT NOT NULL
+	             );",
         )
         .unwrap();
         (dir, db_path)
@@ -674,5 +691,28 @@ mod tests {
         assert_eq!(record.total_edit_lines, 2);
         // grep / text parts are not tracked.
         assert_eq!(record.tool_call_counts.write, 0);
+    }
+
+    #[test]
+    fn test_read_analysis_counts_patch_files() {
+        let (_dir, db_path) = make_db();
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute(
+            "INSERT INTO session (id, model, directory, time_updated) VALUES ('s1', '{\"id\":\"m1\"}', '/repo', 1780757088080)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO part (id, session_id, time_updated, data) VALUES ('p1', 's1', 1780757089000, ?1)",
+            [r#"{"type":"patch","files":["/repo/a.py","/repo/b.py"]}"#],
+        )
+        .unwrap();
+        drop(conn);
+
+        let rows = read_opencode_analysis(&db_path, TimeRange::All, ParseMode::UsageOnly).unwrap();
+        assert_eq!(rows.len(), 1);
+        let record = &rows[0].1.records[0];
+        assert_eq!(record.tool_call_counts.edit, 2);
+        assert_eq!(record.total_edit_lines, 0);
     }
 }

--- a/src/session/opencode.rs
+++ b/src/session/opencode.rs
@@ -34,10 +34,12 @@ use std::path::{Path, PathBuf};
 
 /// Reads per-session token usage from the OpenCode database.
 ///
-/// Each returned pair is `(local YYYY-MM-DD date, CodeAnalysis)` where the
-/// `CodeAnalysis` holds exactly one record whose `conversation_usage` is keyed
-/// by the session's model id. The date comes from `session.time_updated` and is
-/// filtered by `time_range`, matching the file-walker semantics.
+/// Each returned tuple is `(local YYYY-MM-DD date, CodeAnalysis, stored_cost)`
+/// where the `CodeAnalysis` holds exactly one record whose `conversation_usage`
+/// is keyed by the session's model id, and `stored_cost` is OpenCode's own
+/// `session.cost` (USD) for that session. The date comes from
+/// `session.time_updated` and is filtered by `time_range`, matching the
+/// file-walker semantics.
 ///
 /// # Errors
 ///
@@ -45,7 +47,7 @@ use std::path::{Path, PathBuf};
 pub fn read_opencode_usage(
     db_path: &Path,
     time_range: TimeRange,
-) -> Result<Vec<(String, CodeAnalysis)>> {
+) -> Result<Vec<(String, CodeAnalysis, f64)>> {
     with_connection(db_path, |conn| collect_usage(conn, time_range))
 }
 
@@ -77,14 +79,17 @@ struct SessionAccum {
 }
 
 /// Collects the `usage` view from the `session` table only.
-fn collect_usage(conn: &Connection, time_range: TimeRange) -> Result<Vec<(String, CodeAnalysis)>> {
+fn collect_usage(
+    conn: &Connection,
+    time_range: TimeRange,
+) -> Result<Vec<(String, CodeAnalysis, f64)>> {
     let user = get_current_user();
     let machine = get_machine_id().to_string();
     let cutoff = cutoff_string(time_range);
 
     let mut stmt = conn.prepare(
         "SELECT model, tokens_input, tokens_output, tokens_reasoning, \
-                tokens_cache_read, tokens_cache_write, time_updated \
+                tokens_cache_read, tokens_cache_write, time_updated, cost \
          FROM session WHERE model IS NOT NULL AND model != ''",
     )?;
     let rows = stmt.query_map([], |row| {
@@ -96,12 +101,13 @@ fn collect_usage(conn: &Connection, time_range: TimeRange) -> Result<Vec<(String
             row.get::<_, i64>(4)?,
             row.get::<_, i64>(5)?,
             row.get::<_, i64>(6)?,
+            row.get::<_, f64>(7)?,
         ))
     })?;
 
     let mut out = Vec::new();
     for row in rows {
-        let (model, input, output, reasoning, cache_read, cache_write, time_updated) = row?;
+        let (model, input, output, reasoning, cache_read, cache_write, time_updated, cost) = row?;
         let Some(model_id) = parse_model_id(&model) else {
             continue;
         };
@@ -118,7 +124,11 @@ fn collect_usage(conn: &Connection, time_range: TimeRange) -> Result<Vec<(String
 
         let mut state = SessionParseState::with_mode(ParseMode::UsageOnly);
         state.last_ts = time_updated;
-        out.push((date, wrap_record(state.into_record(map), &user, &machine)));
+        out.push((
+            date,
+            wrap_record(state.into_record(map), &user, &machine),
+            cost,
+        ));
     }
 
     Ok(out)
@@ -488,6 +498,7 @@ mod tests {
                  model TEXT,
                  directory TEXT,
                  time_updated INTEGER NOT NULL,
+                 cost REAL NOT NULL DEFAULT 0,
                  tokens_input INTEGER NOT NULL DEFAULT 0,
                  tokens_output INTEGER NOT NULL DEFAULT 0,
                  tokens_reasoning INTEGER NOT NULL DEFAULT 0,
@@ -540,8 +551,8 @@ mod tests {
         let (_dir, db_path) = make_db();
         let conn = Connection::open(&db_path).unwrap();
         conn.execute(
-            "INSERT INTO session (id, model, directory, time_updated, tokens_input, tokens_output, tokens_reasoning, tokens_cache_read, tokens_cache_write)
-             VALUES ('s1', '{\"id\":\"deepseek-v4-pro\"}', '/repo', 1780757088080, 100, 50, 7, 200, 25)",
+            "INSERT INTO session (id, model, directory, time_updated, cost, tokens_input, tokens_output, tokens_reasoning, tokens_cache_read, tokens_cache_write)
+             VALUES ('s1', '{\"id\":\"deepseek-v4-pro\"}', '/repo', 1780757088080, 0.0375, 100, 50, 7, 200, 25)",
             [],
         )
         .unwrap();
@@ -549,8 +560,9 @@ mod tests {
 
         let rows = read_opencode_usage(&db_path, TimeRange::All).unwrap();
         assert_eq!(rows.len(), 1);
-        let (_date, analysis) = &rows[0];
+        let (_date, analysis, cost) = &rows[0];
         assert_eq!(analysis.extension_name, "OpenCode");
+        assert!((cost - 0.0375).abs() < 1e-9);
         let usage = &analysis.records[0].conversation_usage["deepseek-v4-pro"];
         assert_eq!(usage["input_tokens"], 100);
         assert_eq!(usage["output_tokens"], 50);

--- a/src/session/opencode.rs
+++ b/src/session/opencode.rs
@@ -1,0 +1,625 @@
+//! OpenCode session reader (SQLite, not JSONL).
+//!
+//! Unlike the four file-based providers, OpenCode stores every session in a
+//! single SQLite database at `~/.local/share/opencode/opencode.db` (WAL mode).
+//! This module owns the "SQLite rows -> typed [`CodeAnalysis`]" boundary, so
+//! both the `usage` and `analysis` aggregators consume the same shape the
+//! file-based providers produce.
+//!
+//! Two entry points keep the work proportional to what each command needs:
+//!
+//! - [`read_opencode_usage`] reads only the `session` table (model, tokens,
+//!   timestamps). It is enough for the per-model token / cost view.
+//! - [`read_opencode_analysis`] additionally folds the `part` table's tool
+//!   calls (`read`, `edit`, `write`, `bash`, `todowrite`) into per-session
+//!   file-operation metrics.
+//!
+//! Token columns map onto the Claude-style flat usage shape so the existing
+//! `merge_usage_values` / `extract_token_counts` / LiteLLM cost path works
+//! unchanged. Sessions are single-model in practice, so each session's totals
+//! are attributed to `session.model.id`.
+
+use crate::VERSION;
+use crate::cli::TimeRange;
+use crate::constants::FastHashMap;
+use crate::models::{CodeAnalysis, CodeAnalysisRecord, ExtensionType};
+use crate::session::state::{ParseMode, SessionParseState};
+use crate::utils::{get_current_user, get_machine_id};
+use anyhow::{Context, Result, anyhow};
+use rusqlite::{Connection, OpenFlags};
+use serde_json::{Value, json};
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+/// Reads per-session token usage from the OpenCode database.
+///
+/// Each returned pair is `(local YYYY-MM-DD date, CodeAnalysis)` where the
+/// `CodeAnalysis` holds exactly one record whose `conversation_usage` is keyed
+/// by the session's model id. The date comes from `session.time_updated` and is
+/// filtered by `time_range`, matching the file-walker semantics.
+///
+/// # Errors
+///
+/// Returns an error if the database cannot be opened or queried.
+pub fn read_opencode_usage(
+    db_path: &Path,
+    time_range: TimeRange,
+) -> Result<Vec<(String, CodeAnalysis)>> {
+    with_connection(db_path, |conn| collect_usage(conn, time_range))
+}
+
+/// Reads per-session file-operation metrics from the OpenCode database.
+///
+/// Like [`read_opencode_usage`], but also folds each session's tool calls from
+/// the `part` table into `tool_call_counts` and the `total_*` line/character
+/// counts. `mode` controls whether the heavy per-operation detail bodies are
+/// retained ([`ParseMode::Full`]) or skipped ([`ParseMode::UsageOnly`]); the
+/// aggregated `analysis` view uses `UsageOnly`.
+///
+/// # Errors
+///
+/// Returns an error if the database cannot be opened or queried.
+pub fn read_opencode_analysis(
+    db_path: &Path,
+    time_range: TimeRange,
+    mode: ParseMode,
+) -> Result<Vec<(String, CodeAnalysis)>> {
+    with_connection(db_path, |conn| collect_analysis(conn, time_range, mode))
+}
+
+/// Per-session accumulator used while folding tool parts.
+struct SessionAccum {
+    model_id: String,
+    date: String,
+    usage: Value,
+    state: SessionParseState,
+}
+
+/// Collects the `usage` view from the `session` table only.
+fn collect_usage(conn: &Connection, time_range: TimeRange) -> Result<Vec<(String, CodeAnalysis)>> {
+    let user = get_current_user();
+    let machine = get_machine_id().to_string();
+    let cutoff = cutoff_string(time_range);
+
+    let mut stmt = conn.prepare(
+        "SELECT model, tokens_input, tokens_output, tokens_reasoning, \
+                tokens_cache_read, tokens_cache_write, time_updated \
+         FROM session WHERE model IS NOT NULL AND model != ''",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, i64>(1)?,
+            row.get::<_, i64>(2)?,
+            row.get::<_, i64>(3)?,
+            row.get::<_, i64>(4)?,
+            row.get::<_, i64>(5)?,
+            row.get::<_, i64>(6)?,
+        ))
+    })?;
+
+    let mut out = Vec::new();
+    for row in rows {
+        let (model, input, output, reasoning, cache_read, cache_write, time_updated) = row?;
+        let Some(model_id) = parse_model_id(&model) else {
+            continue;
+        };
+        let Some(date) = ms_to_local_date(time_updated) else {
+            continue;
+        };
+        if is_before_cutoff(&date, &cutoff) {
+            continue;
+        }
+
+        let usage = session_usage_value(input, output, reasoning, cache_read, cache_write);
+        let mut map = FastHashMap::default();
+        map.insert(model_id, usage);
+
+        let mut state = SessionParseState::with_mode(ParseMode::UsageOnly);
+        state.last_ts = time_updated;
+        out.push((date, wrap_record(state.into_record(map), &user, &machine)));
+    }
+
+    Ok(out)
+}
+
+/// Collects the `analysis` view from `session` + `part`.
+fn collect_analysis(
+    conn: &Connection,
+    time_range: TimeRange,
+    mode: ParseMode,
+) -> Result<Vec<(String, CodeAnalysis)>> {
+    let user = get_current_user();
+    let machine = get_machine_id().to_string();
+    let cutoff = cutoff_string(time_range);
+
+    // 1. Load session metadata and seed one parse state per session.
+    let mut sessions: HashMap<String, SessionAccum> = HashMap::new();
+    {
+        let mut stmt = conn.prepare(
+            "SELECT id, model, directory, time_updated, tokens_input, tokens_output, \
+                    tokens_reasoning, tokens_cache_read, tokens_cache_write \
+             FROM session WHERE model IS NOT NULL AND model != ''",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, i64>(3)?,
+                row.get::<_, i64>(4)?,
+                row.get::<_, i64>(5)?,
+                row.get::<_, i64>(6)?,
+                row.get::<_, i64>(7)?,
+                row.get::<_, i64>(8)?,
+            ))
+        })?;
+
+        for row in rows {
+            let (id, model, directory, ts, input, output, reasoning, cache_read, cache_write) =
+                row?;
+            let Some(model_id) = parse_model_id(&model) else {
+                continue;
+            };
+            let Some(date) = ms_to_local_date(ts) else {
+                continue;
+            };
+
+            let usage = session_usage_value(input, output, reasoning, cache_read, cache_write);
+            let mut state = SessionParseState::with_mode(mode);
+            state.folder_path = directory;
+            state.task_id = id.clone();
+            state.last_ts = ts;
+
+            sessions.insert(
+                id,
+                SessionAccum {
+                    model_id,
+                    date,
+                    usage,
+                    state,
+                },
+            );
+        }
+    }
+
+    // 2. Fold tool parts into their owning session's parse state.
+    {
+        let mut stmt = conn.prepare(
+            "SELECT session_id, data FROM part WHERE json_extract(data, '$.type') = 'tool'",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?;
+
+        for row in rows {
+            let (session_id, data_text) = row?;
+            let Some(accum) = sessions.get_mut(&session_id) else {
+                continue;
+            };
+            let Ok(data) = serde_json::from_str::<Value>(&data_text) else {
+                continue;
+            };
+            apply_tool_part(&mut accum.state, &data);
+        }
+    }
+
+    // 3. Convert each session into a CodeAnalysis, honouring the time filter.
+    let mut out = Vec::with_capacity(sessions.len());
+    for (_id, accum) in sessions {
+        if is_before_cutoff(&accum.date, &cutoff) {
+            continue;
+        }
+        let mut usage_map = FastHashMap::default();
+        usage_map.insert(accum.model_id, accum.usage);
+        let record = accum.state.into_record(usage_map);
+        out.push((accum.date, wrap_record(record, &user, &machine)));
+    }
+
+    Ok(out)
+}
+
+/// Dispatches a single `part` (type `tool`) onto the session parse state.
+///
+/// Only the tools the analyzer tracks across providers are folded in
+/// (`read`, `edit`, `write`, `bash`, `todowrite`); auxiliary tools such as
+/// `task`, `grep`, `glob`, `webfetch`, and `question` are ignored to stay
+/// consistent with the other providers' tool-count semantics.
+fn apply_tool_part(state: &mut SessionParseState, data: &Value) {
+    let tool = data.get("tool").and_then(|v| v.as_str()).unwrap_or("");
+    let st = data.get("state");
+    let input = st.and_then(|s| s.get("input"));
+    let ts = st
+        .and_then(|s| s.get("time"))
+        .and_then(|t| t.get("start"))
+        .and_then(|v| v.as_i64())
+        .unwrap_or(state.last_ts);
+
+    let str_in = |key: &str| -> &str {
+        input
+            .and_then(|i| i.get(key))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+    };
+
+    match tool {
+        "read" => {
+            let path = str_in("filePath");
+            let output = st
+                .and_then(|s| s.get("output"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let content = extract_read_content(output);
+            if !path.is_empty() && !content.is_empty() {
+                state.add_read_detail(path, &content, ts);
+            } else {
+                // Directory listings (and empty reads) still count as a read
+                // invocation even though they contribute no file lines.
+                state.tool_counts.read += 1;
+            }
+        }
+        "edit" => {
+            let path = str_in("filePath");
+            state.add_edit_detail(path, str_in("oldString"), str_in("newString"), ts);
+        }
+        "write" => {
+            let path = str_in("filePath");
+            state.add_write_detail(path, str_in("content"), ts);
+        }
+        "bash" => {
+            state.add_run_command(str_in("command"), str_in("description"), ts);
+        }
+        "todowrite" => {
+            state.tool_counts.todo_write += 1;
+        }
+        _ => {}
+    }
+}
+
+/// Builds the Claude-style flat usage value from a session's token columns.
+///
+/// OpenCode records non-cached input separately from cache reads (input is
+/// disjoint from cache, matching the Claude convention), so the columns map
+/// straight onto the field names `extract_token_counts` understands.
+fn session_usage_value(
+    input: i64,
+    output: i64,
+    reasoning: i64,
+    cache_read: i64,
+    cache_write: i64,
+) -> Value {
+    json!({
+        "input_tokens": input,
+        "output_tokens": output,
+        "cache_read_input_tokens": cache_read,
+        "cache_creation_input_tokens": cache_write,
+        "reasoning_output_tokens": reasoning,
+    })
+}
+
+/// Resolves the model name from the `session.model` column.
+///
+/// Modern OpenCode stores it as a JSON object `{"id", "providerID", ...}`; we
+/// key everything off `id`. Older builds may store a bare model string, which
+/// is used verbatim. Returns `None` when no usable model name is present.
+fn parse_model_id(raw: &str) -> Option<String> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    match serde_json::from_str::<Value>(raw) {
+        Ok(Value::Object(map)) => map
+            .get("id")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string),
+        Ok(Value::String(s)) => {
+            let s = s.trim();
+            (!s.is_empty()).then(|| s.to_string())
+        }
+        // Not valid JSON: treat the column as a plain model name.
+        _ => Some(raw.to_string()),
+    }
+}
+
+/// Converts a millisecond epoch timestamp into a local `YYYY-MM-DD` date.
+fn ms_to_local_date(ms: i64) -> Option<String> {
+    chrono::DateTime::from_timestamp_millis(ms).map(|dt| {
+        dt.with_timezone(&chrono::Local)
+            .format("%Y-%m-%d")
+            .to_string()
+    })
+}
+
+/// Pre-computes the `YYYY-MM-DD` cutoff for `time_range`, if any.
+fn cutoff_string(time_range: TimeRange) -> Option<String> {
+    time_range
+        .cutoff_date()
+        .map(|d| d.format("%Y-%m-%d").to_string())
+}
+
+/// Returns `true` when `date` is strictly before the cutoff (should be skipped).
+fn is_before_cutoff(date: &str, cutoff: &Option<String>) -> bool {
+    matches!(cutoff, Some(c) if date < c.as_str())
+}
+
+/// Extracts the file body from an OpenCode `read` tool output.
+///
+/// The output wraps file contents as `<content>\n1: line\n2: line\n</content>`,
+/// each line prefixed with `N: `. This returns the joined lines with the
+/// line-number prefixes stripped. Directory listings (no `<content>` block)
+/// yield an empty string.
+fn extract_read_content(output: &str) -> String {
+    let Some(start) = output.find("<content>") else {
+        return String::new();
+    };
+    let after = &output[start + "<content>".len()..];
+    let inner = match after.find("</content>") {
+        Some(end) => &after[..end],
+        None => after,
+    };
+    let inner = inner.strip_prefix('\n').unwrap_or(inner);
+
+    let mut lines: Vec<&str> = inner.split('\n').map(strip_line_number_prefix).collect();
+    // Drop the trailing empty element produced by the newline before </content>.
+    if lines.last().is_some_and(|l| l.is_empty()) {
+        lines.pop();
+    }
+    lines.join("\n")
+}
+
+/// Strips a leading `"<digits>: "` line-number prefix, if present.
+fn strip_line_number_prefix(line: &str) -> &str {
+    let bytes = line.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() && bytes[i].is_ascii_digit() {
+        i += 1;
+    }
+    if i > 0 && i + 1 < bytes.len() && bytes[i] == b':' && bytes[i + 1] == b' ' {
+        &line[i + 2..]
+    } else {
+        line
+    }
+}
+
+/// Wraps a single record into a fully-populated [`CodeAnalysis`].
+fn wrap_record(record: CodeAnalysisRecord, user: &str, machine: &str) -> CodeAnalysis {
+    CodeAnalysis {
+        user: user.to_string(),
+        extension_name: ExtensionType::OpenCode.to_string(),
+        insights_version: VERSION.to_string(),
+        machine_id: machine.to_string(),
+        records: vec![record],
+    }
+}
+
+/// Opens the OpenCode DB read-only and runs `f` against it.
+///
+/// The primary path opens the database read-only so the user's file is never
+/// mutated. A read-only connection reads a WAL database fine on modern SQLite,
+/// but if that ever fails (e.g. the WAL needs recovery and cannot be locked
+/// read-only) we fall back to copying the database plus its `-wal`/`-shm`
+/// sidecars into a private temp directory and reading the copy. The temp copy
+/// is removed when `f` returns.
+fn with_connection<T>(db_path: &Path, f: impl FnOnce(&Connection) -> Result<T>) -> Result<T> {
+    if let Ok(conn) = Connection::open_with_flags(db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        && conn
+            .query_row("SELECT count(*) FROM session", [], |_| Ok(()))
+            .is_ok()
+    {
+        return f(&conn);
+    }
+
+    // Fallback: read from a throwaway copy that includes the WAL sidecars.
+    let copy = TempDbCopy::new(db_path)?;
+    let conn = Connection::open(&copy.db_path).with_context(|| {
+        format!(
+            "Failed to open OpenCode DB copy at {}",
+            copy.db_path.display()
+        )
+    })?;
+    f(&conn)
+}
+
+/// A private temp-directory copy of the OpenCode database (plus WAL sidecars),
+/// removed on drop.
+struct TempDbCopy {
+    dir: PathBuf,
+    db_path: PathBuf,
+}
+
+impl TempDbCopy {
+    fn new(src: &Path) -> Result<Self> {
+        let file_name = src
+            .file_name()
+            .ok_or_else(|| anyhow!("Invalid OpenCode DB path: {}", src.display()))?;
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let dir =
+            std::env::temp_dir().join(format!("vct-opencode-{}-{}", std::process::id(), nanos));
+        std::fs::create_dir_all(&dir)
+            .with_context(|| format!("Failed to create temp dir {}", dir.display()))?;
+
+        let db_path = dir.join(file_name);
+        std::fs::copy(src, &db_path)
+            .with_context(|| format!("Failed to copy OpenCode DB from {}", src.display()))?;
+
+        // Best-effort copy of the WAL sidecars so recently committed rows are
+        // visible; absence is fine for a checkpointed database.
+        for suffix in ["-wal", "-shm"] {
+            let sidecar = append_suffix(src, suffix);
+            if sidecar.exists() {
+                let _ = std::fs::copy(&sidecar, append_suffix(&db_path, suffix));
+            }
+        }
+
+        Ok(Self { dir, db_path })
+    }
+}
+
+impl Drop for TempDbCopy {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.dir);
+    }
+}
+
+/// Appends a raw suffix to a path's final component (e.g. `db` -> `db-wal`).
+fn append_suffix(path: &Path, suffix: &str) -> PathBuf {
+    let mut os: OsString = path.as_os_str().to_owned();
+    os.push(suffix);
+    PathBuf::from(os)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_db() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("opencode.db");
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE session (
+                 id TEXT PRIMARY KEY,
+                 model TEXT,
+                 directory TEXT,
+                 time_updated INTEGER NOT NULL,
+                 tokens_input INTEGER NOT NULL DEFAULT 0,
+                 tokens_output INTEGER NOT NULL DEFAULT 0,
+                 tokens_reasoning INTEGER NOT NULL DEFAULT 0,
+                 tokens_cache_read INTEGER NOT NULL DEFAULT 0,
+                 tokens_cache_write INTEGER NOT NULL DEFAULT 0
+             );
+             CREATE TABLE part (
+                 id TEXT PRIMARY KEY,
+                 session_id TEXT NOT NULL,
+                 data TEXT NOT NULL
+             );",
+        )
+        .unwrap();
+        (dir, db_path)
+    }
+
+    #[test]
+    fn test_parse_model_id() {
+        assert_eq!(
+            parse_model_id(r#"{"id":"deepseek-v4-pro","providerID":"deepseek"}"#).as_deref(),
+            Some("deepseek-v4-pro")
+        );
+        assert_eq!(
+            parse_model_id("gemini-3.5-flash").as_deref(),
+            Some("gemini-3.5-flash")
+        );
+        assert_eq!(parse_model_id(r#"{"providerID":"x"}"#), None);
+        assert_eq!(parse_model_id("   "), None);
+    }
+
+    #[test]
+    fn test_extract_read_content() {
+        let output = "<path>/a/b.py</path>\n<type>file</type>\n<content>\n1: import os\n2: \n3: print(1)\n</content>";
+        assert_eq!(extract_read_content(output), "import os\n\nprint(1)");
+
+        // Directory listing has no <content> block.
+        let dir_output = "<path>/a</path>\n<type>directory</type>\n<entries>\nx.py\n</entries>";
+        assert_eq!(extract_read_content(dir_output), "");
+    }
+
+    #[test]
+    fn test_strip_line_number_prefix() {
+        assert_eq!(strip_line_number_prefix("12: hello"), "hello");
+        assert_eq!(strip_line_number_prefix("1: 2: nested"), "2: nested");
+        assert_eq!(strip_line_number_prefix("no prefix"), "no prefix");
+    }
+
+    #[test]
+    fn test_read_usage_maps_tokens() {
+        let (_dir, db_path) = make_db();
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute(
+            "INSERT INTO session (id, model, directory, time_updated, tokens_input, tokens_output, tokens_reasoning, tokens_cache_read, tokens_cache_write)
+             VALUES ('s1', '{\"id\":\"deepseek-v4-pro\"}', '/repo', 1780757088080, 100, 50, 7, 200, 25)",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+
+        let rows = read_opencode_usage(&db_path, TimeRange::All).unwrap();
+        assert_eq!(rows.len(), 1);
+        let (_date, analysis) = &rows[0];
+        assert_eq!(analysis.extension_name, "OpenCode");
+        let usage = &analysis.records[0].conversation_usage["deepseek-v4-pro"];
+        assert_eq!(usage["input_tokens"], 100);
+        assert_eq!(usage["output_tokens"], 50);
+        assert_eq!(usage["reasoning_output_tokens"], 7);
+        assert_eq!(usage["cache_read_input_tokens"], 200);
+        assert_eq!(usage["cache_creation_input_tokens"], 25);
+    }
+
+    #[test]
+    fn test_time_range_filters_old_sessions() {
+        let (_dir, db_path) = make_db();
+        let conn = Connection::open(&db_path).unwrap();
+        let now_ms = chrono::Local::now().timestamp_millis();
+        // One session today, one well in the past.
+        conn.execute(
+            "INSERT INTO session (id, model, directory, time_updated, tokens_input) VALUES ('recent', '{\"id\":\"m1\"}', '/repo', ?1, 10)",
+            rusqlite::params![now_ms],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO session (id, model, directory, time_updated, tokens_input) VALUES ('old', '{\"id\":\"m1\"}', '/repo', 1000000000000, 10)",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+
+        let all = read_opencode_usage(&db_path, TimeRange::All).unwrap();
+        assert_eq!(all.len(), 2);
+
+        let daily = read_opencode_usage(&db_path, TimeRange::Daily).unwrap();
+        assert_eq!(daily.len(), 1);
+    }
+
+    #[test]
+    fn test_read_analysis_counts_tools() {
+        let (_dir, db_path) = make_db();
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute(
+            "INSERT INTO session (id, model, directory, time_updated) VALUES ('s1', '{\"id\":\"m1\"}', '/repo', 1780757088080)",
+            [],
+        )
+        .unwrap();
+        let parts = [
+            r#"{"type":"tool","tool":"read","state":{"status":"completed","input":{"filePath":"/repo/a.py"},"output":"<path>/repo/a.py</path>\n<type>file</type>\n<content>\n1: one\n2: two\n</content>"}}"#,
+            r#"{"type":"tool","tool":"edit","state":{"status":"completed","input":{"filePath":"/repo/a.py","oldString":"one","newString":"uno\ndos"}}}"#,
+            r#"{"type":"tool","tool":"bash","state":{"status":"completed","input":{"command":"ls -la","description":"list"}}}"#,
+            r#"{"type":"tool","tool":"todowrite","state":{"status":"completed","input":{"todos":[]}}}"#,
+            r#"{"type":"tool","tool":"grep","state":{"status":"completed","input":{"pattern":"x"}}}"#,
+            r#"{"type":"text","text":"ignored"}"#,
+        ];
+        for (i, p) in parts.iter().enumerate() {
+            conn.execute(
+                "INSERT INTO part (id, session_id, data) VALUES (?1, 's1', ?2)",
+                rusqlite::params![format!("p{i}"), p],
+            )
+            .unwrap();
+        }
+        drop(conn);
+
+        let rows = read_opencode_analysis(&db_path, TimeRange::All, ParseMode::UsageOnly).unwrap();
+        assert_eq!(rows.len(), 1);
+        let record = &rows[0].1.records[0];
+        assert_eq!(record.tool_call_counts.read, 1);
+        assert_eq!(record.tool_call_counts.edit, 1);
+        assert_eq!(record.tool_call_counts.bash, 1);
+        assert_eq!(record.tool_call_counts.todo_write, 1);
+        assert_eq!(record.total_read_lines, 2);
+        assert_eq!(record.total_edit_lines, 2);
+        // grep / text parts are not tracked.
+        assert_eq!(record.tool_call_counts.write, 0);
+    }
+}

--- a/src/session/opencode.rs
+++ b/src/session/opencode.rs
@@ -143,32 +143,40 @@ fn collect_analysis(
     let user = get_current_user();
     let machine = get_machine_id().to_string();
     let cutoff = cutoff_string(time_range);
+    let cutoff_ms = cutoff_millis(time_range);
 
     // 1. Load session metadata and seed one parse state per session.
     let mut sessions: HashMap<String, SessionAccum> = HashMap::new();
     {
-        let mut stmt = conn.prepare(
-            "SELECT id, model, directory, time_updated, tokens_input, tokens_output, \
-                    tokens_reasoning, tokens_cache_read, tokens_cache_write \
-             FROM session WHERE model IS NOT NULL AND model != ''",
-        )?;
-        let rows = stmt.query_map([], |row| {
-            Ok((
-                row.get::<_, String>(0)?,
-                row.get::<_, String>(1)?,
-                row.get::<_, String>(2)?,
-                row.get::<_, i64>(3)?,
-                row.get::<_, i64>(4)?,
-                row.get::<_, i64>(5)?,
-                row.get::<_, i64>(6)?,
-                row.get::<_, i64>(7)?,
-                row.get::<_, i64>(8)?,
-            ))
-        })?;
+        let sql = match cutoff_ms {
+            Some(_) => {
+                "SELECT id, model, directory, time_updated, tokens_input, tokens_output, \
+                        tokens_reasoning, tokens_cache_read, tokens_cache_write \
+                 FROM session \
+                 WHERE model IS NOT NULL AND model != '' AND time_updated >= ?1"
+            }
+            None => {
+                "SELECT id, model, directory, time_updated, tokens_input, tokens_output, \
+                        tokens_reasoning, tokens_cache_read, tokens_cache_write \
+                 FROM session WHERE model IS NOT NULL AND model != ''"
+            }
+        };
+        let mut stmt = conn.prepare(sql)?;
+        let mut rows = match cutoff_ms {
+            Some(cutoff_ms) => stmt.query([cutoff_ms])?,
+            None => stmt.query([])?,
+        };
 
-        for row in rows {
-            let (id, model, directory, ts, input, output, reasoning, cache_read, cache_write) =
-                row?;
+        while let Some(row) = rows.next()? {
+            let id = row.get::<_, String>(0)?;
+            let model = row.get::<_, String>(1)?;
+            let directory = row.get::<_, String>(2)?;
+            let ts = row.get::<_, i64>(3)?;
+            let input = row.get::<_, i64>(4)?;
+            let output = row.get::<_, i64>(5)?;
+            let reasoning = row.get::<_, i64>(6)?;
+            let cache_read = row.get::<_, i64>(7)?;
+            let cache_write = row.get::<_, i64>(8)?;
             let Some(model_id) = parse_model_id(&model) else {
                 continue;
             };
@@ -196,15 +204,31 @@ fn collect_analysis(
 
     // 2. Fold tool parts into their owning session's parse state.
     {
-        let mut stmt = conn.prepare(
-            "SELECT session_id, data FROM part WHERE json_extract(data, '$.type') = 'tool'",
-        )?;
-        let rows = stmt.query_map([], |row| {
-            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-        })?;
+        let sql = match cutoff_ms {
+            Some(_) => {
+                "SELECT part.session_id, part.data \
+                 FROM part \
+                 JOIN session ON session.id = part.session_id \
+                 WHERE json_extract(part.data, '$.type') = 'tool' \
+                   AND session.model IS NOT NULL \
+                   AND session.model != '' \
+                   AND session.time_updated >= ?1"
+            }
+            None => {
+                "SELECT session_id, data \
+                 FROM part \
+                 WHERE json_extract(data, '$.type') = 'tool'"
+            }
+        };
+        let mut stmt = conn.prepare(sql)?;
+        let mut rows = match cutoff_ms {
+            Some(cutoff_ms) => stmt.query([cutoff_ms])?,
+            None => stmt.query([])?,
+        };
 
-        for row in rows {
-            let (session_id, data_text) = row?;
+        while let Some(row) = rows.next()? {
+            let session_id = row.get::<_, String>(0)?;
+            let data_text = row.get::<_, String>(1)?;
             let Some(accum) = sessions.get_mut(&session_id) else {
                 continue;
             };
@@ -348,6 +372,18 @@ fn cutoff_string(time_range: TimeRange) -> Option<String> {
     time_range
         .cutoff_date()
         .map(|d| d.format("%Y-%m-%d").to_string())
+}
+
+/// Converts the inclusive local-date cutoff into an epoch-millis lower bound.
+fn cutoff_millis(time_range: TimeRange) -> Option<i64> {
+    use chrono::{Datelike, TimeZone};
+
+    time_range.cutoff_date().and_then(|date| {
+        chrono::Local
+            .with_ymd_and_hms(date.year(), date.month(), date.day(), 0, 0, 0)
+            .earliest()
+            .map(|dt| dt.timestamp_millis())
+    })
 }
 
 /// Returns `true` when `date` is strictly before the cutoff (should be skipped).

--- a/src/session/parser.rs
+++ b/src/session/parser.rs
@@ -397,6 +397,9 @@ fn dispatch_streaming_buffered(
             let rest_events = iter_jsonl_values(&mut reader);
             parse_gemini_events(session, iter.chain(rest_events), mode)
         }
+        // OpenCode stores sessions in a SQLite database, not a JSONL file, so
+        // it never flows through the file parser. See `session::opencode`.
+        ExtensionType::OpenCode => Ok(empty_analysis()),
     }
 }
 
@@ -450,10 +453,11 @@ fn dispatch_by_vec(
                 .collect();
             parse_codex_logs(&logs, mode)?
         }
-        ExtensionType::Copilot | ExtensionType::Gemini => {
-            // Both providers only support the JSONL event stream. A file
-            // that falls through to this branch (e.g. a stray pretty-
-            // printed export) has no parser for its shape — return an
+        ExtensionType::Copilot | ExtensionType::Gemini | ExtensionType::OpenCode => {
+            // Copilot/Gemini only support the JSONL event stream, and OpenCode
+            // is read from a SQLite database (see `session::opencode`), not a
+            // file. A file that falls through to this branch (e.g. a stray
+            // pretty-printed export) has no parser for its shape — return an
             // empty analysis instead of silently mis-parsing.
             empty_analysis()
         }

--- a/src/session/state.rs
+++ b/src/session/state.rs
@@ -218,19 +218,28 @@ impl SessionParseState {
     ///
     /// When `old` is empty but `new` is not, the edit is reclassified as a
     /// `Write` (a new-file creation expressed as a diff) and forwarded to
-    /// [`SessionParseState::add_write_detail`]. Otherwise the line/character
-    /// tally is taken from the trimmed `new` content. No-op when `path`
-    /// normalizes to an empty string; full detail stored only in
-    /// [`ParseMode::Full`].
+    /// [`SessionParseState::add_write_detail`]. Otherwise delegates to
+    /// [`SessionParseState::add_edit_detail_raw`].
     pub fn add_edit_detail(&mut self, path: &str, old: &str, new: &str, ts: i64) {
-        let trimmed_new = new.trim_end_matches('\n');
-        let trimmed_old = old.trim_end_matches('\n');
-
         // If old is empty and new has content, treat as write
-        if trimmed_old.is_empty() && !trimmed_new.is_empty() {
+        if old.trim_end_matches('\n').is_empty() && !new.trim_end_matches('\n').is_empty() {
             self.add_write_detail(path, new, ts);
             return;
         }
+
+        self.add_edit_detail_raw(path, old, new, ts);
+    }
+
+    /// Records an `Edit` operation against `path` without the new-file
+    /// reclassification in [`SessionParseState::add_edit_detail`].
+    ///
+    /// Used for patch hunks that update an existing file, where an empty `old`
+    /// just means an insert-only hunk. The line/character tally is taken from
+    /// the trimmed `new` content. No-op when `path` normalizes to an empty
+    /// string; full detail stored only in [`ParseMode::Full`].
+    pub fn add_edit_detail_raw(&mut self, path: &str, old: &str, new: &str, ts: i64) {
+        let trimmed_new = new.trim_end_matches('\n');
+        let trimmed_old = old.trim_end_matches('\n');
 
         let line_count = count_lines(trimmed_new);
         let char_count = trimmed_new.chars().count();

--- a/src/usage/calculator.rs
+++ b/src/usage/calculator.rs
@@ -62,11 +62,12 @@ pub struct UsageData {
     /// Count of distinct calendar dates that contributed usage, per provider
     /// and overall.
     pub provider_days: ProviderActiveDays,
-    /// OpenCode's own per-model cost (USD), summed from `session.cost`.
+    /// OpenCode's own per-model cost (USD), summed from assistant messages.
     ///
-    /// OpenCode records an authoritative cost per session, so when a model has
-    /// no exact LiteLLM price we display this stored cost instead of guessing
-    /// from a fuzzy match. Keyed by model name; only OpenCode models appear.
+    /// OpenCode records authoritative assistant-message costs, so when a model
+    /// has no exact LiteLLM price we display this stored cost instead of
+    /// guessing from a fuzzy match. Keyed by model name; only OpenCode models
+    /// appear.
     pub opencode_costs: FastHashMap<String, f64>,
 }
 
@@ -337,8 +338,6 @@ fn process_opencode_usage(
         unique_dates.insert(date);
 
         let conversation_usage = extract_conversation_usage_from_analysis(&analysis);
-        // An OpenCode session is single-model, so the whole `session.cost`
-        // belongs to that one model.
         for (model, usage_value) in conversation_usage {
             *opencode_costs.entry(model.clone()).or_insert(0.0) += session_cost;
 

--- a/src/usage/calculator.rs
+++ b/src/usage/calculator.rs
@@ -190,20 +190,20 @@ pub fn get_usage_from_directories(time_range: TimeRange) -> Result<UsageData> {
 
     // OpenCode lives in a single SQLite database rather than a session
     // directory, so it is read directly instead of walked.
-    if paths.opencode_db.exists() {
-        if let Err(err) = process_opencode_usage(
+    if paths.opencode_db.exists()
+        && let Err(err) = process_opencode_usage(
             &paths.opencode_db,
             &mut result,
             &mut per_provider.opencode,
             &mut opencode_costs,
             &mut opencode_dates,
             time_range,
-        ) {
-            eprintln!(
-                "Warning: Failed to read OpenCode DB {}: {err}",
-                paths.opencode_db.display()
-            );
-        }
+        )
+    {
+        eprintln!(
+            "Warning: Failed to read OpenCode DB {}: {err}",
+            paths.opencode_db.display()
+        );
     }
 
     let mut all_dates: HashSet<&String> = HashSet::new();

--- a/src/usage/calculator.rs
+++ b/src/usage/calculator.rs
@@ -96,8 +96,8 @@ fn extract_conversation_usage_from_analysis(analysis: &CodeAnalysis) -> FastHash
 /// Scans the Claude Code, Codex, Copilot, and Gemini session trees resolved by
 /// [`resolve_paths`], filtered by `time_range`, and rolls every session's
 /// per-model usage into a [`UsageData`]. Missing provider directories are
-/// skipped silently, and a session file that fails to parse logs a warning to
-/// stderr and is excluded rather than aborting the whole scan.
+/// skipped silently, and a source file or OpenCode database that fails to parse
+/// logs a warning to stderr and is excluded rather than aborting the whole scan.
 ///
 /// # Errors
 ///
@@ -191,14 +191,19 @@ pub fn get_usage_from_directories(time_range: TimeRange) -> Result<UsageData> {
     // OpenCode lives in a single SQLite database rather than a session
     // directory, so it is read directly instead of walked.
     if paths.opencode_db.exists() {
-        process_opencode_usage(
+        if let Err(err) = process_opencode_usage(
             &paths.opencode_db,
             &mut result,
             &mut per_provider.opencode,
             &mut opencode_costs,
             &mut opencode_dates,
             time_range,
-        )?;
+        ) {
+            eprintln!(
+                "Warning: Failed to read OpenCode DB {}: {err}",
+                paths.opencode_db.display()
+            );
+        }
     }
 
     let mut all_dates: HashSet<&String> = HashSet::new();

--- a/src/usage/calculator.rs
+++ b/src/usage/calculator.rs
@@ -13,7 +13,7 @@ use crate::constants::{FastHashMap, capacity};
 use crate::models::{
     CodeAnalysis, ExtensionType, PerProviderUsage, Provider, ProviderActiveDays, UsageResult,
 };
-use crate::session::{ParseMode, parse_session_file_as};
+use crate::session::{ParseMode, parse_session_file_as, read_opencode_usage};
 use crate::utils::{
     COPILOT_SESSION_MAX_DEPTH, collect_files_with_max_depth, is_claude_session_file,
     is_codex_session_file, is_copilot_session_file, is_gemini_session_file, resolve_paths,
@@ -118,6 +118,7 @@ pub fn get_usage_from_directories(time_range: TimeRange) -> Result<UsageData> {
     let mut codex_dates: HashSet<String> = HashSet::new();
     let mut copilot_dates: HashSet<String> = HashSet::new();
     let mut gemini_dates: HashSet<String> = HashSet::new();
+    let mut opencode_dates: HashSet<String> = HashSet::new();
 
     if paths.claude_session_dir.exists() {
         // Walks the projects tree recursively, so top-level `<session>.jsonl` logs
@@ -178,17 +179,31 @@ pub fn get_usage_from_directories(time_range: TimeRange) -> Result<UsageData> {
         )?;
     }
 
+    // OpenCode lives in a single SQLite database rather than a session
+    // directory, so it is read directly instead of walked.
+    if paths.opencode_db.exists() {
+        process_opencode_usage(
+            &paths.opencode_db,
+            &mut result,
+            &mut per_provider.opencode,
+            &mut opencode_dates,
+            time_range,
+        )?;
+    }
+
     let mut all_dates: HashSet<&String> = HashSet::new();
     all_dates.extend(claude_dates.iter());
     all_dates.extend(codex_dates.iter());
     all_dates.extend(copilot_dates.iter());
     all_dates.extend(gemini_dates.iter());
+    all_dates.extend(opencode_dates.iter());
 
     let provider_days = ProviderActiveDays {
         claude: claude_dates.len(),
         codex: codex_dates.len(),
         copilot: copilot_dates.len(),
         gemini: gemini_dates.len(),
+        opencode: opencode_dates.len(),
         total: all_dates.len(),
     };
 
@@ -271,6 +286,46 @@ where
     for (date, conversation_usage) in file_results {
         unique_dates.insert(date);
 
+        for (model, usage_value) in conversation_usage {
+            provider_result
+                .entry(model.clone())
+                .and_modify(|existing| merge_usage_values(existing, &usage_value))
+                .or_insert_with(|| usage_value.clone());
+
+            global_result
+                .entry(model)
+                .and_modify(|existing| merge_usage_values(existing, &usage_value))
+                .or_insert(usage_value);
+        }
+    }
+
+    Ok(())
+}
+
+/// Reads OpenCode's SQLite database and merges its per-model usage into both
+/// the global and OpenCode-scoped maps.
+///
+/// Mirrors the tail of [`process_usage_directory`] but sources sessions from
+/// the database (via [`read_opencode_usage`]) instead of a directory walk. Each
+/// session's `time_updated` date is recorded in `unique_dates` for the
+/// active-day count.
+///
+/// # Errors
+///
+/// Returns an error if the database cannot be opened or queried.
+fn process_opencode_usage(
+    db_path: &Path,
+    global_result: &mut UsageResult,
+    provider_result: &mut UsageResult,
+    unique_dates: &mut HashSet<String>,
+    time_range: TimeRange,
+) -> Result<()> {
+    let sessions = read_opencode_usage(db_path, time_range)?;
+
+    for (date, analysis) in sessions {
+        unique_dates.insert(date);
+
+        let conversation_usage = extract_conversation_usage_from_analysis(&analysis);
         for (model, usage_value) in conversation_usage {
             provider_result
                 .entry(model.clone())

--- a/src/usage/calculator.rs
+++ b/src/usage/calculator.rs
@@ -13,9 +13,10 @@ use crate::constants::{FastHashMap, capacity};
 use crate::models::{
     CodeAnalysis, ExtensionType, PerProviderUsage, Provider, ProviderActiveDays, UsageResult,
 };
+use crate::pricing::{ModelPricingMap, calculate_cost};
 use crate::session::{ParseMode, parse_session_file_as, read_opencode_usage};
 use crate::utils::{
-    COPILOT_SESSION_MAX_DEPTH, collect_files_with_max_depth, is_claude_session_file,
+    COPILOT_SESSION_MAX_DEPTH, TokenCounts, collect_files_with_max_depth, is_claude_session_file,
     is_codex_session_file, is_copilot_session_file, is_gemini_session_file, resolve_paths,
 };
 use anyhow::Result;
@@ -61,6 +62,12 @@ pub struct UsageData {
     /// Count of distinct calendar dates that contributed usage, per provider
     /// and overall.
     pub provider_days: ProviderActiveDays,
+    /// OpenCode's own per-model cost (USD), summed from `session.cost`.
+    ///
+    /// OpenCode records an authoritative cost per session, so when a model has
+    /// no exact LiteLLM price we display this stored cost instead of guessing
+    /// from a fuzzy match. Keyed by model name; only OpenCode models appear.
+    pub opencode_costs: FastHashMap<String, f64>,
 }
 
 /// Extracts token usage data from a typed `CodeAnalysis`.
@@ -113,6 +120,7 @@ pub fn get_usage_from_directories(time_range: TimeRange) -> Result<UsageData> {
     let paths = resolve_paths()?;
     let mut result = FastHashMap::with_capacity(capacity::MODEL_COMBINATIONS);
     let mut per_provider = PerProviderUsage::default();
+    let mut opencode_costs: FastHashMap<String, f64> = FastHashMap::default();
 
     let mut claude_dates: HashSet<String> = HashSet::new();
     let mut codex_dates: HashSet<String> = HashSet::new();
@@ -186,6 +194,7 @@ pub fn get_usage_from_directories(time_range: TimeRange) -> Result<UsageData> {
             &paths.opencode_db,
             &mut result,
             &mut per_provider.opencode,
+            &mut opencode_costs,
             &mut opencode_dates,
             time_range,
         )?;
@@ -211,6 +220,7 @@ pub fn get_usage_from_directories(time_range: TimeRange) -> Result<UsageData> {
         models: result,
         per_provider,
         provider_days,
+        opencode_costs,
     })
 }
 
@@ -317,16 +327,21 @@ fn process_opencode_usage(
     db_path: &Path,
     global_result: &mut UsageResult,
     provider_result: &mut UsageResult,
+    opencode_costs: &mut FastHashMap<String, f64>,
     unique_dates: &mut HashSet<String>,
     time_range: TimeRange,
 ) -> Result<()> {
     let sessions = read_opencode_usage(db_path, time_range)?;
 
-    for (date, analysis) in sessions {
+    for (date, analysis, session_cost) in sessions {
         unique_dates.insert(date);
 
         let conversation_usage = extract_conversation_usage_from_analysis(&analysis);
+        // An OpenCode session is single-model, so the whole `session.cost`
+        // belongs to that one model.
         for (model, usage_value) in conversation_usage {
+            *opencode_costs.entry(model.clone()).or_insert(0.0) += session_cost;
+
             provider_result
                 .entry(model.clone())
                 .and_modify(|existing| merge_usage_values(existing, &usage_value))
@@ -340,6 +355,49 @@ fn process_opencode_usage(
     }
 
     Ok(())
+}
+
+/// Resolves the USD cost (and optional matched-model annotation) for one model.
+///
+/// Behavior depends on `opencode_cost`:
+/// - `None` (every provider except OpenCode): the existing LiteLLM lookup,
+///   which includes exact, normalized, substring, and fuzzy matching.
+/// - `Some(stored)` (OpenCode): only an **exact** LiteLLM match is computed
+///   from tokens; otherwise the model's stored OpenCode cost is used verbatim.
+///   No fuzzy/normalized guessing happens, so a novel model like
+///   `deepseek-v4-pro` reports OpenCode's own cost instead of being priced
+///   against a loosely-similar model.
+///
+/// Returns `(cost_usd, matched_model)` where `matched_model` is `Some` only
+/// when a non-exact LiteLLM key was used (for display annotation).
+pub fn resolve_model_cost(
+    model: &str,
+    counts: &TokenCounts,
+    pricing_map: &ModelPricingMap,
+    opencode_cost: Option<f64>,
+) -> (f64, Option<String>) {
+    let priced = |pricing: &crate::pricing::ModelPricing| {
+        calculate_cost(
+            counts.input_tokens,
+            counts.output_tokens,
+            counts.reasoning_tokens,
+            counts.cache_read,
+            counts.cache_creation_5m,
+            counts.cache_creation_1h,
+            pricing,
+        )
+    };
+
+    if let Some(stored) = opencode_cost {
+        // OpenCode: only trust an exact price match; otherwise use its own cost.
+        return match pricing_map.get_exact(model) {
+            Some(pricing) => (priced(&pricing), None),
+            None => (stored, None),
+        };
+    }
+
+    let result = pricing_map.get(model);
+    (priced(&result.pricing), result.matched_model)
 }
 
 impl UsageData {
@@ -396,5 +454,63 @@ fn merge_usage_values(existing: &mut Value, new: &Value) {
         {
             accumulate_nested_object(existing_obj, "total_token_usage", new_total);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pricing::{ModelPricing, clear_pricing_cache};
+    use std::collections::HashMap;
+
+    fn map_with_gpt4() -> ModelPricingMap {
+        let mut raw = HashMap::new();
+        raw.insert(
+            "gpt-4".to_string(),
+            ModelPricing {
+                input_cost_per_token: 1e-5,
+                ..Default::default()
+            },
+        );
+        ModelPricingMap::new(raw)
+    }
+
+    fn counts(input: i64) -> TokenCounts {
+        TokenCounts {
+            input_tokens: input,
+            total: input,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_opencode_exact_match_computes_from_tokens() {
+        clear_pricing_cache();
+        let map = map_with_gpt4();
+        // Exact LiteLLM price exists -> compute from tokens, ignore stored cost.
+        let (cost, matched) = resolve_model_cost("gpt-4", &counts(1_000_000), &map, Some(99.0));
+        assert!((cost - 10.0).abs() < 1e-6); // 1e6 * 1e-5
+        assert!(matched.is_none());
+    }
+
+    #[test]
+    fn test_opencode_no_exact_match_uses_stored_cost() {
+        clear_pricing_cache();
+        let map = map_with_gpt4();
+        // No exact price; OpenCode must NOT fuzzy match -> use stored cost.
+        let (cost, matched) =
+            resolve_model_cost("deepseek-v4-pro", &counts(1_000_000), &map, Some(99.0));
+        assert!((cost - 99.0).abs() < 1e-9);
+        assert!(matched.is_none());
+    }
+
+    #[test]
+    fn test_non_opencode_keeps_existing_lookup() {
+        clear_pricing_cache();
+        let map = map_with_gpt4();
+        // Non-OpenCode path is unchanged: exact match still computes.
+        let (cost, matched) = resolve_model_cost("gpt-4", &counts(1_000_000), &map, None);
+        assert!((cost - 10.0).abs() < 1e-6);
+        assert!(matched.is_none());
     }
 }

--- a/src/usage/calculator.rs
+++ b/src/usage/calculator.rs
@@ -323,8 +323,9 @@ where
 ///
 /// Mirrors the tail of [`process_usage_directory`] but sources sessions from
 /// the database (via [`read_opencode_usage`]) instead of a directory walk. Each
-/// session's `time_updated` date is recorded in `unique_dates` for the
-/// active-day count.
+/// row's date comes from the assistant message timestamp (falling back to
+/// `session.time_updated` on legacy schemas) and is recorded in `unique_dates`
+/// for the active-day count.
 ///
 /// # Errors
 ///

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -30,7 +30,7 @@ pub use paths::{
     get_pricing_cache_path, list_pricing_cache_files, resolve_paths,
 };
 pub use time::parse_iso_timestamp;
-pub use token_extractor::extract_token_counts;
+pub use token_extractor::{TokenCounts, extract_token_counts};
 pub use usage_processor::{
     accumulate_i64_fields, accumulate_nested_object, process_claude_usage, process_codex_usage,
     process_gemini_usage,

--- a/src/utils/paths.rs
+++ b/src/utils/paths.rs
@@ -33,6 +33,10 @@ pub struct HelperPaths {
     pub gemini_dir: PathBuf,
     /// Gemini CLI session logs (`~/.gemini/tmp`).
     pub gemini_session_dir: PathBuf,
+    /// OpenCode data root (`$XDG_DATA_HOME/opencode` or `~/.local/share/opencode`).
+    pub opencode_dir: PathBuf,
+    /// OpenCode SQLite database (`<opencode_dir>/opencode.db`).
+    pub opencode_db: PathBuf,
     /// This tool's cache directory (`~/.vibe_coding_tracker`).
     pub cache_dir: PathBuf,
 }
@@ -63,6 +67,14 @@ pub fn resolve_paths() -> Result<HelperPaths> {
     let copilot_session_dir = copilot_dir.join("session-state");
     let gemini_dir = home_dir.join(".gemini");
     let gemini_session_dir = gemini_dir.join("tmp");
+    // OpenCode keeps a single SQLite database under the XDG data directory,
+    // honouring `$XDG_DATA_HOME` and falling back to `~/.local/share`.
+    let opencode_dir = std::env::var_os("XDG_DATA_HOME")
+        .map(PathBuf::from)
+        .filter(|p| p.is_absolute())
+        .unwrap_or_else(|| home_dir.join(".local").join("share"))
+        .join("opencode");
+    let opencode_db = opencode_dir.join("opencode.db");
     let cache_dir = home_dir.join(".vibe_coding_tracker");
 
     Ok(HelperPaths {
@@ -75,6 +87,8 @@ pub fn resolve_paths() -> Result<HelperPaths> {
         copilot_session_dir,
         gemini_dir,
         gemini_session_dir,
+        opencode_dir,
+        opencode_db,
         cache_dir,
     })
 }
@@ -295,6 +309,10 @@ mod tests {
 
         // Gemini paths
         assert_eq!(paths.gemini_session_dir, paths.gemini_dir.join("tmp"));
+
+        // OpenCode paths
+        assert_eq!(paths.opencode_db, paths.opencode_dir.join("opencode.db"));
+        assert!(paths.opencode_dir.ends_with("opencode"));
     }
 
     #[test]

--- a/tests/cache.rs
+++ b/tests/cache.rs
@@ -2,12 +2,14 @@
 //
 // These tests verify the LRU file parsing cache and pricing cache
 
+use serial_test::serial;
 use std::path::PathBuf;
 use tempfile::TempDir;
 use vibe_coding_tracker::cache::global_cache;
 use vibe_coding_tracker::pricing::clear_pricing_cache;
 
 #[test]
+#[serial(global_cache)]
 fn test_file_cache_basic_operations() {
     let cache = global_cache();
 
@@ -21,6 +23,7 @@ fn test_file_cache_basic_operations() {
 }
 
 #[test]
+#[serial(global_cache)]
 fn test_file_cache_get_or_parse() {
     let example_file = PathBuf::from("examples/test_conversation_claude_code.jsonl");
 
@@ -50,6 +53,7 @@ fn test_file_cache_get_or_parse() {
 }
 
 #[test]
+#[serial(global_cache)]
 fn test_file_cache_invalidation() {
     use std::io::Write;
 
@@ -79,6 +83,7 @@ fn test_file_cache_invalidation() {
 }
 
 #[test]
+#[serial(global_cache)]
 fn test_file_cache_clear() {
     let cache = global_cache();
 
@@ -96,6 +101,7 @@ fn test_file_cache_clear() {
 }
 
 #[test]
+#[serial(global_cache)]
 fn test_file_cache_stats() {
     let cache = global_cache();
     cache.clear();
@@ -121,6 +127,7 @@ fn test_file_cache_stats() {
 }
 
 #[test]
+#[serial(global_cache)]
 fn test_file_cache_cleanup_stale() {
     let temp_dir = TempDir::new().unwrap();
     let test_file = temp_dir.path().join("temp.jsonl");
@@ -142,6 +149,7 @@ fn test_file_cache_cleanup_stale() {
 }
 
 #[test]
+#[serial(global_cache)]
 fn test_file_cache_concurrent_access() {
     use std::sync::Arc;
     use std::thread;
@@ -174,6 +182,7 @@ fn test_file_cache_concurrent_access() {
 }
 
 #[test]
+#[serial(global_cache)]
 fn test_file_cache_multiple_files() {
     let cache = global_cache();
 
@@ -204,6 +213,7 @@ fn test_file_cache_multiple_files() {
 }
 
 #[test]
+#[serial(global_cache)]
 fn test_file_cache_lru_eviction() {
     // This test verifies that LRU eviction works (implicitly through capacity limits)
     // The actual LRU capacity is set in constants.rs
@@ -237,6 +247,7 @@ fn test_pricing_cache_clear() {
 }
 
 #[test]
+#[serial(global_cache)]
 fn test_file_cache_invalidate_specific_file() {
     let example_file = PathBuf::from("examples/test_conversation_claude_code.jsonl");
 
@@ -259,6 +270,7 @@ fn test_file_cache_invalidate_specific_file() {
 }
 
 #[test]
+#[serial(global_cache)]
 fn test_cache_with_nonexistent_file() {
     let nonexistent = PathBuf::from("nonexistent_file_12345.jsonl");
 
@@ -269,6 +281,7 @@ fn test_cache_with_nonexistent_file() {
 }
 
 #[test]
+#[serial(global_cache)]
 fn test_cache_with_directory() {
     let dir = PathBuf::from("examples");
 
@@ -279,6 +292,7 @@ fn test_cache_with_directory() {
 }
 
 #[test]
+#[serial(global_cache)]
 fn test_cache_memory_estimation() {
     let cache = global_cache();
     cache.clear();
@@ -301,6 +315,7 @@ fn test_cache_memory_estimation() {
 }
 
 #[test]
+#[serial(global_cache)]
 fn test_cache_arc_sharing() {
     use std::sync::Arc;
 


### PR DESCRIPTION
## Summary

- Add OpenCode as a fifth supported provider, alongside Claude Code, Codex, Copilot CLI, and Gemini CLI.
- OpenCode stores sessions in a single SQLite database at `~/.local/share/opencode/opencode.db` (honoring `$XDG_DATA_HOME`). A new `src/session/opencode.rs` opens the database read-only via `rusqlite` (bundled SQLite) and produces the same `CodeAnalysis` shape the other providers do.
- OpenCode usage is read from assistant messages so sessions that switch models are split by a provider-qualified message model key when `providerID` is available.
- OpenCode usage and analysis use assistant message timestamps for time-range filtering, so resumed old sessions are not pulled into short windows only because `session.time_updated` changed.
- OpenCode analysis folds completed tool parts from `message` + `part`, attributes them to the assistant message model, counts `apply_patch` tools from `state.input.patchText`, and stops plain read parsing before status footers.
- Docs updated across `README.md`, `README.zh-CN.md`, `README.zh-TW.md`, and `CLAUDE.md`.

## Cost handling for OpenCode

- OpenCode models are priced from tokens only on an **exact** LiteLLM match. With no exact match, OpenCode's own assistant-message cost is used instead of normalized, substring, or fuzzy LiteLLM fallback.
- OpenCode model keys preserve `providerID/modelID` when a provider is available, so identical bare model IDs from different backends stay separated.
- The stored-cost fallback is scoped to OpenCode provider usage only. If the same model also appears in another provider, the non-OpenCode portion is still priced through the normal LiteLLM matching path.
- This avoids mis-pricing novel models such as `deepseek-v4-pro` while still allowing exact-match models to compute from tokens.

## Implementation notes

- Assistant-message token columns map onto the Claude-style flat usage shape (`input_tokens`, `output_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens`, `reasoning_output_tokens`) so the existing merge and cost path works unchanged.
- The database is opened read-only and never mutated; a temp-copy fallback copies the database (plus WAL sidecars when present) into an owner-only, unguessable temp directory via `tempfile` and opens the copy read-only.
- OpenCode `patch` parts are snapshot summaries rather than tool invocations, so analysis ignores them to avoid double-counting edits already represented by tool parts. OpenCode `apply_patch` tool parts are counted separately from their patch text: `*** Move to:` markers attribute hunks to the destination path, and insert-only update hunks stay classified as edits.
- If the optional OpenCode database cannot be queried, `usage` and `analysis` log a warning and continue with the other providers.

## Test plan

- [x] `make fmt`
- [x] `cargo test --locked`
- [x] `uvx pre-commit run -a`
- [x] OpenCode reader tests cover message-level provider/model splitting, message-timestamp time-range filtering, completed-tool filtering, plain read output parsing, plain read footer handling, patch snapshot ignoring, `apply_patch` tool counts, `apply_patch` move markers, insert-only update hunk classification, stored cost, and tool counts
- [x] Usage display and JSON tests cover OpenCode stored-cost fallback when the same model also appears in another provider
- [ ] CI green on all targets
