### PR TITLE
feat(logging): add file-based diagnostic logging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,7 @@ Resolved by `src/utils/paths.rs` (`resolve_paths`):
 | Hermes        | `$HERMES_HOME/state.db` (default `~/.hermes`, or `%LOCALAPPDATA%\hermes` on Windows; SQLite `session_model_usage` table, read via `rusqlite`; `usage` only)  |
 | Pricing cache | `~/.vct/model_pricing_YYYY-MM-DD.json`                                                                                                                       |
 | User settings | `~/.vct/config.toml`                                                                                                                                         |
+| Log files     | `~/.vct/logs/vct-YYYY-MM-DD.log` (daily plain-text diagnostics; created lazily)                                                                              |
 
 ### Quota panels (`src/quota/`)
 
@@ -141,6 +142,12 @@ The `usage` TUI shows live remaining quota for **Claude / Codex / Copilot / Curs
 ### File cache (`src/cache/`)
 
 Global singleton `GLOBAL_FILE_CACHE` (capacity = 5 in `constants::capacity::FILE_CACHE_SIZE`) keyed by `PathBuf`, holding `Arc<CodeAnalysis>` — **typed** form, not `serde_json::Value`, because `to_value` deep-clones every string. Invalidation is by mtime. TUI keeps cache size small to bound RSS; bump deliberately if you change the displayed-sessions horizon.
+
+### Diagnostic logging (`src/logging/`)
+
+The crate keeps the standard `log` facade (every `log::warn!` / `error!` call site is unchanged) but the output backend is a **custom `log::Log` that writes only to a file** — never stdout/stderr, so it is TUI-safe by construction (there is no `env_logger` anymore). Records land in `~/.vct/logs/vct-YYYY-MM-DD.log` (plain text, `<utc-nanos> <LEVEL> <target>  <message>`, the crate's `vibe_coding_tracker::` target shortened to `vct::`; the file name is the **UTC** date so it matches the line timestamps, and rolls over on the first record after UTC midnight). The file is opened behind a `Mutex` shared by the main thread and the ≤4 quota workers, written with a single `write_all` per record and **no user-space buffering** so nothing is lost under `panic = "abort"`, and **created lazily on the first record** — a command that logs nothing (e.g. a successful `vct version`) never touches `~/.vct`, preserving the "settings-free commands don't create `~/.vct`" rule.
+
+`main.rs` calls `logging::init()` **once, before dispatch** (installs the logger at the default level `warn` plus a panic hook) and `logging::apply(&config.logging)` in the `usage` / `analysis`-batch branches after `config::load()` — that reads `[logging]` to set the level via `log::set_max_level` and prunes daily files older than `retention_days` (default 7). Because config load is lazy, subcommands that never load it stay at the `warn` default (still enough to record errors). The panic hook chains to the previous hook after calling `tui::force_restore_terminal()` (gated by the `IN_TUI` atomic set by `setup_terminal`/`restore_terminal`) so a panic during the TUI restores the screen before the default message prints, and `main` logs the final top-level `Err` at ERROR before returning it. **Where errors are recorded:** the quota fetchers log every `Transient`-collapse (network / non-success HTTP status / body-parse failure, previously discarded silently), and the batch-parser / SQLite-reader warnings that used to `eprintln!` (and corrupt the TUI during refresh) now go through `log::warn!` (file only). The two non-TUI pricing warnings still `eprintln!` to the console **and** mirror to the log.
 
 ### Build version (`build.rs`)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,29 +782,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
-name = "env_filter"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1546,30 +1523,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "jiff"
-version = "0.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1988,21 +1941,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
-]
-
-[[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
-dependencies = [
- "portable-atomic",
 ]
 
 [[package]]
@@ -3313,7 +3251,6 @@ dependencies = [
  "comfy-table",
  "criterion",
  "crossterm 0.29.0",
- "env_logger",
  "flate2",
  "home",
  "hostname",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ chrono = { version = "0.4.44", features = ["serde"] }
 clap = { version = "4.6.1", features = ["derive", "env"] }
 comfy-table = "7.2.2"
 crossterm = "0.29.0"
-env_logger = "0.11.10"
 flate2 = "1.1.9"
 home = "0.5.11"
 hostname = "0.4.2"

--- a/README.md
+++ b/README.md
@@ -549,6 +549,13 @@ copilot = true
 gemini = true
 opencode = true
 cursor = true
+
+[logging]
+# Minimum level written to ~/.vct/logs/vct-YYYY-MM-DD.log.
+# One of: "off" | "error" | "warn" | "info" | "debug" | "trace".
+level = "warn"
+# Days of daily log files to keep; older files are pruned on startup. 0 keeps every file.
+retention_days = 7
 ```
 
 | Setting                        | Effect                                                                                                                       |
@@ -560,9 +567,14 @@ cursor = true
 | `usage.quota.refresh_interval` | Poll cadence for every live quota panel (seconds); higher is safer against a provider's rate limits.                         |
 | `analysis.refresh_interval`    | Redraw cadence of the `analysis` dashboard (seconds).                                                                        |
 | `providers.*`                  | Skip a provider entirely (no scan, no API) when `false` — handy if you don't use one.                                        |
+| `logging.level`                | Minimum severity written to the log file (`off`..`trace`); never printed to the terminal.                                    |
+| `logging.retention_days`       | Days of daily log files to keep; older `vct-*.log` are pruned on startup (`0` keeps all).                                    |
 
 > [!NOTE]
 > Cursor `usage` is a **local estimate** from the chat stores, so it behaves like Claude Code / Codex / Copilot / Gemini (all computed from local session files) and needs no network. It undercounts Cursor's real spend, because much of it is billed under Cursor-internal model names the local data cannot price — treat Cursor cost as approximate.
+
+> [!NOTE]
+> vct writes diagnostics to `~/.vct/logs/vct-YYYY-MM-DD.log` (plain text, file only — never shown in the dashboard). It stays quiet when healthy (default level `warn`) and the file is created lazily, so a healthy run leaves nothing behind. When a quota fetch fails or a session is skipped, that is where the reason is recorded — bump `logging.level` to `debug` for the full detail.
 
 ### Managing the file
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -548,6 +548,13 @@ copilot = true
 gemini = true
 opencode = true
 cursor = true
+
+[logging]
+# 写入 ~/.vct/logs/vct-YYYY-MM-DD.log 的最低日志级别。
+# 取值: "off" | "error" | "warn" | "info" | "debug" | "trace"。
+level = "warn"
+# 保留多少天的每日日志文件; 更旧的文件会在启动时清除。0 表示全部保留。
+retention_days = 7
 ```
 
 | 设置项                         | 作用                                                                                             |
@@ -559,6 +566,11 @@ cursor = true
 | `usage.quota.refresh_interval` | 每个实时额度面板的轮询间隔（秒）；数值越大越不容易触发 provider 的速率限制。                     |
 | `analysis.refresh_interval`    | `analysis` 面板的自动刷新间隔（秒）。                                                            |
 | `providers.*`                  | 设为 `false` 时完全跳过某个 provider（不扫描、不调用 API）——如果你不用某个 provider 会很方便。   |
+| `logging.level`                | 写入日志文件的最低级别（`off`..`trace`）；从不打印到终端。                                       |
+| `logging.retention_days`       | 保留多少天的每日日志文件；更旧的 `vct-*.log` 会在启动时清除（`0` 表示全部保留）。                |
+
+> [!NOTE]
+> vct 会把诊断信息写入 `~/.vct/logs/vct-YYYY-MM-DD.log`（纯文本，仅写文件，绝不显示在面板上）。健康运行时保持安静（默认级别 `warn`），且文件是惰性创建的，所以一次正常运行不会留下任何文件。当额度获取失败或某个 session 被跳过时，原因就记录在这里——需要完整细节时把 `logging.level` 调到 `debug`。
 
 > [!NOTE]
 > Cursor 的 `usage` 是从聊天库得出的**本地估算**，因此它会像 Claude Code / Codex / Copilot / Gemini 一样（都是从本地 session 文件计算得出）无需联网。该估算会低估 Cursor 的真实花费，因为其中很大一部分是以 Cursor 内部的 model 名称计费，本地数据无法为这些名称定价，所以请把 Cursor 费用视为近似值。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -548,6 +548,13 @@ copilot = true
 gemini = true
 opencode = true
 cursor = true
+
+[logging]
+# 寫入 ~/.vct/logs/vct-YYYY-MM-DD.log 的最低日誌等級。
+# 取值: "off" | "error" | "warn" | "info" | "debug" | "trace"。
+level = "warn"
+# 保留幾天的每日日誌檔; 更舊的檔案會在啟動時清除。0 表示全部保留。
+retention_days = 7
 ```
 
 | 設定項                         | 效果                                                                                            |
@@ -559,6 +566,11 @@ cursor = true
 | `usage.quota.refresh_interval` | 每個即時額度面板的輪詢間隔（秒）；數值越大越不容易觸發 provider 的速率限制。                    |
 | `analysis.refresh_interval`    | `analysis` 儀表板自動刷新的間隔（秒）。                                                         |
 | `providers.*`                  | 設為 `false` 時完全略過某個 provider（不掃描、不呼叫 API），沒在用的話很方便。                  |
+| `logging.level`                | 寫入日誌檔的最低等級（`off`..`trace`）；絕不會印到終端機。                                      |
+| `logging.retention_days`       | 保留幾天的每日日誌檔；更舊的 `vct-*.log` 會在啟動時清除（`0` 表示全部保留）。                   |
+
+> [!NOTE]
+> vct 會把診斷訊息寫入 `~/.vct/logs/vct-YYYY-MM-DD.log`（純文字，只寫檔案，絕不顯示在儀表板上）。健康運行時保持安靜（預設等級 `warn`），而且檔案是延遲建立的，所以一次正常執行不會留下任何檔案。當額度抓取失敗或某個 session 被略過時，原因就記錄在這裡——需要完整細節時把 `logging.level` 調到 `debug`。
 
 > [!NOTE]
 > Cursor 的 `usage` 是從對話庫產生的**本地估算**，因此行為與 Claude Code / Codex / Copilot / Gemini 一致（全都是從本地 session 檔案計算），而且不需要連網。這個估算會低估 Cursor 的真實花費，因為其中有很大一部分是以 Cursor 內部的 model 名稱計費，而本地資料無法為這些名稱定價，所以請把 Cursor 的費用視為概估值。

--- a/src/analysis/aggregator.rs
+++ b/src/analysis/aggregator.rs
@@ -248,8 +248,8 @@ pub fn aggregate_sessions_by_model_from_paths_with(
             time_range,
         )
     {
-        eprintln!(
-            "Warning: Failed to read OpenCode DB {}: {err}",
+        log::warn!(
+            "failed to read OpenCode DB {}: {err}",
             paths.opencode_db.display()
         );
     }
@@ -267,7 +267,7 @@ pub fn aggregate_sessions_by_model_from_paths_with(
             time_range,
         )
     {
-        eprintln!("Warning: Failed to read Cursor stores: {err}");
+        log::warn!("failed to read Cursor stores: {err}");
     }
 
     let mut all_dates: HashSet<&String> = HashSet::new();
@@ -358,11 +358,7 @@ where
             match parse_session_file_as(&file_info.path, provider, ParseMode::UsageOnly) {
                 Ok(analysis) => Some((file_info.modified_date.clone(), analysis)),
                 Err(e) => {
-                    eprintln!(
-                        "Warning: Failed to parse {}: {}",
-                        file_info.path.display(),
-                        e
-                    );
+                    log::warn!("failed to parse {}: {e}", file_info.path.display());
                     None
                 }
             }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -49,6 +49,8 @@ pub struct Config {
     pub analysis: AnalysisConfig,
     #[serde(default)]
     pub providers: ProvidersConfig,
+    #[serde(default)]
+    pub logging: LoggingConfig,
 }
 
 /// `[general]` — settings shared across subcommands.
@@ -192,8 +194,58 @@ impl Default for ProvidersConfig {
     }
 }
 
+/// `[logging]` — file logging preferences.
+///
+/// Diagnostics are written to `~/.vct/logs/vct-YYYY-MM-DD.log` (plain text, one
+/// line per record). Nothing is ever printed to the terminal, so the TUI is
+/// never disturbed. The log file is created lazily on the first record, so a
+/// command that logs nothing never touches `~/.vct`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct LoggingConfig {
+    /// Minimum level written to the log file.
+    /// One of: "off" | "error" | "warn" | "info" | "debug" | "trace".
+    #[serde(default)]
+    pub level: LogLevel,
+    /// Days of daily log files to keep; older `vct-*.log` files are pruned on
+    /// startup. `0` keeps every file.
+    #[serde(default = "default_log_retention_days")]
+    pub retention_days: u32,
+}
+
+impl Default for LoggingConfig {
+    fn default() -> Self {
+        Self {
+            level: LogLevel::default(),
+            retention_days: default_log_retention_days(),
+        }
+    }
+}
+
+/// Minimum severity written to the log file.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum LogLevel {
+    /// Disable file logging entirely.
+    Off,
+    /// Only errors.
+    Error,
+    /// Errors and warnings (the default — quiet when healthy, records problems).
+    #[default]
+    Warn,
+    /// Adds high-level informational breadcrumbs.
+    Info,
+    /// Adds verbose diagnostics (per-file parse skips, quota poll detail).
+    Debug,
+    /// Everything, including cache-hit traces.
+    Trace,
+}
+
 fn default_true() -> bool {
     true
+}
+
+fn default_log_retention_days() -> u32 {
+    7
 }
 
 fn default_refresh_secs() -> u64 {
@@ -740,6 +792,8 @@ mod tests {
         assert_eq!(cfg.analysis.refresh_interval, 10);
         assert_eq!(cfg.providers, ProvidersConfig::default());
         assert!(cfg.providers.cursor);
+        assert_eq!(cfg.logging.level, LogLevel::Warn);
+        assert_eq!(cfg.logging.retention_days, 7);
     }
 
     #[test]
@@ -751,6 +805,9 @@ mod tests {
         assert!(cfg.providers.cursor);
         assert_eq!(cfg.usage.refresh_secs(), 10);
         assert_eq!(cfg.usage.quota_refresh_secs(), 60);
+        // A file with no [logging] section backfills the whole section default,
+        // which is what keeps the additive section migration-free.
+        assert_eq!(cfg.logging, LoggingConfig::default());
     }
 
     #[test]

--- a/src/display/common/tui.rs
+++ b/src/display/common/tui.rs
@@ -7,7 +7,7 @@
 
 use crate::display::common::table::{REPO_LABEL, REPO_URL};
 use crossterm::{
-    cursor::MoveTo,
+    cursor::{MoveTo, Show},
     event::{self, Event, KeyCode, KeyEventKind, KeyModifiers},
     execute, queue,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
@@ -19,7 +19,16 @@ use ratatui::{
     widgets::{ScrollbarState, TableState},
 };
 use std::io::{self, Write};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
+
+/// Whether the alternate-screen TUI currently owns the terminal.
+///
+/// Set while [`setup_terminal`] .. [`restore_terminal`] is active so the panic
+/// hook ([`force_restore_terminal`]) knows whether it must undo raw mode. A
+/// bare atomic (not tied to the `Terminal` handle) is what lets the panic hook,
+/// which has no access to that handle, restore the screen.
+static IN_TUI: AtomicBool = AtomicBool::new(false);
 
 /// Puts the terminal into raw mode and the alternate screen, returning a ready [`Terminal`].
 ///
@@ -39,6 +48,7 @@ pub fn setup_terminal() -> anyhow::Result<Terminal<CrosstermBackend<io::Stdout>>
     execute!(stdout, EnterAlternateScreen)?;
     let backend = CrosstermBackend::new(stdout);
     let terminal = Terminal::new(backend)?;
+    IN_TUI.store(true, Ordering::SeqCst);
     Ok(terminal)
 }
 
@@ -55,7 +65,23 @@ pub fn restore_terminal(
     disable_raw_mode()?;
     execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
     terminal.show_cursor()?;
+    IN_TUI.store(false, Ordering::SeqCst);
     Ok(())
+}
+
+/// Best-effort terminal restore for the panic hook, when no [`Terminal`] handle
+/// is available.
+///
+/// No-ops unless the TUI currently owns the screen (see [`IN_TUI`]), so calling
+/// it from a panic that fired outside the TUI emits nothing. Every step is
+/// best-effort: a panic hook must never itself panic or early-return, so errors
+/// are ignored and the flag is cleared regardless.
+pub fn force_restore_terminal() {
+    if !IN_TUI.swap(false, Ordering::SeqCst) {
+        return;
+    }
+    let _ = disable_raw_mode();
+    let _ = execute!(io::stdout(), LeaveAlternateScreen, Show);
 }
 
 /// Layers an OSC 8 terminal hyperlink over the repo label the footer just drew.

--- a/src/display/usage/table.rs
+++ b/src/display/usage/table.rs
@@ -35,6 +35,7 @@ pub fn display_usage_table(usage_data: &UsageData, merge: bool) {
     let pricing_map = match fetch_model_pricing() {
         Ok(map) => map,
         Err(e) => {
+            log::warn!("failed to fetch pricing data: {e}; costs shown as $0.00");
             eprintln!("Warning: Failed to fetch pricing data: {}", e);
             eprintln!("Costs will be shown as $0.00");
             ModelPricingMap::new(HashMap::new())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub mod config;
 pub mod constants;
 pub mod display;
 pub mod fetch;
+pub mod logging;
 pub mod models;
 pub mod pricing;
 pub mod quota;

--- a/src/logging/mod.rs
+++ b/src/logging/mod.rs
@@ -1,0 +1,357 @@
+//! File-based diagnostic logging (`~/.vct/logs/vct-YYYY-MM-DD.log`).
+//!
+//! Keeps the standard `log` facade — every existing `log::warn!` / `error!` in
+//! the crate is unchanged — but swaps the output backend for a small file
+//! logger. Records land in a plain-text daily file under `~/.vct/logs`, **never**
+//! on stdout/stderr, so the interactive TUI is never corrupted. The file is
+//! created lazily on the first record, so a command that logs nothing (e.g. a
+//! successful `vct version`) leaves `~/.vct` untouched.
+//!
+//! [`init`] installs the logger (default level `warn`) plus a panic hook that
+//! restores the terminal and records the panic. [`apply`] later reconfigures the
+//! level from `[logging]` in the user config and prunes stale files.
+
+use crate::config::{LogLevel, LoggingConfig};
+use crate::utils::now_rfc3339_utc_nanos;
+use chrono::{Duration, NaiveDate, Utc};
+use log::{Level, LevelFilter, Log, Metadata, Record};
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Mutex, OnceLock};
+
+/// Subdirectory of `~/.vct` holding the daily log files.
+const LOG_DIR_NAME: &str = "logs";
+const LOG_FILE_PREFIX: &str = "vct-";
+const LOG_FILE_SUFFIX: &str = ".log";
+
+/// The process-wide file logger, installed once by [`init`].
+static LOGGER: OnceLock<FileLogger> = OnceLock::new();
+
+/// An open daily log file plus the UTC date it was opened for.
+///
+/// Tracking the date lets a process that crosses UTC midnight roll over to the
+/// next day's file instead of appending a whole multi-day session into the file
+/// named for the day it started.
+struct OpenLog {
+    date: String,
+    file: File,
+}
+
+/// A thread-safe file logger implementing [`log::Log`].
+///
+/// The open file lives behind a `Mutex` so the main thread and the (up to four)
+/// background quota workers can share it. Each record is written with a single
+/// `write_all` and no user-space buffering, so nothing is lost on a
+/// `panic = "abort"` process abort.
+struct FileLogger {
+    /// Current max level as `LevelFilter as usize`, kept in sync with
+    /// `log::set_max_level` so [`FileLogger::enabled`] stays authoritative.
+    level: AtomicUsize,
+    /// The log directory (`~/.vct/logs`), or `None` when the home directory
+    /// cannot be resolved (logging then silently no-ops).
+    dir: Option<PathBuf>,
+    /// The currently-open daily file, opened lazily on the first record and
+    /// reopened when the UTC day rolls over.
+    open: Mutex<Option<OpenLog>>,
+}
+
+impl FileLogger {
+    /// Builds a logger rooted at `dir` (test seam) with an initial max level.
+    fn new(dir: Option<PathBuf>, level: LevelFilter) -> Self {
+        Self {
+            level: AtomicUsize::new(level as usize),
+            dir,
+            open: Mutex::new(None),
+        }
+    }
+
+    /// Appends one preformatted line, opening (or rotating to) the day's file.
+    ///
+    /// Creating `~/.vct/logs` and the file only happens here, so a process that
+    /// never emits a record never creates anything on disk. The file name uses
+    /// the same UTC date as the line timestamps, and rolls over on the first
+    /// record after UTC midnight.
+    fn append(&self, line: &str) {
+        let Some(dir) = self.dir.as_deref() else {
+            return;
+        };
+        let today = utc_date();
+        // A poisoned mutex still holds a valid file handle; recover and keep logging.
+        let mut guard = self.open.lock().unwrap_or_else(|p| p.into_inner());
+        // (Re)open when there is no file yet or the UTC day has rolled over.
+        if guard.as_ref().is_none_or(|o| o.date != today) {
+            if fs::create_dir_all(dir).is_err() {
+                return;
+            }
+            let path = dir.join(format!("{LOG_FILE_PREFIX}{today}{LOG_FILE_SUFFIX}"));
+            match OpenOptions::new().create(true).append(true).open(&path) {
+                Ok(file) => *guard = Some(OpenLog { date: today, file }),
+                Err(_) => return,
+            }
+        }
+        if let Some(open) = guard.as_mut() {
+            let _ = open.file.write_all(line.as_bytes());
+        }
+    }
+}
+
+impl Log for FileLogger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        metadata.level() as usize <= self.level.load(Ordering::Relaxed)
+    }
+
+    fn log(&self, record: &Record) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+        let line = format_line(
+            &now_rfc3339_utc_nanos(),
+            record.level(),
+            record.target(),
+            &record.args().to_string(),
+        );
+        self.append(&line);
+    }
+
+    fn flush(&self) {
+        if let Ok(mut guard) = self.open.lock()
+            && let Some(open) = guard.as_mut()
+        {
+            let _ = open.file.flush();
+        }
+    }
+}
+
+/// Today's date in UTC as `YYYY-MM-DD`.
+///
+/// Deliberately UTC (not the local-day `utils::get_current_date`) so a log
+/// file's name matches the UTC timestamps of the lines inside it.
+fn utc_date() -> String {
+    Utc::now().date_naive().format("%Y-%m-%d").to_string()
+}
+
+/// Formats one log line: `<utc-nanos> <LEVEL> <target>  <message>`.
+///
+/// The crate's own `vibe_coding_tracker::` target prefix is shortened to `vct::`
+/// to keep lines readable.
+fn format_line(now: &str, level: Level, target: &str, msg: &str) -> String {
+    format!("{now} {:<5} {}  {msg}\n", level, normalize_target(target))
+}
+
+/// Rewrites the crate's module-path target from `vibe_coding_tracker[...]` to
+/// `vct[...]`; leaves third-party targets untouched.
+fn normalize_target(target: &str) -> String {
+    match target.strip_prefix("vibe_coding_tracker") {
+        Some(rest) => format!("vct{rest}"),
+        None => target.to_string(),
+    }
+}
+
+/// Maps the user-facing [`LogLevel`] onto the `log` crate's [`LevelFilter`].
+fn to_level_filter(level: LogLevel) -> LevelFilter {
+    match level {
+        LogLevel::Off => LevelFilter::Off,
+        LogLevel::Error => LevelFilter::Error,
+        LogLevel::Warn => LevelFilter::Warn,
+        LogLevel::Info => LevelFilter::Info,
+        LogLevel::Debug => LevelFilter::Debug,
+        LogLevel::Trace => LevelFilter::Trace,
+    }
+}
+
+/// Installs the global file logger at the default level (`warn`) and a panic
+/// hook that restores the terminal and records the panic.
+///
+/// Called once at process start, before any subcommand runs. Safe to call more
+/// than once (subsequent calls are ignored) so tests that exercise `main` don't
+/// double-install. The level is later refined by [`apply`] once the user config
+/// is loaded.
+pub fn init() {
+    let dir = home::home_dir().map(|home| home.join(".vct").join(LOG_DIR_NAME));
+    let logger = LOGGER.get_or_init(|| FileLogger::new(dir, LevelFilter::Warn));
+    // `set_logger` succeeds only on the first install for the whole process;
+    // pair the max-level set and panic hook with that one-time success.
+    if log::set_logger(logger).is_ok() {
+        log::set_max_level(LevelFilter::Warn);
+        install_panic_hook();
+    }
+}
+
+/// Applies the persisted `[logging]` settings: sets the max level and prunes
+/// stale daily files. Called after the user config is loaded (usage / analysis).
+pub fn apply(cfg: &LoggingConfig) {
+    let filter = to_level_filter(cfg.level);
+    log::set_max_level(filter);
+    if let Some(logger) = LOGGER.get() {
+        logger.level.store(filter as usize, Ordering::Relaxed);
+    }
+    prune_old_logs(cfg.retention_days);
+}
+
+/// Installs a panic hook that restores the terminal (if the TUI owns it) and
+/// records the panic before delegating to the previous hook.
+///
+/// Chaining to the previous hook preserves the default stderr panic message,
+/// which — now that the terminal is restored — lands on the normal screen. This
+/// runs even under `panic = "abort"` (the hook fires before the abort).
+fn install_panic_hook() {
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        crate::display::common::tui::force_restore_terminal();
+        log::error!("{info}");
+        previous(info);
+    }));
+}
+
+/// Prunes daily log files older than `retention_days` from the log directory.
+fn prune_old_logs(retention_days: u32) {
+    if retention_days == 0 {
+        return;
+    }
+    let Some(dir) = LOGGER.get().and_then(|l| l.dir.as_deref()) else {
+        return;
+    };
+    let cutoff = Utc::now().date_naive() - Duration::days(retention_days as i64);
+    prune_before(dir, cutoff);
+}
+
+/// Deletes every `vct-YYYY-MM-DD.log` file in `dir` whose date is strictly
+/// before `cutoff` (test seam: the cutoff is injected rather than derived from
+/// "now").
+fn prune_before(dir: &Path, cutoff: NaiveDate) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        let Some(date_str) = name
+            .strip_prefix(LOG_FILE_PREFIX)
+            .and_then(|s| s.strip_suffix(LOG_FILE_SUFFIX))
+        else {
+            continue;
+        };
+        if let Ok(date) = NaiveDate::parse_from_str(date_str, "%Y-%m-%d")
+            && date < cutoff
+        {
+            let _ = fs::remove_file(&path);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn format_line_shapes_the_record() {
+        let line = format_line(
+            "2026-07-12T10:30:15.123456789Z",
+            Level::Warn,
+            "vibe_coding_tracker::quota::claude",
+            "quota fetch failed: HTTP 403",
+        );
+        assert_eq!(
+            line,
+            "2026-07-12T10:30:15.123456789Z WARN  vct::quota::claude  quota fetch failed: HTTP 403\n"
+        );
+    }
+
+    #[test]
+    fn normalize_target_shortens_only_our_crate() {
+        assert_eq!(normalize_target("vibe_coding_tracker"), "vct");
+        assert_eq!(
+            normalize_target("vibe_coding_tracker::pricing"),
+            "vct::pricing"
+        );
+        assert_eq!(normalize_target("hyper_util::client"), "hyper_util::client");
+    }
+
+    #[test]
+    fn level_filter_ordering_matches_log_crate() {
+        // Off gates out even Error; Warn admits Error+Warn but not Info.
+        let warn = FileLogger::new(None, LevelFilter::Warn);
+        assert!(warn.enabled(&Metadata::builder().level(Level::Error).build()));
+        assert!(warn.enabled(&Metadata::builder().level(Level::Warn).build()));
+        assert!(!warn.enabled(&Metadata::builder().level(Level::Info).build()));
+
+        let off = FileLogger::new(None, LevelFilter::Off);
+        assert!(!off.enabled(&Metadata::builder().level(Level::Error).build()));
+    }
+
+    #[test]
+    fn append_creates_dir_lazily_and_writes() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("logs");
+        let logger = FileLogger::new(Some(dir.clone()), LevelFilter::Warn);
+
+        // Nothing on disk until the first append.
+        assert!(!dir.exists());
+
+        logger.append("line one\n");
+        logger.append("line two\n");
+
+        let file = dir.join(format!("vct-{}.log", utc_date()));
+        let contents = fs::read_to_string(&file).unwrap();
+        assert_eq!(contents, "line one\nline two\n");
+    }
+
+    #[test]
+    fn log_routes_through_facade_gated_and_formatted() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("logs");
+        let logger = FileLogger::new(Some(dir.clone()), LevelFilter::Warn);
+
+        // Below the gate (info < warn): dropped, and nothing is created on disk.
+        logger.log(
+            &Record::builder()
+                .level(Level::Info)
+                .target("vibe_coding_tracker::x")
+                .args(format_args!("skip me"))
+                .build(),
+        );
+        assert!(
+            !dir.exists(),
+            "info is below warn, so no file/dir is created"
+        );
+
+        // At the gate (warn): written through the full log() -> format -> append path.
+        logger.log(
+            &Record::builder()
+                .level(Level::Warn)
+                .target("vibe_coding_tracker::quota")
+                .args(format_args!("boom"))
+                .build(),
+        );
+        let file = dir.join(format!("vct-{}.log", utc_date()));
+        let contents = fs::read_to_string(&file).unwrap();
+        assert!(
+            contents.contains(" WARN  vct::quota  boom\n"),
+            "unexpected line: {contents}"
+        );
+        assert!(
+            !contents.contains("skip me"),
+            "gated record must not appear"
+        );
+    }
+
+    #[test]
+    fn prune_before_removes_only_older_dated_files() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        for name in ["vct-2026-07-01.log", "vct-2026-07-10.log", "unrelated.txt"] {
+            fs::write(dir.join(name), "x").unwrap();
+        }
+        let cutoff = NaiveDate::from_ymd_opt(2026, 7, 5).unwrap();
+        prune_before(dir, cutoff);
+
+        assert!(!dir.join("vct-2026-07-01.log").exists(), "old file pruned");
+        assert!(dir.join("vct-2026-07-10.log").exists(), "recent file kept");
+        assert!(dir.join("unrelated.txt").exists(), "non-log file untouched");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,9 @@ fn main() -> Result<()> {
     // for why this matters on long TUI sessions.
     vibe_coding_tracker::utils::tune_system_allocator();
 
-    env_logger::init();
+    // Install the file logger (default level `warn`) before anything can log or
+    // panic. It writes only to `~/.vct/logs/`, never the terminal.
+    vibe_coding_tracker::logging::init();
 
     if matches!(
         std::env::args_os().nth(1).and_then(|arg| arg.into_string().ok()),
@@ -64,6 +66,17 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
+    let result = run();
+    if let Err(error) = &result {
+        // Record the final error before anyhow prints it to stderr and the
+        // process exits — the log file is the durable record of the failure.
+        log::error!("command failed: {error:#}");
+    }
+    result
+}
+
+/// Parses the CLI and dispatches the selected subcommand.
+fn run() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
@@ -95,6 +108,7 @@ fn main() -> Result<()> {
                     // so `analysis --path`, `version`, `fetch`, etc. never read or
                     // create `~/.vct/config.toml`.
                     let config = vibe_coding_tracker::config::load();
+                    vibe_coding_tracker::logging::apply(&config.logging);
                     let time_range = resolve_time_range_with_default(
                         daily,
                         weekly,
@@ -147,6 +161,7 @@ fn main() -> Result<()> {
             all,
         } => {
             let config = vibe_coding_tracker::config::load();
+            vibe_coding_tracker::logging::apply(&config.logging);
             let time_range = resolve_time_range_with_default(
                 daily,
                 weekly,
@@ -164,6 +179,7 @@ fn main() -> Result<()> {
                 let pricing_map = match fetch_model_pricing() {
                     Ok(map) => map,
                     Err(e) => {
+                        log::warn!("failed to fetch pricing data: {e}; costs unavailable");
                         eprintln!(
                             "Warning: Failed to fetch pricing data: {}. Costs will be unavailable.",
                             e

--- a/src/quota/claude.rs
+++ b/src/quota/claude.rs
@@ -259,7 +259,10 @@ fn fetch_claude_usage(client: &Client, token: &str, now: i64, usage_url: &str) -
         .send()
     {
         Ok(r) => r,
-        Err(_) => return FetchResult::Transient,
+        Err(e) => {
+            log::warn!("claude quota fetch: request failed: {e}");
+            return FetchResult::Transient;
+        }
     };
     let status = resp.status();
     if status == reqwest::StatusCode::UNAUTHORIZED {
@@ -267,14 +270,21 @@ fn fetch_claude_usage(client: &Client, token: &str, now: i64, usage_url: &str) -
     }
     if !status.is_success() {
         // 403 and friends are not treated as "needs login" (S9).
+        log::warn!("claude quota fetch: HTTP {status}");
         return FetchResult::Transient;
     }
     match resp.text() {
         Ok(text) => match map_claude_usage(&text, now) {
             Ok(snap) => FetchResult::Ok(snap),
-            Err(_) => FetchResult::Transient,
+            Err(e) => {
+                log::warn!("claude quota fetch: failed to parse usage response: {e}");
+                FetchResult::Transient
+            }
         },
-        Err(_) => FetchResult::Transient,
+        Err(e) => {
+            log::warn!("claude quota fetch: failed to read response body: {e}");
+            FetchResult::Transient
+        }
     }
 }
 

--- a/src/quota/copilot.rs
+++ b/src/quota/copilot.rs
@@ -252,7 +252,10 @@ fn fetch_copilot_user(client: &Client, api_url: &str, token: &str, now: i64) -> 
         .send()
     {
         Ok(r) => r,
-        Err(_) => return FetchResult::Transient,
+        Err(e) => {
+            log::warn!("copilot quota fetch: request failed: {e}");
+            return FetchResult::Transient;
+        }
     };
     let status = resp.status();
     // Copilot has no refresh; a logged-out account answers 401 or 403.
@@ -260,14 +263,21 @@ fn fetch_copilot_user(client: &Client, api_url: &str, token: &str, now: i64) -> 
         return FetchResult::Unauthorized;
     }
     if !status.is_success() {
+        log::warn!("copilot quota fetch: HTTP {status}");
         return FetchResult::Transient;
     }
     match resp.text() {
         Ok(text) => match map_copilot_user(&text, now) {
             Ok(snap) => FetchResult::Ok(snap),
-            Err(_) => FetchResult::Transient,
+            Err(e) => {
+                log::warn!("copilot quota fetch: failed to parse user response: {e}");
+                FetchResult::Transient
+            }
         },
-        Err(_) => FetchResult::Transient,
+        Err(e) => {
+            log::warn!("copilot quota fetch: failed to read response body: {e}");
+            FetchResult::Transient
+        }
     }
 }
 

--- a/src/quota/cursor.rs
+++ b/src/quota/cursor.rs
@@ -177,21 +177,31 @@ fn fetch_cursor_usage(client: &Client, cookie: &str, now: i64, usage_url: &str) 
         .send()
     {
         Ok(r) => r,
-        Err(_) => return FetchResult::Transient,
+        Err(e) => {
+            log::warn!("cursor quota fetch: request failed: {e}");
+            return FetchResult::Transient;
+        }
     };
     let status = resp.status();
     if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
         return FetchResult::Unauthorized;
     }
     if !status.is_success() {
+        log::warn!("cursor quota fetch: HTTP {status}");
         return FetchResult::Transient;
     }
     match resp.text() {
         Ok(text) => match map_cursor_usage(&text, now) {
             Ok(snap) => FetchResult::Ok(snap),
-            Err(_) => FetchResult::Transient,
+            Err(e) => {
+                log::warn!("cursor quota fetch: failed to parse usage response: {e}");
+                FetchResult::Transient
+            }
         },
-        Err(_) => FetchResult::Transient,
+        Err(e) => {
+            log::warn!("cursor quota fetch: failed to read response body: {e}");
+            FetchResult::Transient
+        }
     }
 }
 

--- a/src/quota/mod.rs
+++ b/src/quota/mod.rs
@@ -107,11 +107,17 @@ impl CodexState {
     ) -> CodexFetch {
         let body = match std::fs::read_to_string(auth) {
             Ok(b) => b,
-            Err(_) => return CodexFetch::Transient,
+            Err(e) => {
+                log::warn!("codex quota: failed to read {}: {e}", auth.display());
+                return CodexFetch::Transient;
+            }
         };
         let (file_token, account_id) = match wham::parse_auth(&body) {
             Ok(x) => x,
-            Err(_) => return CodexFetch::Transient,
+            Err(e) => {
+                log::warn!("codex quota: failed to parse auth.json: {e}");
+                return CodexFetch::Transient;
+            }
         };
         let cur_mtime = file_mtime(auth);
         // Reuse the cached token only if auth.json hasn't changed since we cached

--- a/src/quota/wham.rs
+++ b/src/quota/wham.rs
@@ -176,21 +176,31 @@ pub fn call_wham(
     }
     let resp = match req.send() {
         Ok(r) => r,
-        Err(_) => return WhamResult::Transient,
+        Err(e) => {
+            log::warn!("codex quota fetch: request failed: {e}");
+            return WhamResult::Transient;
+        }
     };
     let status = resp.status();
     if status == reqwest::StatusCode::UNAUTHORIZED {
         return WhamResult::Unauthorized;
     }
     if !status.is_success() {
+        log::warn!("codex quota fetch: HTTP {status}");
         return WhamResult::Transient;
     }
     match resp.text() {
         Ok(text) => match map_wham_response(&text, now) {
             Ok(snap) => WhamResult::Ok(snap),
-            Err(_) => WhamResult::Transient,
+            Err(e) => {
+                log::warn!("codex quota fetch: failed to parse usage response: {e}");
+                WhamResult::Transient
+            }
         },
-        Err(_) => WhamResult::Transient,
+        Err(e) => {
+            log::warn!("codex quota fetch: failed to read response body: {e}");
+            WhamResult::Transient
+        }
     }
 }
 

--- a/src/session/cursor.rs
+++ b/src/session/cursor.rs
@@ -94,10 +94,9 @@ pub fn read_cursor_analysis(
         match read_store_analysis(&store_db, &conv_models, time_range, mode, &user, &machine) {
             Ok(mut rows) => out.append(&mut rows),
             Err(err) => {
-                eprintln!(
-                    "Warning: Failed to read Cursor store {}: {err}",
-                    store_db.display()
-                );
+                // File-only: this runs during TUI refresh too, so a stderr
+                // write here would corrupt the alternate screen.
+                log::warn!("failed to read Cursor store {}: {err}", store_db.display());
             }
         }
     }

--- a/src/usage/calculator.rs
+++ b/src/usage/calculator.rs
@@ -265,8 +265,8 @@ pub fn get_usage_from_paths_with(
             time_range,
         )
     {
-        eprintln!(
-            "Warning: Failed to read OpenCode DB {}: {err}",
+        log::warn!(
+            "failed to read OpenCode DB {}: {err}",
             paths.opencode_db.display()
         );
     }
@@ -286,7 +286,7 @@ pub fn get_usage_from_paths_with(
             time_range,
         )
     {
-        eprintln!("Warning: Failed to read Cursor usage: {err}");
+        log::warn!("failed to read Cursor usage: {err}");
     }
 
     // Hermes, like OpenCode, is a single SQLite database read directly.
@@ -301,8 +301,8 @@ pub fn get_usage_from_paths_with(
             time_range,
         )
     {
-        eprintln!(
-            "Warning: Failed to read Hermes DB {}: {err}",
+        log::warn!(
+            "failed to read Hermes DB {}: {err}",
             paths.hermes_db.display()
         );
     }
@@ -386,11 +386,7 @@ where
                     Some((file_info.modified_date.clone(), conversation_usage))
                 }
                 Err(e) => {
-                    eprintln!(
-                        "Warning: Failed to analyze {}: {}",
-                        file_info.path.display(),
-                        e
-                    );
+                    log::warn!("failed to analyze {}: {e}", file_info.path.display());
                     None
                 }
             }

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -27,6 +27,7 @@ fn load_in_creates_default_commented_file_when_absent() {
     assert_eq!(cfg.usage.refresh_interval, 10);
     assert_eq!(cfg.usage.quota.refresh_interval, 60);
     assert_eq!(cfg.analysis.refresh_interval, 10);
+    assert_eq!(cfg.logging.retention_days, 7);
 
     let path = dir.join("config.toml");
     assert!(path.exists(), "first run must create config.toml");
@@ -36,6 +37,7 @@ fn load_in_creates_default_commented_file_when_absent() {
     assert!(text.contains("[usage]"));
     assert!(text.contains("[usage.quota]"));
     assert!(text.contains("[providers]"));
+    assert!(text.contains("[logging]"));
     assert!(text.contains("merge_models = false"));
     // A generated comment must survive so the file is self-documenting.
     assert!(text.contains("# Toggled live"));

--- a/vct.schema.json
+++ b/vct.schema.json
@@ -53,6 +53,59 @@
       },
       "type": "object"
     },
+    "logging": {
+      "default": {
+        "level": "warn",
+        "retention_days": 7
+      },
+      "description": "`[logging]` — file logging preferences.\n\nDiagnostics are written to `~/.vct/logs/vct-YYYY-MM-DD.log` (plain text, one\nline per record). Nothing is ever printed to the terminal, so the TUI is\nnever disturbed. The log file is created lazily on the first record, so a\ncommand that logs nothing never touches `~/.vct`.",
+      "properties": {
+        "level": {
+          "default": "warn",
+          "description": "Minimum level written to the log file.\nOne of: \"off\" | \"error\" | \"warn\" | \"info\" | \"debug\" | \"trace\".",
+          "oneOf": [
+            {
+              "const": "off",
+              "description": "Disable file logging entirely.",
+              "type": "string"
+            },
+            {
+              "const": "error",
+              "description": "Only errors.",
+              "type": "string"
+            },
+            {
+              "const": "warn",
+              "description": "Errors and warnings (the default — quiet when healthy, records problems).",
+              "type": "string"
+            },
+            {
+              "const": "info",
+              "description": "Adds high-level informational breadcrumbs.",
+              "type": "string"
+            },
+            {
+              "const": "debug",
+              "description": "Adds verbose diagnostics (per-file parse skips, quota poll detail).",
+              "type": "string"
+            },
+            {
+              "const": "trace",
+              "description": "Everything, including cache-hit traces.",
+              "type": "string"
+            }
+          ]
+        },
+        "retention_days": {
+          "default": 7,
+          "description": "Days of daily log files to keep; older `vct-*.log` files are pruned on\nstartup. `0` keeps every file.",
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
     "providers": {
       "default": {
         "claude": true,


### PR DESCRIPTION
## What

Adds a file-based diagnostic logging system for `vct`. Previously the tool had `env_logger::init()` wired up but it wrote to stderr at the default `error` level, so the existing `log::*` calls were effectively silent, and the failures that mattered most (background quota fetches, skipped sessions, panics) were swallowed with no record anywhere.

## How

- **Custom `log::Log` backend** (`src/logging/mod.rs`) that writes only to `~/.vct/logs/vct-YYYY-MM-DD.log` (plain text, one line per record), never to stdout/stderr — so it is safe while the TUI owns the screen. The `log` facade is kept, so every existing call site is unchanged. `env_logger` is removed.
  - Thread-safe (`Mutex<Option<File>>`) for the main thread and the background quota workers, unbuffered writes so nothing is lost under `panic = "abort"`, and the file is created lazily on the first record (a command that logs nothing never touches `~/.vct`).
  - Daily files with retention: files older than `retention_days` are pruned on startup.
- **`[logging]` config section** (`level`, `retention_days`), schema-driven like the rest of the config. `level` defaults to `warn` (quiet when healthy, records problems).
- **Panic hook** that restores the terminal (so a TUI panic no longer leaves it in raw/alternate-screen mode) and records the panic, before chaining to the default hook.
- **Wires the previously-swallowed errors into the log**: the quota fetchers now record each transient failure (network / non-success HTTP status / body-parse), the noisy per-file/DB parser warnings that used to `eprintln!` (and corrupt the TUI during refresh) now go to the log file, and the final top-level error is logged before exit.

## Notes

- Control is config-only (no env var), per design discussion.
- Plain text was chosen over SQLite: for a mostly one-shot CLI, text append is both lower-overhead and simpler; SQLite's only real win (queryable logs) isn't needed here.
- Docs updated in all three READMEs and CLAUDE.md; `vct.schema.json` regenerated.
