### PR TITLE
feat(usage): merge models across provider prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,14 +168,15 @@ Time range flags (shared by `usage` and `analysis`, mutually exclusive, default 
 
 ### Flags
 
-| Flag                                           | Purpose                             |
-| ---------------------------------------------- | ----------------------------------- |
-| *(none)*                                       | Interactive TUI dashboard (default) |
-| `--table`                                      | Static table, no TUI                |
-| `--text`                                       | Plain text, script-friendly         |
-| `--json`                                       | JSON with enriched pricing metadata |
-| `--output <FILE>`                              | Save enriched JSON to a file        |
-| `--daily` / `--weekly` / `--monthly` / `--all` | Time range filter (see table above) |
+| Flag                                           | Purpose                                                                          |
+| ---------------------------------------------- | -------------------------------------------------------------------------------- |
+| *(none)*                                       | Interactive TUI dashboard (default)                                              |
+| `--table`                                      | Static table, no TUI                                                             |
+| `--text`                                       | Plain text, script-friendly                                                      |
+| `--json`                                       | JSON with enriched pricing metadata                                              |
+| `--output <FILE>`                              | Save enriched JSON to a file                                                     |
+| `--merge-providers`                            | Merge models sharing a base name across provider prefixes (ignored for `--json`) |
+| `--daily` / `--weekly` / `--monthly` / `--all` | Time range filter (see table above)                                              |
 
 ### Basic Usage
 
@@ -199,10 +200,17 @@ vct usage --output report.json
 vct usage --weekly
 vct usage --table --monthly
 vct usage --json --daily
+
+# Merge same model reported under different provider prefixes
+# (e.g. openai/gpt-5.5 + azure/gpt-5.5 + gpt-5.5 -> one row)
+vct usage --table --merge-providers
 ```
 
 > [!NOTE]
 > Model rows are sorted by cost in ascending order, so the highest-spending model is listed last (right above the `TOTAL` row in `--table`). This applies to the interactive dashboard, `--table`, and `--text` output; `--json` preserves the same order. The interactive dashboard also hides models with zero usage in the selected range.
+
+> [!TIP]
+> The same model can show up as several rows when it is routed under different provider prefixes (`openai/gpt-5.5`, `azure/gpt-5.5`, plain `gpt-5.5`). `--merge-providers` collapses rows that share the base name after the first `/` (versions like `gpt-5.5` vs `gpt-5.4` stay separate) and sums their already-priced cost. In the interactive dashboard, press `m` to toggle it live; `--merge-providers` opens the dashboard already merged. `--json` is left as the raw per-model export.
 
 ### Preview: Interactive Dashboard (`vct usage`)
 
@@ -223,7 +231,7 @@ vct usage --json --daily
 ┌─────────────────────────────────────────────────────────────────────────────────────────────┐
 │ Total Cost: $79.33  |  Total Tokens: 49.3M  |  Models: 3  |  Memory: 42.8 MB                │
 └─────────────────────────────────────────────────────────────────────────────────────────────┘
-  ↑/↓ scroll  PgUp/PgDn page  g/G top/end  r refresh  q quit  |  ★ github.com/Mai0313/VibeCodingTracker
+  ↑/↓ scroll  PgUp/PgDn page  g/G top/end  m merge  r refresh  q quit  |  ★ github.com/Mai0313/VibeCodingTracker
 ```
 
 ### Preview: Table & JSON (`vct usage`)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -168,14 +168,15 @@ Commands:
 
 ### Flag 一览
 
-| Flag                                           | 用途                       |
-| ---------------------------------------------- | -------------------------- |
-| *(不带参数)*                                   | 互动式 TUI 面板（默认）    |
-| `--table`                                      | 静态表格，不启动 TUI       |
-| `--text`                                       | 纯文本，适合脚本处理       |
-| `--json`                                       | JSON 输出，附带定价信息    |
-| `--output <FILE>`                              | 将富化 JSON 保存到文件     |
-| `--daily` / `--weekly` / `--monthly` / `--all` | 时间范围筛选（见上方表格） |
+| Flag                                           | 用途                                                                          |
+| ---------------------------------------------- | ----------------------------------------------------------------------------- |
+| *(不带参数)*                                   | 互动式 TUI 面板（默认）                                                       |
+| `--table`                                      | 静态表格，不启动 TUI                                                          |
+| `--text`                                       | 纯文本，适合脚本处理                                                          |
+| `--json`                                       | JSON 输出，附带定价信息                                                       |
+| `--output <FILE>`                              | 将富化 JSON 保存到文件                                                        |
+| `--merge-providers`                            | 合并共享同一 base 名称、仅 provider 前缀不同的 model（`--json` 会忽略此选项） |
+| `--daily` / `--weekly` / `--monthly` / `--all` | 时间范围筛选（见上方表格）                                                    |
 
 ### 基本用法
 
@@ -199,10 +200,17 @@ vct usage --output report.json
 vct usage --weekly
 vct usage --table --monthly
 vct usage --json --daily
+
+# 合并同一 model 在不同 provider 前缀下的多行
+# (例如 openai/gpt-5.5 + azure/gpt-5.5 + gpt-5.5 -> 一行)
+vct usage --table --merge-providers
 ```
 
 > [!NOTE]
 > Model 行会按 cost 升序排序，因此花费最高的 model 会排在最后（在 `--table` 中紧邻 `TOTAL` 行上方）。该排序适用于交互式面板、`--table` 与 `--text` 三种输出；`--json` 也会保持相同顺序。交互式面板还会隐藏在所选范围内用量为 0 的模型。
+
+> [!TIP]
+> 同一个 model 在不同 provider 前缀下路由时会显示成多行（`openai/gpt-5.5`、`azure/gpt-5.5`、纯 `gpt-5.5`）。`--merge-providers` 会把第一个 `/` 之后 base 名称相同的行合并（`gpt-5.5` 与 `gpt-5.4` 这类版本不同的仍分开），并把它们已定价的 cost 相加。在交互式面板中按 `m` 可实时切换；`--merge-providers` 则让面板一打开就是合并状态。`--json` 保持为逐一 model 的原始导出。
 
 ### 预览：交互式面板（`vct usage`）
 
@@ -223,7 +231,7 @@ vct usage --json --daily
 ┌─────────────────────────────────────────────────────────────────────────────────────────────┐
 │ Total Cost: $79.33  |  Total Tokens: 49.3M  |  Models: 3  |  Memory: 42.8 MB                │
 └─────────────────────────────────────────────────────────────────────────────────────────────┘
-  ↑/↓ scroll  PgUp/PgDn page  g/G top/end  r refresh  q quit  |  ★ github.com/Mai0313/VibeCodingTracker
+  ↑/↓ scroll  PgUp/PgDn page  g/G top/end  m merge  r refresh  q quit  |  ★ github.com/Mai0313/VibeCodingTracker
 ```
 
 ### 预览：表格与 JSON（`vct usage`）

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -168,14 +168,15 @@ Commands:
 
 ### Flag 一覽
 
-| Flag                                           | 用途                         |
-| ---------------------------------------------- | ---------------------------- |
-| *(不帶參數)*                                   | 互動式 TUI 儀表板（預設）    |
-| `--table`                                      | 靜態表格，不啟動 TUI         |
-| `--text`                                       | 純文字，適合腳本處理         |
-| `--json`                                       | JSON 輸出，附帶 pricing 資訊 |
-| `--output <FILE>`                              | 將富化 JSON 存成檔案         |
-| `--daily` / `--weekly` / `--monthly` / `--all` | 時間範圍篩選（見上方表格）   |
+| Flag                                           | 用途                                                                          |
+| ---------------------------------------------- | ----------------------------------------------------------------------------- |
+| *(不帶參數)*                                   | 互動式 TUI 儀表板（預設）                                                     |
+| `--table`                                      | 靜態表格，不啟動 TUI                                                          |
+| `--text`                                       | 純文字，適合腳本處理                                                          |
+| `--json`                                       | JSON 輸出，附帶 pricing 資訊                                                  |
+| `--output <FILE>`                              | 將富化 JSON 存成檔案                                                          |
+| `--merge-providers`                            | 合併共享同一 base 名稱、僅 provider 前綴不同的 model（`--json` 會忽略此選項） |
+| `--daily` / `--weekly` / `--monthly` / `--all` | 時間範圍篩選（見上方表格）                                                    |
 
 ### 基本用法
 
@@ -199,10 +200,17 @@ vct usage --output report.json
 vct usage --weekly
 vct usage --table --monthly
 vct usage --json --daily
+
+# 合併同一 model 在不同 provider 前綴下的多列
+# (例如 openai/gpt-5.5 + azure/gpt-5.5 + gpt-5.5 -> 一列)
+vct usage --table --merge-providers
 ```
 
 > [!NOTE]
 > Model 列會依 cost 由小到大排序，所以花費最高的 model 會排在最後(在 `--table` 中緊鄰 `TOTAL` 列上方)。這個排序會套用到互動式儀表板、`--table` 與 `--text` 三種輸出;`--json` 也會保持相同順序。互動式儀表板也會隱藏在所選範圍內用量為 0 的 model。
+
+> [!TIP]
+> 同一個 model 在不同 provider 前綴下路由時會顯示成多列（`openai/gpt-5.5`、`azure/gpt-5.5`、純 `gpt-5.5`）。`--merge-providers` 會把第一個 `/` 之後 base 名稱相同的列合併（`gpt-5.5` 與 `gpt-5.4` 這類版本不同的仍分開），並把它們已定價的 cost 相加。在互動式儀表板中按 `m` 可即時切換;`--merge-providers` 則讓儀表板一打開就是合併狀態。`--json` 保持為逐一 model 的原始輸出。
 
 ### 預覽：互動式儀表板（`vct usage`）
 
@@ -223,7 +231,7 @@ vct usage --json --daily
 ┌─────────────────────────────────────────────────────────────────────────────────────────────┐
 │ Total Cost: $79.33  |  Total Tokens: 49.3M  |  Models: 3  |  Memory: 42.8 MB                │
 └─────────────────────────────────────────────────────────────────────────────────────────────┘
-  ↑/↓ scroll  PgUp/PgDn page  g/G top/end  r refresh  q quit  |  ★ github.com/Mai0313/VibeCodingTracker
+  ↑/↓ scroll  PgUp/PgDn page  g/G top/end  m merge  r refresh  q quit  |  ★ github.com/Mai0313/VibeCodingTracker
 ```
 
 ### 預覽：表格與 JSON（`vct usage`）

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -141,6 +141,12 @@ pub enum Commands {
         #[arg(long, group = "usage_format")]
         table: bool,
 
+        /// Merge models that share a base name across provider prefixes
+        /// (e.g. `openai/gpt-5.5` + `azure/gpt-5.5`). In the TUI this seeds the
+        /// initial state; press `m` to toggle. Ignored for `--json`.
+        #[arg(long)]
+        merge_providers: bool,
+
         /// Show only today's data.
         #[arg(long, group = "period")]
         daily: bool,

--- a/src/display/analysis/interactive.rs
+++ b/src/display/analysis/interactive.rs
@@ -236,6 +236,8 @@ pub fn display_analysis_interactive(
         match action {
             InputAction::Quit => break,
             InputAction::Refresh => refresh_state.force(),
+            // Provider-prefix merge is a usage-view feature; nothing to do here.
+            InputAction::ToggleMerge => {}
             // Move the selection / scroll, then repaint without re-aggregating.
             InputAction::Navigate(nav) => {
                 scroll.apply(nav, rows_data.len());
@@ -472,7 +474,7 @@ fn render_analysis_frame(
         let summary = create_summary(summary_items, sys, pid);
         f.render_widget(summary, chunks.summary);
 
-        f.render_widget(create_controls(), chunks.controls);
+        f.render_widget(create_controls(&[]), chunks.controls);
     })?;
 
     Ok(())

--- a/src/display/common/table.rs
+++ b/src/display/common/table.rs
@@ -89,28 +89,40 @@ pub fn create_summary<'a>(
 ///
 /// Everything is on one line to save vertical space; the star link sits last so
 /// it is the first thing truncated on a narrow terminal, leaving the keys
-/// readable.
-pub fn create_controls() -> Paragraph<'static> {
+/// readable. `extra` inserts view-specific `(key, label)` hints just before
+/// `r refresh` — the usage view passes its `m merge` toggle; other views pass
+/// an empty slice.
+pub fn create_controls(extra: &[(&str, &str)]) -> Paragraph<'static> {
     let key = Style::default().fg(RatatuiColor::Cyan).bold();
     let dim = Style::default().fg(RatatuiColor::DarkGray);
-    Paragraph::new(vec![Line::from(vec![
+    let mut spans = vec![
         Span::styled("↑/↓", key),
         Span::styled(" scroll  ", dim),
         Span::styled("PgUp/PgDn", key),
         Span::styled(" page  ", dim),
         Span::styled("g/G", key),
         Span::styled(" top/end  ", dim),
-        Span::styled("r", key),
-        Span::styled(" refresh  ", dim),
-        Span::styled("q", Style::default().fg(RatatuiColor::Red).bold()),
-        Span::styled(" quit", dim),
-        Span::styled("  |  ★ ", Style::default().fg(RatatuiColor::Yellow)),
-        Span::styled(
-            "github.com/Mai0313/VibeCodingTracker",
-            Style::default().fg(RatatuiColor::Cyan).underlined(),
-        ),
-    ])])
-    .centered()
+    ];
+    for (k, label) in extra {
+        spans.push(Span::styled(k.to_string(), key));
+        spans.push(Span::styled(label.to_string(), dim));
+    }
+    spans.push(Span::styled("r", key));
+    spans.push(Span::styled(" refresh  ", dim));
+    spans.push(Span::styled(
+        "q",
+        Style::default().fg(RatatuiColor::Red).bold(),
+    ));
+    spans.push(Span::styled(" quit", dim));
+    spans.push(Span::styled(
+        "  |  ★ ",
+        Style::default().fg(RatatuiColor::Yellow),
+    ));
+    spans.push(Span::styled(
+        "github.com/Mai0313/VibeCodingTracker",
+        Style::default().fg(RatatuiColor::Cyan).underlined(),
+    ));
+    Paragraph::new(vec![Line::from(spans)]).centered()
 }
 
 /// Vertical chunk rects for an interactive frame.

--- a/src/display/common/tui.rs
+++ b/src/display/common/tui.rs
@@ -214,6 +214,16 @@ pub struct UpdateTracker {
     highlight_duration: Duration,
 }
 
+/// Hashes any `Hash` value with [`DefaultHasher`](std::collections::hash_map::DefaultHasher)
+/// — used to store a compact fingerprint of a row instead of a full clone.
+fn hash_of<T: std::hash::Hash>(data: &T) -> u64 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::Hasher;
+    let mut hasher = DefaultHasher::new();
+    data.hash(&mut hasher);
+    hasher.finish()
+}
+
 impl UpdateTracker {
     /// Creates a tracker retaining up to `max_tracked` rows and highlighting changes for `highlight_duration_millis`.
     pub fn new(max_tracked: usize, highlight_duration_millis: u64) -> Self {
@@ -232,12 +242,7 @@ impl UpdateTracker {
     /// to avoid retaining a full copy. This never evicts entries — call
     /// [`cleanup`](Self::cleanup) to bound growth.
     pub fn track_update<T: std::hash::Hash>(&mut self, key: String, data: &T) {
-        use std::collections::hash_map::DefaultHasher;
-        use std::hash::Hasher;
-
-        let mut hasher = DefaultHasher::new();
-        data.hash(&mut hasher);
-        let hash = hasher.finish();
+        let hash = hash_of(data);
 
         let entry_changed = match self.previous_hashes.get(&key) {
             Some(&prev_hash) => prev_hash != hash,
@@ -249,6 +254,18 @@ impl UpdateTracker {
         }
 
         self.previous_hashes.insert(key, hash);
+    }
+
+    /// Records `data`'s hash for `key` as the baseline **without** marking it
+    /// updated.
+    ///
+    /// Used when rows are relabeled but not actually changed — e.g. toggling the
+    /// provider-merge view swaps `openai/gpt-5.5` for `gpt-5.5`. Priming the new
+    /// key means the next [`track_update`](Self::track_update) compares against a
+    /// real baseline instead of treating it as first-seen and green-flashing the
+    /// whole table on the next refresh.
+    pub fn prime<T: std::hash::Hash>(&mut self, key: String, data: &T) {
+        self.previous_hashes.insert(key, hash_of(data));
     }
 
     /// Drops tracked entries whose key is no longer present, then enforces the `max_tracked` cap.

--- a/src/display/common/tui.rs
+++ b/src/display/common/tui.rs
@@ -90,6 +90,9 @@ pub fn handle_input() -> anyhow::Result<InputAction> {
                 if key.code == KeyCode::Char('r') || key.code == KeyCode::Char('R') {
                     return Ok(InputAction::Refresh);
                 }
+                if key.code == KeyCode::Char('m') || key.code == KeyCode::Char('M') {
+                    return Ok(InputAction::ToggleMerge);
+                }
                 // Navigation accumulates across the drained batch so a held key
                 // collapses into a single net move per tick.
                 match key.code {
@@ -147,6 +150,9 @@ pub enum InputAction {
     Quit,
     /// User asked to re-fetch and redraw (`r` / `R`).
     Refresh,
+    /// User toggled provider-prefix merging (`m` / `M`); usage view only,
+    /// ignored elsewhere.
+    ToggleMerge,
     /// User scrolled / moved the selection; redraw without re-fetching.
     Navigate(NavDelta),
     /// Terminal was resized — redraw the current frame at the new size

--- a/src/display/usage/averages.rs
+++ b/src/display/usage/averages.rs
@@ -13,7 +13,7 @@ use std::borrow::Cow;
 /// numbers reconcile with `total`, while `cost` is computed against the
 /// per-token reasoning rate (when the model publishes one) via
 /// `calculate_cost`.
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct UsageRow {
     /// Raw model name as reported by the session (the pricing-lookup key).
     pub model: String, // 原始模型名稱
@@ -399,6 +399,66 @@ fn build_usage_row(
     }
 }
 
+/// Returns the base model key used to merge rows across provider-routing
+/// prefixes: everything after the first `/`, or the whole name when there is no
+/// `/`. Unlike [`normalize_model_name`](crate::pricing::normalize_model_name)
+/// this does **not** strip version/date suffixes, so `gpt-5.5` and `gpt-5.4`
+/// stay distinct.
+fn base_model_key(model: &str) -> &str {
+    model.split_once('/').map(|(_, rest)| rest).unwrap_or(model)
+}
+
+/// Collapses rows by [`base_model_key`], summing every token bucket and the
+/// already-resolved cost, and shows every row under its bare base name.
+///
+/// Costs are summed verbatim: each input row was already priced against its
+/// full model name, so a merged `gpt-5.5` correctly adds the differently-priced
+/// `openai/gpt-5.5`, `azure/gpt-5.5`, and bare `gpt-5.5` pieces — re-pricing the
+/// merged token bucket under a single name would be wrong. Every output row is
+/// labeled with just the base name (the provider prefix is dropped even when a
+/// model has no duplicate, e.g. `opencode/big-pickle` -> `big-pickle`) with no
+/// count suffix, so the merged view reads uniformly. The result is re-sorted by
+/// ascending cost, tie-broken by model name, matching [`build_usage_summary`].
+pub fn merge_rows_by_base_model(rows: &[UsageRow]) -> Vec<UsageRow> {
+    use std::collections::HashMap;
+
+    let mut groups: HashMap<&str, Vec<&UsageRow>> = HashMap::new();
+    for row in rows {
+        groups
+            .entry(base_model_key(&row.model))
+            .or_default()
+            .push(row);
+    }
+
+    let mut merged: Vec<UsageRow> = Vec::with_capacity(groups.len());
+    for (key, members) in groups {
+        let mut acc = UsageRow {
+            model: key.to_string(),
+            display_model: key.to_string(),
+            ..UsageRow::default()
+        };
+        for m in members {
+            acc.input_tokens += m.input_tokens;
+            acc.output_tokens += m.output_tokens;
+            acc.reasoning_tokens += m.reasoning_tokens;
+            acc.cache_read += m.cache_read;
+            acc.cache_creation += m.cache_creation;
+            acc.total += m.total;
+            acc.cost += m.cost;
+        }
+        merged.push(acc);
+    }
+
+    // Same ordering as build_usage_summary so the merged view reads identically.
+    merged.sort_by(|a, b| {
+        a.cost
+            .partial_cmp(&b.cost)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.model.cmp(&b.model))
+    });
+    merged
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -444,5 +504,97 @@ mod tests {
         assert_eq!(summary.rows.len(), 1);
         assert!((summary.rows[0].cost - 8.0).abs() < 1e-9);
         assert_eq!(summary.rows[0].display_model, "shared-pro (shared)");
+    }
+
+    fn row(model: &str, input: i64, total: i64, cost: f64) -> UsageRow {
+        UsageRow {
+            model: model.to_string(),
+            display_model: model.to_string(),
+            input_tokens: input,
+            total,
+            cost,
+            ..UsageRow::default()
+        }
+    }
+
+    #[test]
+    fn merge_collapses_prefixed_and_bare_names_and_sums() {
+        let rows = vec![
+            row("openai/gpt-5.5", 100, 100, 0.20),
+            row("azure/gpt-5.5", 200, 200, 3.00),
+            row("gpt-5.5", 300, 300, 5.00),
+        ];
+
+        let merged = merge_rows_by_base_model(&rows);
+
+        assert_eq!(merged.len(), 1);
+        let m = &merged[0];
+        assert_eq!(m.model, "gpt-5.5");
+        assert_eq!(m.display_model, "gpt-5.5");
+        assert_eq!(m.input_tokens, 600);
+        assert_eq!(m.total, 600);
+        assert!((m.cost - 8.20).abs() < 1e-9);
+    }
+
+    #[test]
+    fn merge_keeps_different_versions_apart() {
+        // gpt-5.5 has two provider variants (they merge); gpt-5.4 has one. The
+        // key check: the 5.4 tokens never fold into the 5.5 row.
+        let rows = vec![
+            row("openai/gpt-5.5", 10, 10, 1.0),
+            row("azure/gpt-5.5", 30, 30, 3.0),
+            row("openai/gpt-5.4", 20, 20, 2.0),
+        ];
+
+        let merged = merge_rows_by_base_model(&rows);
+
+        assert_eq!(merged.len(), 2);
+        // The two gpt-5.5 rows collapse to one base row; gpt-5.4 stays separate.
+        let five_five = merged.iter().find(|r| r.model == "gpt-5.5").unwrap();
+        assert_eq!(five_five.display_model, "gpt-5.5");
+        assert_eq!(five_five.total, 40);
+        // The lone 5.4 also shows under its bare base name, keeping its tokens.
+        let five_four = merged.iter().find(|r| r.model == "gpt-5.4").unwrap();
+        assert_eq!(five_four.display_model, "gpt-5.4");
+        assert_eq!(five_four.total, 20);
+    }
+
+    #[test]
+    fn merge_strips_prefix_from_single_row() {
+        // Even a model with no duplicate drops its provider prefix (and any
+        // fuzzy-match hint) so the merged view reads uniformly.
+        let mut only = row("deepseek/deepseek-v4-pro", 5, 5, 1.5);
+        only.display_model = "deepseek/deepseek-v4-pro (deepseek-v4)".to_string();
+
+        let merged = merge_rows_by_base_model(std::slice::from_ref(&only));
+
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].model, "deepseek-v4-pro");
+        assert_eq!(merged[0].display_model, "deepseek-v4-pro");
+        assert_eq!(merged[0].total, 5);
+    }
+
+    #[test]
+    fn merge_only_strips_first_slash_segment() {
+        assert_eq!(base_model_key("a/b/c"), "b/c");
+        assert_eq!(base_model_key("gpt-5.5"), "gpt-5.5");
+        assert_eq!(base_model_key("openai/gpt-5.5"), "gpt-5.5");
+    }
+
+    #[test]
+    fn merge_reorders_by_ascending_cost() {
+        let rows = vec![
+            row("openai/gpt-5.5", 1, 1, 9.0),
+            row("azure/gpt-5.5", 1, 1, 9.0),
+            row("cheap-model", 1, 1, 0.01),
+        ];
+
+        let merged = merge_rows_by_base_model(&rows);
+
+        assert_eq!(merged.len(), 2);
+        // cheap-model (0.01) sorts before the merged gpt-5.5 row (18.0).
+        assert_eq!(merged[0].model, "cheap-model");
+        assert_eq!(merged[1].model, "gpt-5.5");
+        assert!((merged[1].cost - 18.0).abs() < 1e-9);
     }
 }

--- a/src/display/usage/interactive.rs
+++ b/src/display/usage/interactive.rs
@@ -18,7 +18,7 @@ use crate::display::common::tui::{
 };
 use crate::display::usage::averages::{
     ProviderStats, UsageProviderTotals, UsageRow, UsageTotals, build_provider_total_rows,
-    build_usage_summary,
+    build_usage_summary, merge_rows_by_base_model,
 };
 use crate::models::{
     ClaudeQuotaSnapshot, CodexQuotaSnapshot, CopilotQuotaSnapshot, CursorQuotaSnapshot,
@@ -156,7 +156,10 @@ const USAGE_PANELS_MIN_H: u16 = 22;
 /// - Real-time memory monitoring
 /// - Provider-grouped totals
 /// - Scrollable model table (arrow keys / `PgUp`/`PgDn` / `g`/`G`)
-/// - Keyboard controls: `q`, `Esc`, or `Ctrl+C` to exit, `r` to refresh
+/// - Keyboard controls: `q`, `Esc`, or `Ctrl+C` to exit, `r` to refresh, `m` to
+///   toggle merging models that share a base name across provider prefixes
+///   (e.g. `openai/gpt-5.5` + `azure/gpt-5.5`). `merge_providers` seeds the
+///   initial state.
 ///
 /// # Errors
 ///
@@ -168,7 +171,10 @@ const USAGE_PANELS_MIN_H: u16 = 22;
 /// # Panics
 ///
 /// Panics if the current process ID cannot be obtained for memory monitoring.
-pub fn display_usage_interactive(time_range: crate::cli::TimeRange) -> anyhow::Result<()> {
+pub fn display_usage_interactive(
+    time_range: crate::cli::TimeRange,
+    merge_providers: bool,
+) -> anyhow::Result<()> {
     let mut terminal = setup_terminal()?;
     let mut refresh_state = RefreshState::new(USAGE_REFRESH_SECS);
 
@@ -330,6 +336,13 @@ pub fn display_usage_interactive(time_range: crate::cli::TimeRange) -> anyhow::R
     let mut rows_data: Vec<UsageRow> = Vec::new();
     let mut totals = UsageTotals::default();
     let mut provider_totals = UsageProviderTotals::default();
+    // `rows_data` is the un-merged canonical list; `display_rows` is what the
+    // table actually shows. When merging is on it collapses provider-prefix
+    // duplicates (e.g. `openai/gpt-5.5` + `azure/gpt-5.5`) into one row. Toggling
+    // `m` re-derives `display_rows` from the cached `rows_data`, so it never
+    // re-scans the session directories.
+    let mut merge_enabled = merge_providers;
+    let mut display_rows: Vec<UsageRow> = Vec::new();
     // Quota panel state, cached across frames so a resize repaints without
     // re-reading the shared snapshots.
     let mut claude_snapshot = ClaudeQuotaSnapshot::default();
@@ -391,7 +404,7 @@ pub fn display_usage_interactive(time_range: crate::cli::TimeRange) -> anyhow::R
             let prev_model = scroll
                 .table
                 .selected()
-                .and_then(|i| rows_data.get(i))
+                .and_then(|i| display_rows.get(i))
                 .map(|row| row.model.clone());
 
             // Cache the rendered display state so a resize can redraw without
@@ -410,7 +423,13 @@ pub fn display_usage_interactive(time_range: crate::cli::TimeRange) -> anyhow::R
             totals = summary.totals;
             provider_totals = summary.provider_totals;
 
-            let model_names: Vec<String> = rows_data.iter().map(|row| row.model.clone()).collect();
+            // Derive the displayed rows from the canonical list per the current
+            // merge toggle. Totals stay from `summary` (a row-wise sum is the
+            // same merged or not), so only the table body changes.
+            display_rows = view_rows(&rows_data, merge_enabled);
+
+            let model_names: Vec<String> =
+                display_rows.iter().map(|row| row.model.clone()).collect();
             scroll.sync(prev_model.as_deref(), &model_names);
 
             // Refresh quota panels from each background worker's latest snapshot.
@@ -432,13 +451,14 @@ pub fn display_usage_interactive(time_range: crate::cli::TimeRange) -> anyhow::R
             // backed by a dated on-disk file — clearing it just forces another
             // file-parse on the next refresh.
 
-            // Track updates
+            // Track updates against the displayed rows so highlighting keys off
+            // the merged model name when merging is on.
             let current_row_keys: Vec<String> =
-                rows_data.iter().map(|row| row.model.clone()).collect();
+                display_rows.iter().map(|row| row.model.clone()).collect();
 
             update_tracker.cleanup(current_row_keys);
 
-            for row in &rows_data {
+            for row in &display_rows {
                 let row_key = row.model.clone();
                 // Include reasoning in the change fingerprint so Gemini
                 // sessions whose only delta lands in `thoughts_tokens` still
@@ -455,7 +475,7 @@ pub fn display_usage_interactive(time_range: crate::cli::TimeRange) -> anyhow::R
 
             render_usage_frame(
                 &mut terminal,
-                &rows_data,
+                &display_rows,
                 &totals,
                 &provider_totals,
                 &update_tracker,
@@ -469,6 +489,7 @@ pub fn display_usage_interactive(time_range: crate::cli::TimeRange) -> anyhow::R
                     present,
                 },
                 &mut scroll,
+                merge_enabled,
             )?;
 
             // Hand any arena-held free pages back to the OS. The refresh cycle
@@ -487,13 +508,23 @@ pub fn display_usage_interactive(time_range: crate::cli::TimeRange) -> anyhow::R
                 break;
             }
             InputAction::Refresh => refresh_state.force(),
-            // Move the selection / scroll, then repaint the cached frame
-            // without re-aggregating.
-            InputAction::Navigate(nav) => {
-                scroll.apply(nav, rows_data.len());
+            // Flip provider-prefix merging and re-derive the displayed rows from
+            // the cached canonical list — no directory re-scan. Keep the current
+            // model selected across the collapse/expand when it survives.
+            InputAction::ToggleMerge => {
+                merge_enabled = !merge_enabled;
+                let prev_model = scroll
+                    .table
+                    .selected()
+                    .and_then(|i| display_rows.get(i))
+                    .map(|row| row.model.clone());
+                display_rows = view_rows(&rows_data, merge_enabled);
+                let model_names: Vec<String> =
+                    display_rows.iter().map(|row| row.model.clone()).collect();
+                scroll.sync(prev_model.as_deref(), &model_names);
                 render_usage_frame(
                     &mut terminal,
-                    &rows_data,
+                    &display_rows,
                     &totals,
                     &provider_totals,
                     &update_tracker,
@@ -507,6 +538,30 @@ pub fn display_usage_interactive(time_range: crate::cli::TimeRange) -> anyhow::R
                         present,
                     },
                     &mut scroll,
+                    merge_enabled,
+                )?;
+            }
+            // Move the selection / scroll, then repaint the cached frame
+            // without re-aggregating.
+            InputAction::Navigate(nav) => {
+                scroll.apply(nav, display_rows.len());
+                render_usage_frame(
+                    &mut terminal,
+                    &display_rows,
+                    &totals,
+                    &provider_totals,
+                    &update_tracker,
+                    &sys,
+                    pid,
+                    &QuotaView {
+                        claude: &claude_snapshot,
+                        codex: &codex_snapshot,
+                        copilot: &copilot_snapshot,
+                        cursor: &cursor_snapshot,
+                        present,
+                    },
+                    &mut scroll,
+                    merge_enabled,
                 )?;
             }
             // Redraw the cached frame at the new terminal size without
@@ -514,7 +569,7 @@ pub fn display_usage_interactive(time_range: crate::cli::TimeRange) -> anyhow::R
             // for the next refresh tick.
             InputAction::Resize => render_usage_frame(
                 &mut terminal,
-                &rows_data,
+                &display_rows,
                 &totals,
                 &provider_totals,
                 &update_tracker,
@@ -528,6 +583,7 @@ pub fn display_usage_interactive(time_range: crate::cli::TimeRange) -> anyhow::R
                     present,
                 },
                 &mut scroll,
+                merge_enabled,
             )?,
             InputAction::Continue => {}
         }
@@ -535,6 +591,20 @@ pub fn display_usage_interactive(time_range: crate::cli::TimeRange) -> anyhow::R
 
     restore_terminal(&mut terminal)?;
     Ok(())
+}
+
+/// Returns the rows to display for the current merge toggle: the canonical list
+/// verbatim, or provider-prefix duplicates collapsed into one row per base name.
+///
+/// The clone on the un-merged path is cheap (a few dozen small rows) and keeps
+/// the caller holding an owned `Vec` either way, so `rows_data` stays the
+/// untouched canonical source that a later toggle can re-derive from.
+fn view_rows(rows: &[UsageRow], merge_enabled: bool) -> Vec<UsageRow> {
+    if merge_enabled {
+        merge_rows_by_base_model(rows)
+    } else {
+        rows.to_vec()
+    }
 }
 
 /// Render a single usage frame from already-aggregated display state.
@@ -558,6 +628,7 @@ fn render_usage_frame(
     pid: Pid,
     quota: &QuotaView,
     scroll: &mut ScrollState,
+    merge_enabled: bool,
 ) -> anyhow::Result<()> {
     let provider_rows = build_provider_total_rows(provider_totals);
 
@@ -751,7 +822,13 @@ fn render_usage_frame(
         let summary = create_summary(summary_items, sys, pid);
         f.render_widget(summary, chunks.summary);
 
-        f.render_widget(create_controls(), chunks.controls);
+        // When merged, the toggle un-merges, so label it "split" to match.
+        let merge_hint = if merge_enabled {
+            " split  "
+        } else {
+            " merge  "
+        };
+        f.render_widget(create_controls(&[("m", merge_hint)]), chunks.controls);
     })?;
 
     Ok(())

--- a/src/display/usage/interactive.rs
+++ b/src/display/usage/interactive.rs
@@ -32,7 +32,7 @@ use crate::quota::{
     spawn_quota_worker,
 };
 use crate::utils::{
-    format_compact, format_cost, format_duration_until, get_claude_credentials_path,
+    format_compact, format_cost_compact, format_duration_until, get_claude_credentials_path,
     get_copilot_config_path, get_cursor_auth_path, resolve_paths,
 };
 use ratatui::{
@@ -679,7 +679,7 @@ fn render_usage_frame(
                         format_compact(row.cache_read),
                         format_compact(row.cache_creation),
                         format_compact(row.total),
-                        format_cost(row.cost),
+                        format_cost_compact(row.cost),
                     ],
                     style,
                     1,
@@ -741,7 +741,7 @@ fn render_usage_frame(
                             vec![
                                 row.label.to_string(),
                                 format_compact(row.stats.total_tokens),
-                                format_cost(row.stats.total_cost),
+                                format_cost_compact(row.stats.total_cost),
                             ],
                             row.tui_color,
                             row.emphasize,
@@ -805,7 +805,7 @@ fn render_usage_frame(
             }
         }
 
-        let total_cost_str = format_cost(totals.cost);
+        let total_cost_str = format_cost_compact(totals.cost);
         let total_tokens_str = format_compact(totals.total);
         let entries_str = format!("{}", rows_data.len());
 

--- a/src/display/usage/interactive.rs
+++ b/src/display/usage/interactive.rs
@@ -336,11 +336,12 @@ pub fn display_usage_interactive(
     let mut rows_data: Vec<UsageRow> = Vec::new();
     let mut totals = UsageTotals::default();
     let mut provider_totals = UsageProviderTotals::default();
-    // `rows_data` is the un-merged canonical list; `display_rows` is what the
-    // table actually shows. When merging is on it collapses provider-prefix
-    // duplicates (e.g. `openai/gpt-5.5` + `azure/gpt-5.5`) into one row. Toggling
-    // `m` re-derives `display_rows` from the cached `rows_data`, so it never
-    // re-scans the session directories.
+    // `rows_data` is the un-merged canonical list. `display_rows` holds the
+    // provider-prefix-collapsed rows (e.g. `openai/gpt-5.5` + `azure/gpt-5.5` ->
+    // `gpt-5.5`) and is materialized **only while merging is on**; when off it
+    // stays empty and the table renders `rows_data` directly (see
+    // `current_view`), so the default path keeps a single copy of the rows.
+    // Toggling `m` re-derives from the cached `rows_data`, never re-scanning disk.
     let mut merge_enabled = merge_providers;
     let mut display_rows: Vec<UsageRow> = Vec::new();
     // Quota panel state, cached across frames so a resize repaints without
@@ -401,11 +402,14 @@ pub fn display_usage_interactive(
 
             // Remember which model was selected so the highlight can follow it
             // across a refresh even if rows are reordered or added/removed.
-            let prev_model = scroll
-                .table
-                .selected()
-                .and_then(|i| display_rows.get(i))
-                .map(|row| row.model.clone());
+            let prev_model = {
+                let view = current_view(merge_enabled, &rows_data, &display_rows);
+                scroll
+                    .table
+                    .selected()
+                    .and_then(|i| view.get(i))
+                    .map(|row| row.model.clone())
+            };
 
             // Cache the rendered display state so a resize can redraw without
             // re-aggregating. These per-model summaries are small; the heavy
@@ -423,13 +427,15 @@ pub fn display_usage_interactive(
             totals = summary.totals;
             provider_totals = summary.provider_totals;
 
-            // Derive the displayed rows from the canonical list per the current
-            // merge toggle. Totals stay from `summary` (a row-wise sum is the
-            // same merged or not), so only the table body changes.
-            display_rows = view_rows(&rows_data, merge_enabled);
+            // Materialize the merged view only when merging is on; when off the
+            // table renders `rows_data` directly (no clone). Totals stay from
+            // `summary` (a row-wise sum is the same merged or not).
+            if merge_enabled {
+                display_rows = merge_rows_by_base_model(&rows_data);
+            }
+            let view = current_view(merge_enabled, &rows_data, &display_rows);
 
-            let model_names: Vec<String> =
-                display_rows.iter().map(|row| row.model.clone()).collect();
+            let model_names: Vec<String> = view.iter().map(|row| row.model.clone()).collect();
             scroll.sync(prev_model.as_deref(), &model_names);
 
             // Refresh quota panels from each background worker's latest snapshot.
@@ -452,30 +458,19 @@ pub fn display_usage_interactive(
             // file-parse on the next refresh.
 
             // Track updates against the displayed rows so highlighting keys off
-            // the merged model name when merging is on.
-            let current_row_keys: Vec<String> =
-                display_rows.iter().map(|row| row.model.clone()).collect();
+            // the merged model name when merging is on. See `row_fingerprint`
+            // for why a merged base name highlights on any variant's change.
+            let current_row_keys: Vec<String> = view.iter().map(|row| row.model.clone()).collect();
 
             update_tracker.cleanup(current_row_keys);
 
-            for row in &display_rows {
-                let row_key = row.model.clone();
-                // Include reasoning in the change fingerprint so Gemini
-                // sessions whose only delta lands in `thoughts_tokens` still
-                // trigger a highlight; otherwise the row would look idle
-                // while its cost silently grew.
-                let current_data = (
-                    row.input_tokens,
-                    row.output_with_reasoning(),
-                    row.cache_read,
-                    row.cache_creation,
-                );
-                update_tracker.track_update(row_key, &current_data);
+            for row in view {
+                update_tracker.track_update(row.model.clone(), &row_fingerprint(row));
             }
 
             render_usage_frame(
                 &mut terminal,
-                &display_rows,
+                view,
                 &totals,
                 &provider_totals,
                 &update_tracker,
@@ -512,19 +507,34 @@ pub fn display_usage_interactive(
             // the cached canonical list — no directory re-scan. Keep the current
             // model selected across the collapse/expand when it survives.
             InputAction::ToggleMerge => {
+                let prev_model = {
+                    let view = current_view(merge_enabled, &rows_data, &display_rows);
+                    scroll
+                        .table
+                        .selected()
+                        .and_then(|i| view.get(i))
+                        .map(|row| row.model.clone())
+                };
                 merge_enabled = !merge_enabled;
-                let prev_model = scroll
-                    .table
-                    .selected()
-                    .and_then(|i| display_rows.get(i))
-                    .map(|row| row.model.clone());
-                display_rows = view_rows(&rows_data, merge_enabled);
-                let model_names: Vec<String> =
-                    display_rows.iter().map(|row| row.model.clone()).collect();
+                // Materialize the merged rows when turning on; drop them (freeing
+                // the copy) when turning off.
+                if merge_enabled {
+                    display_rows = merge_rows_by_base_model(&rows_data);
+                } else {
+                    display_rows = Vec::new();
+                }
+                let view = current_view(merge_enabled, &rows_data, &display_rows);
+                let model_names: Vec<String> = view.iter().map(|row| row.model.clone()).collect();
                 scroll.sync(prev_model.as_deref(), &model_names);
+                // Prime the tracker with the relabeled keys so the next refresh
+                // doesn't treat them as first-seen and green-flash the whole
+                // table; a row still highlights later if its tokens actually move.
+                for row in view {
+                    update_tracker.prime(row.model.clone(), &row_fingerprint(row));
+                }
                 render_usage_frame(
                     &mut terminal,
-                    &display_rows,
+                    view,
                     &totals,
                     &provider_totals,
                     &update_tracker,
@@ -544,10 +554,11 @@ pub fn display_usage_interactive(
             // Move the selection / scroll, then repaint the cached frame
             // without re-aggregating.
             InputAction::Navigate(nav) => {
-                scroll.apply(nav, display_rows.len());
+                let view = current_view(merge_enabled, &rows_data, &display_rows);
+                scroll.apply(nav, view.len());
                 render_usage_frame(
                     &mut terminal,
-                    &display_rows,
+                    view,
                     &totals,
                     &provider_totals,
                     &update_tracker,
@@ -567,24 +578,27 @@ pub fn display_usage_interactive(
             // Redraw the cached frame at the new terminal size without
             // re-aggregating, so resize tracks the drag instead of waiting
             // for the next refresh tick.
-            InputAction::Resize => render_usage_frame(
-                &mut terminal,
-                &display_rows,
-                &totals,
-                &provider_totals,
-                &update_tracker,
-                &sys,
-                pid,
-                &QuotaView {
-                    claude: &claude_snapshot,
-                    codex: &codex_snapshot,
-                    copilot: &copilot_snapshot,
-                    cursor: &cursor_snapshot,
-                    present,
-                },
-                &mut scroll,
-                merge_enabled,
-            )?,
+            InputAction::Resize => {
+                let view = current_view(merge_enabled, &rows_data, &display_rows);
+                render_usage_frame(
+                    &mut terminal,
+                    view,
+                    &totals,
+                    &provider_totals,
+                    &update_tracker,
+                    &sys,
+                    pid,
+                    &QuotaView {
+                        claude: &claude_snapshot,
+                        codex: &codex_snapshot,
+                        copilot: &copilot_snapshot,
+                        cursor: &cursor_snapshot,
+                        present,
+                    },
+                    &mut scroll,
+                    merge_enabled,
+                )?;
+            }
             InputAction::Continue => {}
         }
     }
@@ -593,18 +607,42 @@ pub fn display_usage_interactive(
     Ok(())
 }
 
-/// Returns the rows to display for the current merge toggle: the canonical list
-/// verbatim, or provider-prefix duplicates collapsed into one row per base name.
+/// Returns the rows currently on screen without copying: the canonical
+/// `rows_data` when merging is off, or the pre-materialized merged `display_rows`
+/// when it is on.
 ///
-/// The clone on the un-merged path is cheap (a few dozen small rows) and keeps
-/// the caller holding an owned `Vec` either way, so `rows_data` stays the
-/// untouched canonical source that a later toggle can re-derive from.
-fn view_rows(rows: &[UsageRow], merge_enabled: bool) -> Vec<UsageRow> {
+/// Keeping `display_rows` empty in the (default) un-merged case means the loop
+/// holds a single copy of the rows and skips a per-refresh clone; it is only
+/// populated while the merge toggle is on, where the collapsed rows genuinely
+/// differ from the canonical list.
+fn current_view<'a>(
+    merge_enabled: bool,
+    rows_data: &'a [UsageRow],
+    display_rows: &'a [UsageRow],
+) -> &'a [UsageRow] {
     if merge_enabled {
-        merge_rows_by_base_model(rows)
+        display_rows
     } else {
-        rows.to_vec()
+        rows_data
     }
+}
+
+/// The change-highlight fingerprint of a row: the token buckets only (never
+/// cost, so a fuzzy-price shift can't flicker a row).
+///
+/// Reasoning is folded into the second field so a Gemini session whose only
+/// delta lands in `thoughts_tokens` still registers as a change. When merging is
+/// on this is computed over the summed row, so a collapsed base name highlights
+/// whenever **any** of its folded-in provider variants grows — a base name that
+/// looks idle can flash because a hidden variant (a subagent, another provider
+/// prefix, a background session) is being written. That is truthful, not a bug.
+fn row_fingerprint(row: &UsageRow) -> (i64, i64, i64, i64) {
+    (
+        row.input_tokens,
+        row.output_with_reasoning(),
+        row.cache_read,
+        row.cache_creation,
+    )
 }
 
 /// Render a single usage frame from already-aggregated display state.

--- a/src/display/usage/table.rs
+++ b/src/display/usage/table.rs
@@ -3,7 +3,9 @@
 use crate::display::common::table::{
     add_totals_row, create_comfy_table, create_metric_cell, create_provider_cell,
 };
-use crate::display::usage::averages::{build_provider_total_rows, build_usage_summary};
+use crate::display::usage::averages::{
+    build_provider_total_rows, build_usage_summary, merge_rows_by_base_model,
+};
 use crate::pricing::{ModelPricingMap, fetch_model_pricing};
 use crate::usage::UsageData;
 use crate::utils::format_number;
@@ -18,8 +20,9 @@ use std::collections::HashMap;
 /// so each row reconciles with "Total Tokens", while cost is priced against the
 /// separated buckets. Prints a "no usage data" message when empty. If pricing
 /// cannot be fetched, a warning is written to stderr and costs are shown as
-/// `$0.00`.
-pub fn display_usage_table(usage_data: &UsageData) {
+/// `$0.00`. When `merge` is set, rows sharing a base model name across provider
+/// prefixes (e.g. `openai/gpt-5.5` + `azure/gpt-5.5`) are collapsed into one.
+pub fn display_usage_table(usage_data: &UsageData, merge: bool) {
     if usage_data.models.is_empty() {
         println!("No usage data found in Claude Code, Codex, Copilot, or Gemini sessions");
         return;
@@ -38,7 +41,7 @@ pub fn display_usage_table(usage_data: &UsageData) {
         }
     };
 
-    let summary = build_usage_summary(
+    let mut summary = build_usage_summary(
         &usage_data.models,
         &usage_data.per_provider,
         &usage_data.provider_days,
@@ -49,6 +52,11 @@ pub fn display_usage_table(usage_data: &UsageData) {
     if summary.rows.is_empty() {
         println!("No usage data found in Claude Code, Codex, Copilot, or Gemini sessions");
         return;
+    }
+
+    // Totals are a row-wise sum, so they are identical merged or not.
+    if merge {
+        summary.rows = merge_rows_by_base_model(&summary.rows);
     }
 
     let rows = &summary.rows;

--- a/src/display/usage/text.rs
+++ b/src/display/usage/text.rs
@@ -1,6 +1,6 @@
 //! Plain-text renderer for the usage view: one `model: $cost` line per model.
 
-use crate::display::usage::averages::build_usage_summary;
+use crate::display::usage::averages::{build_usage_summary, merge_rows_by_base_model};
 use crate::pricing::{ModelPricingMap, fetch_model_pricing};
 use crate::usage::UsageData;
 use std::collections::HashMap;
@@ -9,8 +9,10 @@ use std::collections::HashMap;
 ///
 /// Rows are ordered by ascending cost. Prints `No usage data found` when there
 /// is nothing to show. If pricing cannot be fetched, costs fall back to `$0.00`
-/// rather than failing.
-pub fn display_usage_text(usage_data: &UsageData) {
+/// rather than failing. When `merge` is set, rows sharing a base model name
+/// across provider prefixes (e.g. `openai/gpt-5.5` + `azure/gpt-5.5`) are
+/// collapsed into one.
+pub fn display_usage_text(usage_data: &UsageData, merge: bool) {
     if usage_data.models.is_empty() {
         println!("No usage data found");
         return;
@@ -20,7 +22,7 @@ pub fn display_usage_text(usage_data: &UsageData) {
     let pricing_map =
         fetch_model_pricing().unwrap_or_else(|_| ModelPricingMap::new(HashMap::new()));
 
-    let summary = build_usage_summary(
+    let mut summary = build_usage_summary(
         &usage_data.models,
         &usage_data.per_provider,
         &usage_data.provider_days,
@@ -31,6 +33,10 @@ pub fn display_usage_text(usage_data: &UsageData) {
     if summary.rows.is_empty() {
         println!("No usage data found");
         return;
+    }
+
+    if merge {
+        summary.rows = merge_rows_by_base_model(&summary.rows);
     }
 
     for row in &summary.rows {

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,6 +126,7 @@ fn main() -> Result<()> {
             json,
             text,
             table,
+            merge_providers,
             daily,
             weekly,
             monthly,
@@ -157,12 +158,12 @@ fn main() -> Result<()> {
                 }
             } else if text {
                 let usage_data = get_usage_from_directories(time_range)?;
-                display_usage_text(&usage_data);
+                display_usage_text(&usage_data, merge_providers);
             } else if table {
                 let usage_data = get_usage_from_directories(time_range)?;
-                display_usage_table(&usage_data);
+                display_usage_table(&usage_data, merge_providers);
             } else {
-                display_usage_interactive(time_range)?;
+                display_usage_interactive(time_range, merge_providers)?;
             }
         }
 

--- a/src/utils/format.rs
+++ b/src/utils/format.rs
@@ -136,6 +136,33 @@ pub fn format_cost(cost: f64) -> String {
     format!("{sign}${}.{:02}", format_number(cents / 100), cents % 100)
 }
 
+/// Formats a USD amount for the dense interactive dashboard, abbreviating large
+/// values with a K/M/B/T suffix.
+///
+/// Amounts under `$1000` keep full cents via [`format_cost`] (`$74.18`); larger
+/// amounts drop to [`format_compact`]'s 3-significant-figure form prefixed with
+/// `$` (`$8.63K`, `$14.2K`). This mirrors how the TUI already abbreviates token
+/// counts — only the interactive view uses it, while the static table, text, and
+/// JSON paths keep [`format_cost`] so their amounts stay exact to the cent.
+///
+/// # Examples
+///
+/// ```
+/// use vibe_coding_tracker::utils::format_cost_compact;
+///
+/// assert_eq!(format_cost_compact(74.18), "$74.18");
+/// assert_eq!(format_cost_compact(4114.28), "$4.11K");
+/// assert_eq!(format_cost_compact(10021.35), "$10.0K");
+/// assert_eq!(format_cost_compact(-1500.0), "-$1.50K");
+/// ```
+pub fn format_cost_compact(cost: f64) -> String {
+    if cost.abs() < 1000.0 {
+        return format_cost(cost);
+    }
+    let sign = if cost < 0.0 { "-" } else { "" };
+    format!("{sign}${}", format_compact(cost.abs().round() as i64))
+}
+
 // Cache for current date (updated once per day)
 static DATE_CACHE: RwLock<Option<(NaiveDate, String)>> = RwLock::new(None);
 
@@ -290,6 +317,26 @@ mod tests {
         assert_eq!(format_cost(1234.56), "$1,234.56");
         assert_eq!(format_cost(1_234_567.891), "$1,234,567.89");
         assert_eq!(format_cost(-5.5), "-$5.50");
+    }
+
+    #[test]
+    fn test_format_cost_compact() {
+        // Under $1000: full cents via format_cost.
+        assert_eq!(format_cost_compact(0.0), "$0.00");
+        assert_eq!(format_cost_compact(2.42), "$2.42");
+        assert_eq!(format_cost_compact(74.18), "$74.18");
+        assert_eq!(format_cost_compact(999.99), "$999.99");
+
+        // $1000 and up: K/M/B/T with 3 significant figures.
+        assert_eq!(format_cost_compact(1000.0), "$1.00K");
+        assert_eq!(format_cost_compact(4114.28), "$4.11K");
+        assert_eq!(format_cost_compact(10021.35), "$10.0K");
+        assert_eq!(format_cost_compact(14212.22), "$14.2K");
+        assert_eq!(format_cost_compact(8_631_270.0), "$8.63M");
+
+        // Negative (credit) amounts keep a leading minus.
+        assert_eq!(format_cost_compact(-50.0), "-$50.00");
+        assert_eq!(format_cost_compact(-1500.0), "-$1.50K");
     }
 
     #[test]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -26,7 +26,8 @@ pub use file::{
     write_json_atomic_pretty,
 };
 pub use format::{
-    format_compact, format_cost, format_duration_until, format_number, get_current_date,
+    format_compact, format_cost, format_cost_compact, format_duration_until, format_number,
+    get_current_date,
 };
 pub use git::get_git_remote_url;
 pub use heap::{release_freed_heap, tune_system_allocator};

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -252,6 +252,16 @@ fn test_usage_command_table() {
 }
 
 #[test]
+fn test_usage_command_merge_providers() {
+    // The `--merge-providers` flag must parse and run in the static modes.
+    for format in ["--table", "--text"] {
+        let mut cmd = Command::cargo_bin("vibe_coding_tracker").unwrap();
+        cmd.arg("usage").arg(format).arg("--merge-providers");
+        cmd.assert().success();
+    }
+}
+
+#[test]
 fn test_usage_command_with_output_file() {
     use std::time::Duration;
 


### PR DESCRIPTION
## Summary

The same underlying model often appears as several rows in the `usage` view because the model name carries a provider-routing prefix before `/` (e.g. `openai/gpt-5.5`, `azure/gpt-5.5`, and a bare `gpt-5.5`). This makes it hard to see a model's real total.

This PR adds an **opt-in** merge that collapses rows sharing the base model name (the segment after the first `/`) into one, summing every token bucket and the already-priced cost. It also abbreviates large costs in the dashboard so the Cost figures line up with the compacted token columns.

## Merge behaviour

- **Merge key** is everything after the first `/`; bare (un-prefixed) names fold in too. Version suffixes are **not** stripped, so `gpt-5.5` and `gpt-5.4` stay distinct.
- **Cost is summed after per-model pricing**, never re-priced under a single name. Each source row is already priced against its full model name (the differently-priced `openai/` / `azure/` variants stay correct), so the merged cost is just their sum.
- In the merged view **every row is shown under its bare base name** — the provider prefix is dropped even for a model with no duplicate (`opencode/big-pickle` -> `big-pickle`), and there is no count suffix, so the list reads uniformly.
- The per-provider **Provider Usage** panel and the grand totals are unchanged (they run on a separate source-directory aggregation).

### Surface

- **Interactive TUI**: press `m` to toggle live (default off). Re-derives from cached rows, so no directory re-scan.
- **`--merge-providers` flag**: applies to `--table` / `--text`, and seeds the TUI's initial state. **`--json` is left as the raw per-model export.**

## Compact costs in the TUI

- A new `format_cost_compact` renders costs with a K/M/B suffix in the interactive dashboard (`$8.63K`, `$14.2K`); amounts under `$1000` keep full cents (`$74.18`). This mirrors how the TUI already abbreviates token counts.
- Applied to the model table Cost column, the Provider Usage cost, and the Total Cost summary. The static `--table` / `--text` / `--json` paths stay exact to the cent.

## Testing

- Unit + doctests for the merge helper and `format_cost_compact`.
- CLI test for `usage --merge-providers` on `--table` / `--text`.
- `cargo test` (all green), `make fmt`, `uvx pre-commit run -a`.
- Manual end-to-end via a pyte screen capture: verified merged base names, summed costs matching hand totals, the `m` toggle, and compact costs (`$8.69K` / `$3.79K` in the model table, `$10.0K` / `$14.2K` in the Provider band and Total).
- READMEs (en / zh-CN / zh-TW) updated for the merge flag/keybind.