### PR TITLE
feat: add fetch subcommand for raw provider quota APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Commands:
   usage       Display token usage statistics
   version     Display version information
   update      Update to the latest version from GitHub releases
+  fetch       Fetch a provider's raw quota/usage API response
   help        Print this message or the help of the given subcommand(s)
 ```
 
@@ -467,6 +468,42 @@ vct version --json   # Machine-readable JSON
 ```
 
 The binary version is produced at build time by `build.rs` from `git describe`, so development builds include commit count + short SHA + `dirty` suffix when applicable.
+
+---
+
+## Fetch Command
+
+**Print a provider's raw quota/usage API response — no parsing, no aggregation.**
+
+Calls the same quota endpoint the `usage` dashboard uses (Claude / Codex / Copilot / Cursor) exactly once and prints the raw body, so you can inspect the exact API shape or sanity-check your credentials. It reads each provider's stored credentials and does **not** refresh tokens: if a token is expired, re-auth with that provider's own CLI (`claude` / `codex` / `copilot` / `cursor-agent`).
+
+### Flags
+
+| Flag      | Purpose                                       |
+| --------- | --------------------------------------------- |
+| *(none)*  | Pretty JSON (default)                         |
+| `--json`  | Pretty JSON                                   |
+| `--text`  | Flattened `key: value` lines, script-friendly |
+| `--table` | Flattened Field / Value table                 |
+
+### Basic Usage
+
+```bash
+# Raw JSON (default)
+vct fetch claude
+vct fetch codex
+vct fetch copilot
+vct fetch cursor
+
+# Flattened plain text
+vct fetch codex --text
+
+# Flattened key/value table
+vct fetch copilot --table
+```
+
+> [!NOTE]
+> The response body is printed to stdout as-is. On an HTTP error the body is still printed and the process exits non-zero; a 401/403 additionally prints a `run: <cli> login` hint on stderr.
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -148,6 +148,7 @@ Commands:
   usage       Display token usage statistics
   version     Display version information
   update      Update to the latest version from GitHub releases
+  fetch       Fetch a provider's raw quota/usage API response
   help        Print this message or the help of the given subcommand(s)
 ```
 
@@ -467,6 +468,42 @@ vct version --json   # 机读 JSON
 ```
 
 Binary version 由 `build.rs` 在编译期通过 `git describe` 写入，开发版本会附带 commit 计数、short SHA 与 `dirty` 后缀。
+
+---
+
+## Fetch 命令
+
+**打印某个供应商的原始 quota/usage API 响应 — 不解析、不聚合。**
+
+对 `usage` 面板使用的同一个 quota 端点（Claude / Codex / Copilot / Cursor）发一次请求，直接打印原始 body，方便你查看 API 的实际结构或检查凭证是否正常。它读取各供应商已保存的凭证，并且**不会**刷新 token：token 过期时，请用对应供应商自己的 CLI 重新登录（`claude` / `codex` / `copilot` / `cursor-agent`）。
+
+### 参数
+
+| 参数      | 用途                          |
+| --------- | ----------------------------- |
+| *(无)*    | 彩色 JSON（默认）             |
+| `--json`  | 彩色 JSON                     |
+| `--text`  | 摊平成 `key: value`，适合脚本 |
+| `--table` | 摊平成 Field / Value 表格     |
+
+### 基本用法
+
+```bash
+# 原始 JSON（默认）
+vct fetch claude
+vct fetch codex
+vct fetch copilot
+vct fetch cursor
+
+# 摊平成纯文本
+vct fetch codex --text
+
+# 摊平成 key/value 表格
+vct fetch copilot --table
+```
+
+> [!NOTE]
+> 响应 body 会原样打印到 stdout。遇到 HTTP 错误时仍会打印 body 并以非零状态退出；401/403 还会在 stderr 额外打印 `run: <cli> login` 提示。
 
 ---
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -148,6 +148,7 @@ Commands:
   usage       Display token usage statistics
   version     Display version information
   update      Update to the latest version from GitHub releases
+  fetch       Fetch a provider's raw quota/usage API response
   help        Print this message or the help of the given subcommand(s)
 ```
 
@@ -467,6 +468,42 @@ vct version --json   # 機器可讀的 JSON
 ```
 
 Binary version 由 `build.rs` 在編譯期透過 `git describe` 寫入，開發版本會附上 commit 數、short SHA 與 `dirty` 後綴。
+
+---
+
+## Fetch 指令
+
+**印出某個供應商的原始 quota/usage API 回應 — 不解析、不彙整。**
+
+對 `usage` 面板使用的同一個 quota 端點（Claude / Codex / Copilot / Cursor）發一次請求，直接印出原始 body，方便你檢視 API 的實際結構或確認憑證是否正常。它讀取各供應商已儲存的憑證，而且**不會**刷新 token：token 過期時，請用對應供應商自己的 CLI 重新登入（`claude` / `codex` / `copilot` / `cursor-agent`）。
+
+### 參數
+
+| 參數      | 用途                          |
+| --------- | ----------------------------- |
+| *(無)*    | 彩色 JSON（預設）             |
+| `--json`  | 彩色 JSON                     |
+| `--text`  | 攤平成 `key: value`，適合腳本 |
+| `--table` | 攤平成 Field / Value 表格     |
+
+### 基本用法
+
+```bash
+# 原始 JSON（預設）
+vct fetch claude
+vct fetch codex
+vct fetch copilot
+vct fetch cursor
+
+# 攤平成純文字
+vct fetch codex --text
+
+# 攤平成 key/value 表格
+vct fetch copilot --table
+```
+
+> [!NOTE]
+> 回應 body 會原樣印到 stdout。遇到 HTTP 錯誤時仍會印出 body 並以非零狀態結束；401/403 會在 stderr 額外印出 `run: <cli> login` 提示。
 
 ---
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,7 +6,7 @@
 //! mutually-exclusive `--daily` / `--weekly` / `--monthly` / `--all` flags
 //! into a single [`TimeRange`].
 
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;
 
 /// Time window applied when aggregating sessions.
@@ -69,6 +69,19 @@ pub fn resolve_time_range(daily: bool, weekly: bool, monthly: bool) -> TimeRange
     } else {
         TimeRange::All
     }
+}
+
+/// A provider whose raw quota/usage API response `vct fetch` can print.
+#[derive(ValueEnum, Debug, Clone, Copy)]
+pub enum FetchProvider {
+    /// Claude Code (`GET /api/oauth/usage`).
+    Claude,
+    /// OpenAI Codex (ChatGPT `wham/usage`).
+    Codex,
+    /// GitHub Copilot CLI (`GET /copilot_internal/user`).
+    Copilot,
+    /// Cursor CLI (`GET /api/usage-summary`).
+    Cursor,
 }
 
 /// Vibe Coding Tracker - AI coding assistant usage analyzer.
@@ -184,5 +197,23 @@ pub enum Commands {
         /// Force update without confirmation prompt.
         #[arg(long, short)]
         force: bool,
+    },
+
+    /// Fetch a provider's raw quota/usage API response.
+    Fetch {
+        /// Which provider to fetch (claude | codex | copilot | cursor).
+        provider: FetchProvider,
+
+        /// Output as pretty JSON (default).
+        #[arg(long, group = "fetch_format")]
+        json: bool,
+
+        /// Output as flattened plain text.
+        #[arg(long, group = "fetch_format")]
+        text: bool,
+
+        /// Output as a flattened key/value table.
+        #[arg(long, group = "fetch_format")]
+        table: bool,
     },
 }

--- a/src/display/fetch.rs
+++ b/src/display/fetch.rs
@@ -1,0 +1,158 @@
+//! Renderers for `vct fetch`.
+//!
+//! The provider quota APIs return nested JSON dicts. `--json` (the default)
+//! pretty-prints the body as-is; `--text` and `--table` flatten it to
+//! dotted-path `key -> value` rows. Every renderer falls back to printing the
+//! raw body verbatim when it is not valid JSON (e.g. an HTML error page).
+
+use comfy_table::{Cell, CellAlignment, Color, ContentArrangement, Table, presets::UTF8_FULL};
+use serde_json::Value;
+
+/// Prints the response body as pretty JSON, or verbatim if it is not JSON.
+pub fn print_fetch_json(body: &str) {
+    match serde_json::from_str::<Value>(body) {
+        Ok(value) => match serde_json::to_string_pretty(&value) {
+            Ok(pretty) => println!("{pretty}"),
+            Err(_) => println!("{body}"),
+        },
+        Err(_) => println!("{body}"),
+    }
+}
+
+/// Prints the response as flattened `key: value` lines, or verbatim if it is
+/// not JSON.
+pub fn display_fetch_text(body: &str) {
+    match serde_json::from_str::<Value>(body) {
+        Ok(value) => {
+            let mut rows = Vec::new();
+            flatten(&value, String::new(), &mut rows);
+            for (key, val) in rows {
+                println!("{key}: {val}");
+            }
+        }
+        Err(_) => println!("{body}"),
+    }
+}
+
+/// Prints the response as a flattened Field/Value table, or the raw body
+/// verbatim if it is not JSON.
+pub fn display_fetch_table(body: &str) {
+    let value = match serde_json::from_str::<Value>(body) {
+        Ok(v) => v,
+        Err(_) => {
+            println!("{body}");
+            return;
+        }
+    };
+
+    let mut rows = Vec::new();
+    flatten(&value, String::new(), &mut rows);
+
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_FULL)
+        .set_content_arrangement(ContentArrangement::Dynamic)
+        .set_header(vec![
+            Cell::new("Field")
+                .fg(Color::Green)
+                .set_alignment(CellAlignment::Left),
+            Cell::new("Value")
+                .fg(Color::Green)
+                .set_alignment(CellAlignment::Left),
+        ]);
+    for (key, val) in rows {
+        table.add_row(vec![
+            Cell::new(key)
+                .fg(Color::Cyan)
+                .set_alignment(CellAlignment::Left),
+            Cell::new(val)
+                .fg(Color::White)
+                .set_alignment(CellAlignment::Left),
+        ]);
+    }
+
+    println!("{table}");
+}
+
+/// Recursively flattens a JSON value into `(dotted-key, value)` rows.
+///
+/// Objects recurse as `prefix.key`, arrays as `prefix[i]`, and scalars emit one
+/// row. An empty container or a scalar root still yields a single row so the
+/// output is never silently empty.
+fn flatten(value: &Value, prefix: String, out: &mut Vec<(String, String)>) {
+    match value {
+        Value::Object(map) if !map.is_empty() => {
+            for (k, v) in map {
+                let key = if prefix.is_empty() {
+                    k.clone()
+                } else {
+                    format!("{prefix}.{k}")
+                };
+                flatten(v, key, out);
+            }
+        }
+        Value::Array(arr) if !arr.is_empty() => {
+            for (i, v) in arr.iter().enumerate() {
+                flatten(v, format!("{prefix}[{i}]"), out);
+            }
+        }
+        _ => {
+            let key = if prefix.is_empty() {
+                "(root)".to_string()
+            } else {
+                prefix
+            };
+            out.push((key, scalar_to_string(value)));
+        }
+    }
+}
+
+/// Renders a JSON scalar (or empty container) as a plain display string,
+/// unquoting strings so `"pro"` shows as `pro`.
+fn scalar_to_string(value: &Value) -> String {
+    match value {
+        Value::String(s) => s.clone(),
+        Value::Null => "null".to_string(),
+        Value::Object(_) => "{}".to_string(),
+        Value::Array(_) => "[]".to_string(),
+        other => other.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flatten_nested_object_uses_dotted_keys() {
+        let value = serde_json::json!({
+            "plan_type": "pro",
+            "rate_limit": { "primary": { "used_percent": 42.5 } },
+            "windows": [ { "kind": "weekly" } ],
+            "empty": {}
+        });
+        let mut rows = Vec::new();
+        flatten(&value, String::new(), &mut rows);
+        let map: std::collections::HashMap<_, _> = rows.into_iter().collect();
+
+        assert_eq!(map.get("plan_type").map(String::as_str), Some("pro"));
+        assert_eq!(
+            map.get("rate_limit.primary.used_percent")
+                .map(String::as_str),
+            Some("42.5")
+        );
+        assert_eq!(
+            map.get("windows[0].kind").map(String::as_str),
+            Some("weekly")
+        );
+        assert_eq!(map.get("empty").map(String::as_str), Some("{}"));
+    }
+
+    #[test]
+    fn flatten_scalar_root_yields_single_row() {
+        let value = serde_json::json!("hello");
+        let mut rows = Vec::new();
+        flatten(&value, String::new(), &mut rows);
+        assert_eq!(rows, vec![("(root)".to_string(), "hello".to_string())]);
+    }
+}

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -6,4 +6,5 @@
 
 pub mod analysis;
 pub mod common;
+pub mod fetch;
 pub mod usage;

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -1,0 +1,80 @@
+//! `vct fetch <provider>`: one-shot raw quota-API fetch.
+//!
+//! Reads the provider's stored credentials (no token refresh — an expired token
+//! just 401s and the user re-auths via that provider's own CLI), sends a single
+//! request impersonating that provider's CLI, and prints the raw response body
+//! in the chosen format (pretty JSON by default). A non-2xx status still prints
+//! the body, then exits non-zero with the provider's login hint.
+
+use crate::cli::FetchProvider;
+use crate::display::fetch::{display_fetch_table, display_fetch_text, print_fetch_json};
+use crate::quota::{
+    CLAUDE_LOGIN_HINT, CODEX_LOGIN_HINT, COPILOT_LOGIN_HINT, CURSOR_LOGIN_HINT, http,
+};
+use anyhow::{Result, bail};
+
+/// Runs `vct fetch <provider>`: fetch the raw body and render it.
+///
+/// `text` / `table` pick the output format; neither set means pretty JSON.
+///
+/// # Errors
+///
+/// Returns an error if credentials are missing, the request fails, or the API
+/// answers a non-2xx status (the body is still printed first).
+pub fn run(provider: FetchProvider, text: bool, table: bool) -> Result<()> {
+    let (status, body) = fetch_raw(provider)?;
+
+    if text {
+        display_fetch_text(&body);
+    } else if table {
+        display_fetch_table(&body);
+    } else {
+        print_fetch_json(&body);
+    }
+
+    if !(200..300).contains(&status) {
+        // A rejected token (401/403) is the one case a re-login fixes, so only
+        // then append the provider's login hint; other statuses (429, 5xx, ...)
+        // just report the code.
+        if status == 401 || status == 403 {
+            bail!(
+                "HTTP {status} from {} ({})",
+                provider_name(provider),
+                login_hint(provider)
+            );
+        }
+        bail!("HTTP {status} from {}", provider_name(provider));
+    }
+    Ok(())
+}
+
+/// Dispatches to the provider's raw fetcher over the shared HTTP client.
+fn fetch_raw(provider: FetchProvider) -> Result<(u16, String)> {
+    let client = http::build_client()?;
+    match provider {
+        FetchProvider::Claude => crate::quota::claude::fetch_claude_raw(&client),
+        FetchProvider::Codex => crate::quota::wham::fetch_codex_raw(&client),
+        FetchProvider::Copilot => crate::quota::copilot::fetch_copilot_raw(&client),
+        FetchProvider::Cursor => crate::quota::cursor::fetch_cursor_raw(&client),
+    }
+}
+
+/// The provider's lowercase name, for error messages.
+fn provider_name(provider: FetchProvider) -> &'static str {
+    match provider {
+        FetchProvider::Claude => "claude",
+        FetchProvider::Codex => "codex",
+        FetchProvider::Copilot => "copilot",
+        FetchProvider::Cursor => "cursor",
+    }
+}
+
+/// The provider's `run: <cli> login` hint.
+fn login_hint(provider: FetchProvider) -> &'static str {
+    match provider {
+        FetchProvider::Claude => CLAUDE_LOGIN_HINT,
+        FetchProvider::Codex => CODEX_LOGIN_HINT,
+        FetchProvider::Copilot => COPILOT_LOGIN_HINT,
+        FetchProvider::Cursor => CURSOR_LOGIN_HINT,
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub mod cache;
 pub mod cli;
 pub mod constants;
 pub mod display;
+pub mod fetch;
 pub mod models;
 pub mod pricing;
 pub mod quota;

--- a/src/main.rs
+++ b/src/main.rs
@@ -225,6 +225,15 @@ fn main() -> Result<()> {
                 vibe_coding_tracker::update::update_interactive(force)?;
             }
         }
+
+        Commands::Fetch {
+            provider,
+            text,
+            table,
+            ..
+        } => {
+            vibe_coding_tracker::fetch::run(provider, text, table)?;
+        }
     }
 
     Ok(())

--- a/src/quota/claude.rs
+++ b/src/quota/claude.rs
@@ -86,6 +86,44 @@ fn read_claude_oauth(path: &Path) -> Option<ClaudeOauth> {
     creds.claude_ai_oauth
 }
 
+/// Fetches the raw `/api/oauth/usage` response for `vct fetch claude`.
+///
+/// Uses the stored access token verbatim (no refresh, no file writes) and
+/// returns `(status_code, body)`. A non-2xx status is left for the caller to
+/// surface — the body (often a JSON error) is still returned.
+///
+/// # Errors
+///
+/// Returns an error if the credentials file is missing, has no access token, or
+/// the request cannot be sent.
+pub(crate) fn fetch_claude_raw(client: &Client) -> Result<(u16, String)> {
+    let path = get_claude_credentials_path()?;
+    let token = read_claude_oauth(&path)
+        .and_then(|o| o.access_token)
+        .filter(|t| !t.is_empty())
+        .with_context(|| {
+            format!(
+                "no Claude access token in {} ({CLAUDE_LOGIN_HINT})",
+                path.display()
+            )
+        })?;
+    let resp = client
+        .get(CLAUDE_USAGE_URL)
+        .header(reqwest::header::USER_AGENT, claude_ua())
+        .header("x-app", CLAUDE_APP)
+        .header("anthropic-version", CLAUDE_ANTHROPIC_VERSION)
+        .header("anthropic-beta", CLAUDE_OAUTH_BETA)
+        .header("anthropic-dangerous-direct-browser-access", "true")
+        .bearer_auth(&token)
+        .send()
+        .context("Failed to send Claude usage request")?;
+    let status = resp.status().as_u16();
+    let body = resp
+        .text()
+        .context("Failed to read Claude usage response body")?;
+    Ok((status, body))
+}
+
 /// Reads the plan tier for the Plan line: prefer `rateLimitTier` (it
 /// distinguishes 5x / 20x), fall back to `subscriptionType`, prettified. Returns
 /// `None` when neither is set, so the Plan line is simply omitted.

--- a/src/quota/copilot.rs
+++ b/src/quota/copilot.rs
@@ -270,6 +270,48 @@ fn fetch_copilot_user(client: &Client, api_url: &str, token: &str, now: i64) -> 
     }
 }
 
+/// Fetches the raw `/copilot_internal/user` response for `vct fetch copilot`.
+///
+/// Uses the stored `gho_` token verbatim (Copilot has no refresh) and returns
+/// `(status_code, body)`. A non-2xx status is left for the caller to surface.
+///
+/// # Errors
+///
+/// Returns an error if the config is missing, has no usable token, or the
+/// request cannot be sent.
+pub(crate) fn fetch_copilot_raw(client: &Client) -> Result<(u16, String)> {
+    let path = get_copilot_config_path()?;
+    let body = std::fs::read_to_string(&path).with_context(|| {
+        format!(
+            "no Copilot credentials at {} ({COPILOT_LOGIN_HINT})",
+            path.display()
+        )
+    })?;
+    let creds = read_copilot_creds(&body).with_context(|| {
+        format!(
+            "no usable Copilot token in {} ({COPILOT_LOGIN_HINT})",
+            path.display()
+        )
+    })?;
+    let resp = client
+        .get(creds.api_url.as_str())
+        .header(
+            reqwest::header::AUTHORIZATION,
+            format!("token {}", creds.token),
+        )
+        .header(reqwest::header::ACCEPT, "application/json")
+        .header(reqwest::header::USER_AGENT, copilot_ua())
+        .header("Copilot-Integration-Id", COPILOT_INTEGRATION_ID)
+        .header("X-GitHub-Api-Version", COPILOT_API_VERSION)
+        .send()
+        .context("Failed to send Copilot usage request")?;
+    let status = resp.status().as_u16();
+    let text = resp
+        .text()
+        .context("Failed to read Copilot usage response body")?;
+    Ok((status, text))
+}
+
 /// Per-worker Copilot state. Copilot's token is long-lived with no refresh, so
 /// there is no in-memory token cache or refresh backoff to keep.
 #[derive(Default)]

--- a/src/quota/cursor.rs
+++ b/src/quota/cursor.rs
@@ -191,6 +191,45 @@ fn fetch_cursor_usage(client: &Client, cookie: &str, now: i64) -> FetchResult {
     }
 }
 
+/// Fetches the raw `/api/usage-summary` response for `vct fetch cursor`.
+///
+/// Synthesizes the session cookie from the stored JWT and sends one request. It
+/// does **not** check the JWT `exp` (an expired token just 401s) and never
+/// writes the file back. Returns `(status_code, body)`; a non-2xx status is
+/// left for the caller to surface.
+///
+/// # Errors
+///
+/// Returns an error if `auth.json` is missing, has no usable session, or the
+/// request cannot be sent.
+pub(crate) fn fetch_cursor_raw(client: &Client) -> Result<(u16, String)> {
+    let path = get_cursor_auth_path()?;
+    let body = std::fs::read_to_string(&path).with_context(|| {
+        format!(
+            "no Cursor credentials at {} ({CURSOR_LOGIN_HINT})",
+            path.display()
+        )
+    })?;
+    let session = read_cursor_session(&body).with_context(|| {
+        format!(
+            "no usable Cursor session in {} ({CURSOR_LOGIN_HINT})",
+            path.display()
+        )
+    })?;
+    let resp = client
+        .get(CURSOR_USAGE_URL)
+        .header(reqwest::header::COOKIE, session.cookie.as_str())
+        .header(reqwest::header::ACCEPT, "application/json")
+        .header(reqwest::header::USER_AGENT, cursor_ua())
+        .send()
+        .context("Failed to send Cursor usage request")?;
+    let status = resp.status().as_u16();
+    let text = resp
+        .text()
+        .context("Failed to read Cursor usage response body")?;
+    Ok((status, text))
+}
+
 /// Per-worker Cursor state. Refresh is reactive (the official CLI keeps
 /// `auth.json` fresh), so nothing is cached between ticks.
 #[derive(Default)]

--- a/src/quota/wham.rs
+++ b/src/quota/wham.rs
@@ -193,6 +193,42 @@ pub fn call_wham(
     }
 }
 
+/// Fetches the raw `wham/usage` response for `vct fetch codex`.
+///
+/// Uses the stored access token verbatim (no refresh, no file writes) and
+/// returns `(status_code, body)`. A non-2xx status is left for the caller to
+/// surface.
+///
+/// # Errors
+///
+/// Returns an error if `auth.json` is missing, has no access token, or the
+/// request cannot be sent.
+pub(crate) fn fetch_codex_raw(client: &reqwest::blocking::Client) -> Result<(u16, String)> {
+    let auth_path = crate::utils::resolve_paths()?.codex_dir.join("auth.json");
+    let body = std::fs::read_to_string(&auth_path).with_context(|| {
+        format!(
+            "no Codex credentials at {} ({})",
+            auth_path.display(),
+            crate::quota::CODEX_LOGIN_HINT
+        )
+    })?;
+    let (access_token, account_id) = parse_auth(&body)?;
+    let mut req = client
+        .get(WHAM_URL)
+        .header(reqwest::header::USER_AGENT, codex_ua())
+        .header("originator", CODEX_ORIGINATOR)
+        .bearer_auth(&access_token);
+    if let Some(id) = &account_id {
+        req = req.header("ChatGPT-Account-Id", id);
+    }
+    let resp = req.send().context("Failed to send Codex usage request")?;
+    let status = resp.status().as_u16();
+    let text = resp
+        .text()
+        .context("Failed to read Codex usage response body")?;
+    Ok((status, text))
+}
+
 /// Refreshes the Codex token and writes it back (rotation-safe). Returns the new
 /// access token.
 ///

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -399,6 +399,56 @@ fn test_analysis_multiple_output_formats() {
 }
 
 #[test]
+fn test_fetch_help() {
+    let mut cmd = Command::cargo_bin("vibe_coding_tracker").unwrap();
+    cmd.arg("fetch").arg("--help");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("claude"))
+        .stdout(predicate::str::contains("codex"))
+        .stdout(predicate::str::contains("copilot"))
+        .stdout(predicate::str::contains("cursor"));
+}
+
+#[test]
+fn test_fetch_requires_provider() {
+    let mut cmd = Command::cargo_bin("vibe_coding_tracker").unwrap();
+    cmd.arg("fetch");
+
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("required").or(predicate::str::contains("PROVIDER")));
+}
+
+#[test]
+fn test_fetch_invalid_provider() {
+    let mut cmd = Command::cargo_bin("vibe_coding_tracker").unwrap();
+    cmd.arg("fetch").arg("not-a-provider");
+
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid value"));
+}
+
+#[test]
+fn test_fetch_multiple_output_formats() {
+    // --json/--text/--table share a clap group and must be mutually exclusive;
+    // clap rejects the combination before any network call is made.
+    for combo in [
+        ["--json", "--text"],
+        ["--json", "--table"],
+        ["--text", "--table"],
+    ] {
+        let mut cmd = Command::cargo_bin("vibe_coding_tracker").unwrap();
+        cmd.arg("fetch").arg("claude").args(combo);
+        cmd.assert()
+            .failure()
+            .stderr(predicate::str::contains("cannot be used with"));
+    }
+}
+
+#[test]
 fn test_cli_with_env_vars() {
     // Test that environment variables are respected if defined
     let mut cmd = Command::cargo_bin("vibe_coding_tracker").unwrap();


### PR DESCRIPTION
## Summary

Adds a new `fetch` subcommand that prints a provider's **raw** quota/usage API response, with no parsing or aggregation. It hits the same endpoints the `usage` quota panels use, but returns the untouched body so you can inspect the exact API shape or sanity-check credentials.

```bash
vct fetch claude       # pretty JSON (default)
vct fetch codex --text # flattened key: value lines
vct fetch copilot --table
vct fetch cursor
```

## Details

- Providers: `claude`, `codex`, `copilot`, `cursor` (a clap `ValueEnum`, so invalid names are rejected with the valid set).
- Output modes mirror the other subcommands: `--json` (default), `--text`, `--table`. `--text` / `--table` flatten the nested JSON into dotted-path `key -> value` rows; a non-JSON body is printed verbatim.
- **No token refresh.** Each provider's stored credentials are read as-is; an expired token just returns 401 and the user re-auths via that provider's own CLI (`claude` / `codex` / `copilot` / `cursor-agent`).
- On a non-2xx status the body is still printed, then the process exits non-zero; a 401/403 additionally prints the provider's `run: <cli> login` hint on stderr.
- Reuses the existing per-provider request builders / credential readers and the shared 8s HTTP client; no changes to the existing quota workers or snapshot mapping.

## Docs & tests

- Updated all three READMEs (`README.md`, `README.zh-CN.md`, `README.zh-TW.md`) with a `Fetch Command` section.
- Added `tests/cli.rs` coverage (help, required/invalid provider, output-flag mutual exclusion) plus inline unit tests for the JSON flattener.

## Verification

- `cargo build`, `cargo test`, `make fmt` (clippy `-D warnings`), and `uvx pre-commit run -a` all pass.
- Ran `vct fetch` against all four providers locally: JSON / text / table render correctly, and an expired/limited token surfaces the expected status and hint.
