### PR TITLE
docs: add Antigravity and Grok quota curl/jq examples

### DIFF
--- a/examples/quota.md
+++ b/examples/quota.md
@@ -9,12 +9,14 @@ These are minimal examples: they stop at "dump the JSON response". Field extract
 
 ## At a glance
 
-| Provider    | Credential file               | Quota endpoint                              | Refresh model                                |
-| ----------- | ----------------------------- | ------------------------------------------- | -------------------------------------------- |
-| Codex       | `~/.codex/auth.json`          | `GET  chatgpt.com/backend-api/wham/usage`   | `POST auth.openai.com/oauth/token` (rotates) |
-| Claude Code | `~/.claude/.credentials.json` | `GET  api.anthropic.com/api/oauth/usage`    | `POST platform.claude.com/v1/oauth/token`    |
-| Copilot     | `~/.copilot/config.json`      | `GET  api.github.com/copilot_internal/user` | none (long-lived `gho_` token)               |
-| Cursor      | `~/.config/cursor/auth.json`  | `GET  cursor.com/api/usage-summary`         | reactive (official CLI keeps the file fresh) |
+| Provider    | Credential file                                     | Quota endpoint                                                         | Refresh model                                    |
+| ----------- | --------------------------------------------------- | ---------------------------------------------------------------------- | ------------------------------------------------ |
+| Codex       | `~/.codex/auth.json`                                | `GET  chatgpt.com/backend-api/wham/usage`                              | `POST auth.openai.com/oauth/token` (rotates)     |
+| Claude Code | `~/.claude/.credentials.json`                       | `GET  api.anthropic.com/api/oauth/usage`                               | `POST platform.claude.com/v1/oauth/token`        |
+| Copilot     | `~/.copilot/config.json`                            | `GET  api.github.com/copilot_internal/user`                            | none (long-lived `gho_` token)                   |
+| Cursor      | `~/.config/cursor/auth.json`                        | `GET  cursor.com/api/usage-summary`                                    | reactive (official CLI keeps the file fresh)     |
+| Antigravity | `~/.gemini/antigravity-cli/antigravity-oauth-token` | `POST cloudcode-pa.googleapis.com/v1internal:retrieveUserQuotaSummary` | `POST oauth2.googleapis.com/token` (no rotation) |
+| Grok        | `~/.grok/auth.json`                                 | `GET  cli-chat-proxy.grok.com/v1/billing?format=credits`               | `POST auth.x.ai/oauth2/token` (rotates)          |
 
 ## Client impersonation
 
@@ -177,3 +179,104 @@ Response is `totalUsageEventsCount` + a `usageEventsDisplay[]` page; paginate `p
 Reactive. The `accessToken` is valid ~60 days (`offline_access` scope) and the official Cursor CLI / IDE keeps `auth.json` fresh in the background, so the simplest approach is to re-read the file each poll and use the token while its JWT `exp` is in the future.
 cursor.com does not return a rotating `Set-Cookie` on the usage call.
 Self-refresh would go through WorkOS AuthKit (`authentication.cursor.sh`) via the cursor backend (`api2.cursor.sh`, paths like `/auth/token`), but the exact request shape is not pinned here. On a `401` re-login via `cursor login`.
+
+## Antigravity
+
+Credential file (Linux) `~/.gemini/antigravity-cli/antigravity-oauth-token`: plain JSON, `.token.access_token`, `.token.refresh_token`, `.token.expiry`. On macOS the same blob lives in the Keychain instead (service `gemini`, account `antigravity`), sometimes wrapped with a `go-keyring-base64:` prefix; the field names are the same once unwrapped.
+
+Antigravity also has a second, richer source when the app (or the `agy` CLI) is **running**: a local Connect-RPC language server on loopback (`RetrieveUserQuotaSummary` on `https://127.0.0.1:<port>/...`), discovered by scanning for the process and reading its `--csrf_token`. That path needs no OAuth but only works while the app is up. The recipe below is the **app-closed** path, the one that fits this file: credential file in, HTTP out, works over plain SSH.
+
+Unlike the other providers, the stored `access_token` is short-lived (~1h) and nothing keeps it fresh in the background, so in practice you refresh first (see **Refresh token**) and use that token to fetch.
+
+### Fetch quota
+
+Two base URLs: `cloudcode-pa.googleapis.com` (prod) and `daily-cloudcode-pa.googleapis.com` (canary), same schema. The authoritative endpoint is `retrieveUserQuotaSummary`: two shared pools (Gemini, and everything non-Gemini incl. Claude / GPT-OSS), each with a rolling 5-hour and a weekly window.
+
+```bash
+# The stored access_token is ~1h-lived; if this 401s, run Refresh token below and use that access_token.
+TOKEN=$(jq -r '.token.access_token' ~/.gemini/antigravity-cli/antigravity-oauth-token)
+
+curl -s -X POST "https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuotaSummary" \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -H "User-Agent: antigravity" \
+    -H "Content-Type: application/json" \
+    -d '{}' | jq
+```
+
+Each bucket carries `bucketId` (`gemini-5h` / `gemini-weekly` / `3p-5h` / `3p-weekly`), `remainingFraction` (0…1, where 1 = full, so used% = `(1 - remainingFraction) * 100`), and `resetTime`.
+
+Older builds lack that RPC; the legacy fallbacks are 5h-only and take the same bearer token:
+
+- `POST .../v1internal:fetchAvailableModels` (`User-Agent: antigravity`, body `{}`) — full model list, each with a `quotaInfo`.
+- `POST .../v1internal:loadCodeAssist` (`User-Agent: agy`, body `{}`) — plan tier (`paidTier.name`) + `cloudaicompanionProject`.
+- `POST .../v1internal:retrieveUserQuota` (`User-Agent: agy`, body `{"project":"<from loadCodeAssist>"}`) — per-Gemini-model request buckets.
+
+### Refresh token
+
+```bash
+CRED=~/.gemini/antigravity-cli/antigravity-oauth-token
+RT=$(jq -r '.token.refresh_token' "$CRED")
+
+# client_id / client_secret: Antigravity's own Google OAuth installed-app credentials (see the note
+# below). Fill in the real secret from the app bundle / agy binary, or copy the pair from openusage's
+# AntigravityUsageClient.swift.
+CLIENT_ID="1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com"
+CLIENT_SECRET="<antigravity-installed-app-secret>"
+
+curl -s "https://oauth2.googleapis.com/token" \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    --data-urlencode "client_id=${CLIENT_ID}" \
+    --data-urlencode "client_secret=${CLIENT_SECRET}" \
+    --data-urlencode "grant_type=refresh_token" \
+    --data-urlencode "refresh_token=${RT}" | jq
+```
+
+Response carries `access_token` / `expires_in` (~3600s) / `scope`; use the `access_token` as the Bearer above.
+
+`client_id` / `client_secret` are **not** yours to create: they are Antigravity's own Google OAuth **installed-application** credentials, baked into every copy of the app / `agy` CLI. Google does not treat an installed-app secret as confidential (it ships inside the client), so this is a public identifier, not a private key — but it is Google's, and the per-user `refresh_token` in the credential file is the only truly sensitive value here.
+
+Unlike Codex / Claude above, this refresh does **not** rotate the refresh token (Google reuses installed-app refresh tokens until revoked), so there is nothing to write back to the credential file and it is safe to run alongside the live app. Cache only the returned `access_token`. A `400` / `invalid_grant` means the refresh token was revoked: re-login via the Antigravity app or `agy`.
+
+## Grok
+
+Credential file `~/.grok/auth.json`: a JSON object keyed by one entry per login, each `{ key, refresh_token, id_token, expires_at, oidc_client_id }`. The **access token is the `key` field** (not a field named `access_token`) — a JWT — and it is the bearer for the calls below. The refresh client id comes from `oidc_client_id`, else the trailing `::`-delimited segment of the entry key, else the CLI default.
+
+Every proxy call also sends `X-XAI-Token-Auth: xai-grok-cli` — the marker the Grok CLI attaches alongside the bearer.
+
+### Fetch quota
+
+```bash
+AUTH=~/.grok/auth.json
+TOKEN=$(jq -r 'to_entries[0].value.key' "$AUTH")   # access token lives under `.key`
+
+# Weekly shared pool + pay-as-you-go cap (the exact call the Grok CLI makes):
+curl -s "https://cli-chat-proxy.grok.com/v1/billing?format=credits" \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -H "X-XAI-Token-Auth: xai-grok-cli" \
+    -H "Accept: application/json" | jq
+
+# Plan / subscription name:
+curl -s "https://cli-chat-proxy.grok.com/v1/settings" \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -H "X-XAI-Token-Auth: xai-grok-cli" \
+    -H "Accept: application/json" | jq
+```
+
+`billing?format=credits` returns the `GetGrokCreditsConfig` message: the weekly shared-pool usage percent + reset, and the pay-as-you-go cap. Accounts not yet on unified weekly billing report no weekly pool. A `401` / `403` means the token expired: refresh (below) and retry once.
+
+### Refresh token
+
+```bash
+AUTH=~/.grok/auth.json
+RT=$(jq -r 'to_entries[0].value.refresh_token // to_entries[0].value.refresh' "$AUTH")
+# client id: prefer the entry's oidc_client_id, else the tail after "::" in the entry key, else the CLI default.
+CID=$(jq -r 'to_entries[0] | .value.oidc_client_id // (.key | split("::") | last) // "b1a00492-073a-47ea-816f-4c329264a828"' "$AUTH")
+
+curl -s "https://auth.x.ai/oauth2/token" \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    --data-urlencode "grant_type=refresh_token" \
+    --data-urlencode "client_id=${CID}" \
+    --data-urlencode "refresh_token=${RT}" | jq
+```
+
+Response carries `access_token` / `refresh_token` / `id_token` / `expires_in`. Write the new `access_token` back into that entry's `key`, plus the rotated `refresh_token` / `id_token` / `expires_at`, preserving every **other** entry in the file. There is no `client_secret` (xAI's CLI OAuth client is public and secret-less), so this refresh trips none of the secret scanners.

--- a/examples/quota.md
+++ b/examples/quota.md
@@ -269,8 +269,8 @@ curl -s "https://cli-chat-proxy.grok.com/v1/settings" \
 ```bash
 AUTH=~/.grok/auth.json
 RT=$(jq -r 'to_entries[0].value.refresh_token // to_entries[0].value.refresh' "$AUTH")
-# client id: prefer the entry's oidc_client_id, else the tail after "::" in the entry key, else the CLI default.
-CID=$(jq -r 'to_entries[0] | .value.oidc_client_id // (.key | split("::") | last) // "b1a00492-073a-47ea-816f-4c329264a828"' "$AUTH")
+# client id: the entry's oidc_client_id, else the trailing "::" segment of the entry key (no hardcoded fallback).
+CID=$(jq -r 'to_entries[0] | .value.oidc_client_id // (.key | split("::") | last) // empty' "$AUTH")
 
 curl -s "https://auth.x.ai/oauth2/token" \
     -H "Content-Type: application/x-www-form-urlencoded" \


### PR DESCRIPTION
## What

Adds **Antigravity** and **Grok** sections to `examples/quota.md`: raw `curl` + `jq` recipes to read each provider's quota from the credential files their CLIs already store, plus the token-refresh step. Mirrors the existing per-provider entries (Codex / Claude / Copilot / Cursor).

## Antigravity

- App-closed path: read the OAuth token from `~/.gemini/antigravity-cli/antigravity-oauth-token` (macOS keeps it in the Keychain), refresh via Google OAuth, then `POST cloudcode-pa.googleapis.com/v1internal:retrieveUserQuotaSummary`.
- The `client_secret` is a placeholder on purpose. It is Antigravity's public installed-app secret; a reader fills it in from the app / `agy` binary or openusage's source, so the repo carries no real secret.

## Grok

- Read the access token from `~/.grok/auth.json` (the `.key` field), `GET cli-chat-proxy.grok.com/v1/billing?format=credits` for the weekly pool, refresh via `auth.x.ai`. No client secret involved.
- Derived from openusage's source; not yet live-tested (no local `grok login` on the author's machine).

## Notes

Docs-only change. `mdformat` + `gitleaks` pass locally.