### PR TITLE
fix(codex): include archived sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ Resolved by `src/core/src/utils/paths.rs` (`resolve_paths`):
 | Provider      | Source path                                                                                                                                                  |
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Claude Code   | `~/.claude/projects/**/*.jsonl` (recursive — includes subagents)                                                                                             |
-| Codex         | `~/.codex/sessions/**/*.jsonl`                                                                                                                               |
+| Codex         | `~/.codex/sessions/**/*.jsonl` plus `~/.codex/archived_sessions/*.jsonl`                                                                                     |
 | Copilot CLI   | `~/.copilot/session-state/<sessionId>/events.jsonl` (depth-bounded walk via `COPILOT_SESSION_MAX_DEPTH` to skip per-session snapshot subtrees)               |
 | Gemini CLI    | `~/.gemini/tmp/<project_hash>/chats/*.jsonl` plus `chats/<parent_session>/*.jsonl` for subagents                                                             |
 | OpenCode      | `~/.local/share/opencode/opencode.db` (SQLite database, read via `rusqlite`; honors `$XDG_DATA_HOME`)                                                        |

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Every row serializes the same flat token fields regardless of provider (Codex's 
 The tool automatically scans these directories:
 
 - `~/.claude/projects/**/*.jsonl` (Claude Code — recursive, includes subagent logs)
-- `~/.codex/sessions/**/*.jsonl` (Codex — recursive, includes daily subdirectories)
+- `~/.codex/sessions/**/*.jsonl` and `~/.codex/archived_sessions/*.jsonl` (Codex — active and archived sessions)
 - `~/.copilot/session-state/<sessionId>/events.jsonl` (Copilot CLI)
 - `~/.gemini/tmp/<project_hash>/chats/*.jsonl` (Gemini CLI)
 - `~/.local/share/opencode/opencode.db` (OpenCode — SQLite database; honors `$XDG_DATA_HOME`)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -291,7 +291,7 @@ Totals (by Provider)
 该工具会自动扫描以下目录：
 
 - `~/.claude/projects/**/*.jsonl`（Claude Code，递归包含 subagent 日志）
-- `~/.codex/sessions/**/*.jsonl`（Codex，递归包含每日子目录）
+- `~/.codex/sessions/**/*.jsonl` 与 `~/.codex/archived_sessions/*.jsonl`（Codex，包含使用中与已归档的 session）
 - `~/.copilot/session-state/<sessionId>/events.jsonl`（Copilot CLI）
 - `~/.gemini/tmp/<project_hash>/chats/*.jsonl`（Gemini CLI）
 - `~/.local/share/opencode/opencode.db`（OpenCode，SQLite 数据库；遵循 `$XDG_DATA_HOME`）

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -291,7 +291,7 @@ Totals (by Provider)
 此工具會自動掃描以下目錄：
 
 - `~/.claude/projects/**/*.jsonl`（Claude Code，遞迴包含 subagent 日誌）
-- `~/.codex/sessions/**/*.jsonl`（Codex，遞迴包含每日子目錄）
+- `~/.codex/sessions/**/*.jsonl` 與 `~/.codex/archived_sessions/*.jsonl`（Codex，包含使用中與已封存的 session）
 - `~/.copilot/session-state/<sessionId>/events.jsonl`（Copilot CLI）
 - `~/.gemini/tmp/<project_hash>/chats/*.jsonl`（Gemini CLI）
 - `~/.local/share/opencode/opencode.db`（OpenCode，SQLite 資料庫；遵循 `$XDG_DATA_HOME`）

--- a/src/core/src/analysis/aggregator.rs
+++ b/src/core/src/analysis/aggregator.rs
@@ -14,11 +14,12 @@ use crate::session::state::ParseMode;
 use crate::summary_cache::{
     CompactSourceSummary, SourceFingerprint, SummaryCacheKey, SummaryKind, SummaryScanCache,
 };
-use crate::utils::directory::{FileInfo, collect_files_with_max_depth_diagnostics};
+use crate::utils::collect_codex_session_files_with_diagnostics;
+use crate::utils::directory::{FileDiscovery, FileInfo, collect_files_with_max_depth_diagnostics};
 use crate::utils::{
     COPILOT_SESSION_MAX_DEPTH, GROK_SESSION_MAX_DEPTH, HelperPaths, get_current_user,
-    get_machine_id, is_claude_session_file, is_codex_session_file, is_copilot_session_file,
-    is_gemini_session_file, is_grok_session_file,
+    get_machine_id, is_claude_session_file, is_copilot_session_file, is_gemini_session_file,
+    is_grok_session_file,
 };
 use anyhow::Result;
 use rayon::prelude::*;
@@ -72,7 +73,7 @@ pub struct AnalysisCollection {
 pub struct PerProviderAnalysisRows {
     /// Rows from the Claude Code session directory.
     pub claude: Vec<AggregatedAnalysisRow>,
-    /// Rows from the Codex session directory.
+    /// Rows from the active and archived Codex session directories.
     pub codex: Vec<AggregatedAnalysisRow>,
     /// Rows from the Copilot CLI session directory.
     pub copilot: Vec<AggregatedAnalysisRow>,
@@ -340,12 +341,15 @@ where
     }
 
     if providers.codex {
-        visit_file_sessions(
+        let archived_session_dir = paths.codex_archived_session_dir();
+        let discovery = collect_codex_session_files_with_diagnostics(
             &paths.codex_session_dir,
-            ExtensionType::Codex,
-            is_codex_session_file,
+            &archived_session_dir,
             time_range,
-            None,
+        );
+        visit_discovered_file_sessions(
+            discovery,
+            ExtensionType::Codex,
             mode,
             &mut diagnostics,
             visitor,
@@ -785,6 +789,19 @@ where
     V: FnMut(AnalysisSession),
 {
     let discovery = collect_files_with_max_depth_diagnostics(dir, filter_fn, time_range, max_depth);
+    visit_discovered_file_sessions(discovery, provider, mode, diagnostics, visitor)
+}
+
+fn visit_discovered_file_sessions<V>(
+    discovery: FileDiscovery,
+    provider: ExtensionType,
+    mode: ParseMode,
+    diagnostics: &mut ScanDiagnostics,
+    visitor: &mut V,
+) -> Result<()>
+where
+    V: FnMut(AnalysisSession),
+{
     diagnostics.candidates += discovery.failures.len();
     for failure in discovery.failures {
         record_failure(diagnostics, provider, &failure.path, failure.error);

--- a/src/core/src/scan/compact.rs
+++ b/src/core/src/scan/compact.rs
@@ -18,7 +18,7 @@ use crate::summary_cache::{
     CachedSourceSummary, CompactSourceSummary, SourceFingerprint, SummaryCacheKey, SummaryKind,
     SummaryScanCache,
 };
-use crate::utils::directory::{FileInfo, collect_files_with_max_depth_diagnostics};
+use crate::utils::directory::{FileDiscovery, FileInfo};
 use anyhow::Result;
 use rayon::prelude::*;
 use std::path::Path;
@@ -117,27 +117,21 @@ pub(crate) fn fold_loaded(
     }
 }
 
-/// Scans one file-backed provider directory through the incremental cache.
+/// Scans one file-backed provider discovery through the incremental cache.
 ///
-/// Shared verbatim by usage and analysis: discovery, cache lookup, parallel
-/// miss-load, cache insert, and fold. Each feature supplies only its `sink`.
+/// Shared verbatim by usage and analysis: cache lookup, parallel miss-load,
+/// cache insert, and fold. Each feature supplies only its `sink`.
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn scan_cached_files<F>(
-    dir: &Path,
+pub(crate) fn scan_cached_files(
+    discovery: FileDiscovery,
     provider: ExtensionType,
-    filter: F,
     time_range: TimeRange,
-    max_depth: Option<usize>,
     cache: &mut SummaryScanCache,
     seen: &mut FastHashSet<SummaryCacheKey>,
     sink: &mut impl CompactSink,
     diagnostics: &mut ScanDiagnostics,
     tiers: Option<&TierThresholds>,
-) -> Result<()>
-where
-    F: Copy + Fn(&Path) -> bool + Sync + Send,
-{
-    let discovery = collect_files_with_max_depth_diagnostics(dir, filter, time_range, max_depth);
+) -> Result<()> {
     if !discovery.failures.is_empty() {
         cache.preserve_provider_keys(seen, SummaryKind::File, provider);
     }

--- a/src/core/src/scan/descriptor.rs
+++ b/src/core/src/scan/descriptor.rs
@@ -2,7 +2,7 @@
 //!
 //! The five file-backed providers are scanned with the identical
 //! [`scan_cached_files`](super::scan_cached_files) call, differing only in their
-//! directory, filter, depth cap, and enable toggle. Listing them once here means
+//! discovery function and enable toggle. Listing them once here means
 //! adding a provider is a single table row instead of a new `if` block in every
 //! scan loop.
 
@@ -13,20 +13,21 @@ use crate::models::ExtensionType;
 use crate::models::TimeRange;
 use crate::pricing::TierThresholds;
 use crate::summary_cache::{SummaryCacheKey, SummaryScanCache};
+use crate::utils::directory::{
+    FileDiscovery, collect_codex_session_files_with_diagnostics,
+    collect_files_with_max_depth_diagnostics,
+};
 use crate::utils::{
     COPILOT_SESSION_MAX_DEPTH, GROK_SESSION_MAX_DEPTH, HelperPaths, is_claude_session_file,
-    is_codex_session_file, is_copilot_session_file, is_gemini_session_file, is_grok_session_file,
+    is_copilot_session_file, is_gemini_session_file, is_grok_session_file,
 };
 use anyhow::Result;
-use std::path::Path;
 
 /// One file-backed provider's scan parameters.
 struct FileProviderSpec {
     provider: ExtensionType,
     enabled: fn(&ProvidersConfig) -> bool,
-    dir: fn(&HelperPaths) -> &Path,
-    filter: fn(&Path) -> bool,
-    max_depth: Option<usize>,
+    discover: fn(&HelperPaths, TimeRange) -> FileDiscovery,
 }
 
 /// The file-backed providers, in canonical scan order.
@@ -37,37 +38,62 @@ const FILE_PROVIDERS: [FileProviderSpec; 5] = [
     FileProviderSpec {
         provider: ExtensionType::ClaudeCode,
         enabled: |p| p.claude,
-        dir: |p| p.claude_session_dir.as_path(),
-        filter: is_claude_session_file,
-        max_depth: None,
+        discover: |p, time_range| {
+            collect_files_with_max_depth_diagnostics(
+                &p.claude_session_dir,
+                is_claude_session_file,
+                time_range,
+                None,
+            )
+        },
     },
     FileProviderSpec {
         provider: ExtensionType::Codex,
         enabled: |p| p.codex,
-        dir: |p| p.codex_session_dir.as_path(),
-        filter: is_codex_session_file,
-        max_depth: None,
+        discover: |p, time_range| {
+            let archived_session_dir = p.codex_archived_session_dir();
+            collect_codex_session_files_with_diagnostics(
+                &p.codex_session_dir,
+                &archived_session_dir,
+                time_range,
+            )
+        },
     },
     FileProviderSpec {
         provider: ExtensionType::Copilot,
         enabled: |p| p.copilot,
-        dir: |p| p.copilot_session_dir.as_path(),
-        filter: is_copilot_session_file,
-        max_depth: Some(COPILOT_SESSION_MAX_DEPTH),
+        discover: |p, time_range| {
+            collect_files_with_max_depth_diagnostics(
+                &p.copilot_session_dir,
+                is_copilot_session_file,
+                time_range,
+                Some(COPILOT_SESSION_MAX_DEPTH),
+            )
+        },
     },
     FileProviderSpec {
         provider: ExtensionType::Gemini,
         enabled: |p| p.gemini,
-        dir: |p| p.gemini_session_dir.as_path(),
-        filter: is_gemini_session_file,
-        max_depth: None,
+        discover: |p, time_range| {
+            collect_files_with_max_depth_diagnostics(
+                &p.gemini_session_dir,
+                is_gemini_session_file,
+                time_range,
+                None,
+            )
+        },
     },
     FileProviderSpec {
         provider: ExtensionType::Grok,
         enabled: |p| p.grok,
-        dir: |p| p.grok_session_dir.as_path(),
-        filter: is_grok_session_file,
-        max_depth: Some(GROK_SESSION_MAX_DEPTH),
+        discover: |p, time_range| {
+            collect_files_with_max_depth_diagnostics(
+                &p.grok_session_dir,
+                is_grok_session_file,
+                time_range,
+                Some(GROK_SESSION_MAX_DEPTH),
+            )
+        },
     },
 ];
 
@@ -88,11 +114,9 @@ pub(crate) fn scan_all_cached_files(
     for spec in &FILE_PROVIDERS {
         if (spec.enabled)(&providers) {
             scan_cached_files(
-                (spec.dir)(paths),
+                (spec.discover)(paths, time_range),
                 spec.provider,
-                spec.filter,
                 time_range,
-                spec.max_depth,
                 cache,
                 seen,
                 sink,

--- a/src/core/src/usage/aggregator.rs
+++ b/src/core/src/usage/aggregator.rs
@@ -29,10 +29,12 @@ use crate::session::{
 use crate::summary_cache::{
     CompactSourceSummary, SourceFingerprint, SummaryCacheKey, SummaryKind, SummaryScanCache,
 };
+use crate::utils::directory::FileInfo;
 use crate::utils::{
-    COPILOT_SESSION_MAX_DEPTH, GROK_SESSION_MAX_DEPTH, HelperPaths, collect_files_with_max_depth,
-    is_claude_session_file, is_codex_session_file, is_copilot_session_file, is_gemini_session_file,
-    is_grok_session_file, merge_usage_values, resolve_paths,
+    COPILOT_SESSION_MAX_DEPTH, GROK_SESSION_MAX_DEPTH, HelperPaths,
+    collect_codex_session_files_with_diagnostics, collect_files_with_max_depth,
+    is_claude_session_file, is_copilot_session_file, is_gemini_session_file, is_grok_session_file,
+    merge_usage_values, resolve_paths,
 };
 use anyhow::Result;
 use rayon::prelude::*;
@@ -233,16 +235,21 @@ pub fn aggregate_usage_from_paths_with_providers(
         )?;
     }
 
-    if providers.codex && paths.codex_session_dir.exists() {
-        process_usage_directory(
+    let codex_archived_session_dir = paths.codex_archived_session_dir();
+    if providers.codex && (paths.codex_session_dir.exists() || codex_archived_session_dir.exists())
+    {
+        let files = collect_codex_session_files_with_diagnostics(
             &paths.codex_session_dir,
+            &codex_archived_session_dir,
+            time_range,
+        )
+        .files;
+        process_usage_files(
+            files,
             ExtensionType::Codex,
             &mut result,
             &mut per_provider.codex,
             &mut codex_dates,
-            is_codex_session_file,
-            time_range,
-            None,
         )?;
     }
 
@@ -890,7 +897,22 @@ where
 {
     let dir = dir.as_ref();
     let files = collect_files_with_max_depth(dir, filter_fn, time_range, max_depth)?;
+    process_usage_files(
+        files,
+        provider,
+        global_result,
+        provider_result,
+        unique_dates,
+    )
+}
 
+fn process_usage_files(
+    files: Vec<FileInfo>,
+    provider: ExtensionType,
+    global_result: &mut UsageResult,
+    provider_result: &mut UsageResult,
+    unique_dates: &mut HashSet<String>,
+) -> Result<()> {
     // Parse each file directly in `UsageOnly` mode, extract the small
     // per-model usage map, then drop the analysis. The provider is fixed by
     // the source directory — we do not re-detect from file contents, which

--- a/src/core/src/utils/directory.rs
+++ b/src/core/src/utils/directory.rs
@@ -1,6 +1,9 @@
 use crate::models::TimeRange;
 use anyhow::Result;
+use serde::Deserialize;
+use std::collections::HashSet;
 use std::fs;
+use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
 
@@ -196,6 +199,93 @@ where
     }
 }
 
+/// Discovers active and archived Codex rollout files as one deduplicated source.
+///
+/// Current Codex logs carry their stable session identity in
+/// `session_meta.payload.id`. Active files are considered first so they win
+/// when the same session also remains under `archived_sessions`. A file without
+/// a readable session id is retained rather than guessed to be a duplicate.
+pub(crate) fn collect_codex_session_files_with_diagnostics(
+    active_dir: &Path,
+    archived_dir: &Path,
+    time_range: TimeRange,
+) -> FileDiscovery {
+    let mut active = collect_files_with_max_depth_diagnostics(
+        active_dir,
+        is_codex_session_file,
+        time_range,
+        None,
+    );
+    let mut archived = collect_files_with_max_depth_diagnostics(
+        archived_dir,
+        is_codex_session_file,
+        time_range,
+        None,
+    );
+    active
+        .files
+        .sort_unstable_by(|left, right| left.path.cmp(&right.path));
+    archived
+        .files
+        .sort_unstable_by(|left, right| left.path.cmp(&right.path));
+
+    let mut seen_session_ids = HashSet::new();
+    let mut files = Vec::with_capacity(active.files.len() + archived.files.len());
+    for file in active.files.into_iter().chain(archived.files) {
+        if let Some(session_id) = read_codex_session_id(&file.path)
+            && !seen_session_ids.insert(session_id)
+        {
+            continue;
+        }
+        files.push(file);
+    }
+    files.sort_unstable_by(|left, right| left.path.cmp(&right.path));
+
+    active.failures.append(&mut archived.failures);
+    active.failures.sort_by(|left, right| {
+        left.path
+            .cmp(&right.path)
+            .then_with(|| left.error.cmp(&right.error))
+    });
+    FileDiscovery {
+        files,
+        failures: active.failures,
+    }
+}
+
+#[derive(Deserialize)]
+struct CodexSessionIdentityRecord {
+    #[serde(rename = "type")]
+    record_type: String,
+    #[serde(default)]
+    payload: CodexSessionIdentityPayload,
+}
+
+#[derive(Default, Deserialize)]
+struct CodexSessionIdentityPayload {
+    id: Option<String>,
+}
+
+fn read_codex_session_id(path: &Path) -> Option<String> {
+    let file = fs::File::open(path).ok()?;
+    let mut reader = BufReader::new(file);
+    let mut line = String::new();
+
+    loop {
+        line.clear();
+        match reader.read_line(&mut line) {
+            Ok(0) | Err(_) => return None,
+            Ok(_) => {}
+        }
+        let Ok(record) = serde_json::from_str::<CodexSessionIdentityRecord>(&line) else {
+            continue;
+        };
+        if record.record_type == "session_meta" {
+            return record.payload.id.filter(|id| !id.is_empty());
+        }
+    }
+}
+
 /// Maximum traversal depth for Copilot CLI session scans.
 ///
 /// Copilot writes `~/.copilot/session-state/<sessionId>/events.jsonl`, so
@@ -213,9 +303,10 @@ pub const COPILOT_SESSION_MAX_DEPTH: usize = 2;
 /// each signals file is exactly three levels below the sessions root.
 pub const GROK_SESSION_MAX_DEPTH: usize = 3;
 
-/// Filter for Codex session files under `~/.codex/sessions/YYYY/MM/DD/`.
+/// Filter for Codex session files under the active or archived session roots.
 ///
-/// Codex writes `rollout-*.jsonl` files directly into the dated sub-folders.
+/// Active sessions live in dated sub-folders under `~/.codex/sessions`, while
+/// archived sessions live directly under `~/.codex/archived_sessions`.
 /// We also accept `.json` defensively in case an older dump ever gets dropped
 /// into the tree, but reject Claude Code's `*.meta.json` / `*.meta.jsonl`
 /// subagent sidecar files (those live under `~/.claude/projects/` in

--- a/src/core/src/utils/mod.rs
+++ b/src/core/src/utils/mod.rs
@@ -18,6 +18,7 @@ pub mod token_merge;
 pub mod usage_processor;
 
 // Public API exports (commonly used across modules)
+pub(crate) use directory::collect_codex_session_files_with_diagnostics;
 pub use directory::{
     COPILOT_SESSION_MAX_DEPTH, GROK_SESSION_MAX_DEPTH, collect_files_with_dates,
     collect_files_with_max_depth, is_claude_session_file, is_codex_session_file,

--- a/src/core/src/utils/paths.rs
+++ b/src/core/src/utils/paths.rs
@@ -12,7 +12,9 @@ use std::sync::OnceLock;
 ///
 /// Construct one with [`resolve_paths`]; the fields are derived from the
 /// user's home directory and are not validated to exist. The `*_session_dir`
-/// fields point at the subtree a directory walker scans for that provider.
+/// fields point at the primary subtree a directory walker scans for that
+/// provider; [`HelperPaths::codex_archived_session_dir`] returns Codex's
+/// additional archive root.
 #[derive(Debug, Clone)]
 pub struct HelperPaths {
     /// The user's home directory, the root for every other path.
@@ -61,6 +63,13 @@ pub struct HelperPaths {
     pub hermes_db: PathBuf,
     /// This tool's cache directory (`~/.vct`).
     pub cache_dir: PathBuf,
+}
+
+impl HelperPaths {
+    /// Returns the archived Codex session directory (`~/.codex/archived_sessions`).
+    pub fn codex_archived_session_dir(&self) -> PathBuf {
+        self.codex_dir.join("archived_sessions")
+    }
 }
 
 /// Builds a [`HelperPaths`] from the current user's home directory.
@@ -539,6 +548,10 @@ mod tests {
         assert!(p.cache_dir.ends_with(".vct"));
 
         assert_eq!(p.codex_session_dir, home.join(".codex").join("sessions"));
+        assert_eq!(
+            p.codex_archived_session_dir(),
+            home.join(".codex").join("archived_sessions")
+        );
         assert_eq!(p.claude_session_dir, home.join(".claude").join("projects"));
         assert_eq!(
             p.copilot_session_dir,

--- a/src/core/tests/analysis.rs
+++ b/src/core/tests/analysis.rs
@@ -431,6 +431,105 @@ fn batch_analysis_from_paths_groups_by_model() {
 }
 
 #[test]
+fn codex_archived_sessions_are_included_and_deduplicated() {
+    let home = TempHome::new();
+    let fixture = fixture_str("sessions/codex.jsonl");
+    let archived_duplicate = fixture.replace("aide-gpt-5", "archived-duplicate-model");
+    home.put_archived_codex_session("rollout-shared.jsonl", &archived_duplicate);
+    let providers = providers_only(ExtensionType::Codex);
+
+    let archive_only = collect_analysis_sessions_from_paths_with(
+        &home.paths,
+        TimeRange::All,
+        providers,
+        ParseMode::Full,
+    )
+    .unwrap();
+    assert_eq!(archive_only.len(), 1);
+    assert_eq!(archive_only.diagnostics.candidates, 1);
+    assert!(
+        archive_only
+            .summarize()
+            .per_provider
+            .codex
+            .iter()
+            .any(|row| row.model == "archived-duplicate-model")
+    );
+
+    home.put_codex_session("2026/07/29/rollout-active-copy.jsonl", &fixture);
+    let active_preferred = collect_analysis_sessions_from_paths_with(
+        &home.paths,
+        TimeRange::All,
+        providers,
+        ParseMode::Full,
+    )
+    .unwrap();
+    assert_eq!(active_preferred.len(), 1);
+    let active_summary = active_preferred.summarize();
+    let rows = &active_summary.per_provider.codex;
+    assert!(rows.iter().any(|row| row.model == "aide-gpt-5"));
+    assert!(
+        !rows
+            .iter()
+            .any(|row| row.model == "archived-duplicate-model")
+    );
+
+    let distinct_archived = fixture
+        .replace(
+            "01996135-afde-7911-97f0-d863511eca56",
+            "019fae00-0000-7000-8000-000000000124",
+        )
+        .replace("aide-gpt-5", "archived-distinct-model");
+    home.put_archived_codex_session("rollout-distinct.jsonl", &distinct_archived);
+
+    let combined = collect_analysis_sessions_from_paths_with(
+        &home.paths,
+        TimeRange::All,
+        providers,
+        ParseMode::Full,
+    )
+    .unwrap();
+    assert_eq!(combined.len(), 2);
+    assert_eq!(combined.diagnostics.candidates, 2);
+    let combined_summary = combined.summarize();
+    let rows = &combined_summary.per_provider.codex;
+    assert!(rows.iter().any(|row| row.model == "aide-gpt-5"));
+    assert!(
+        rows.iter()
+            .any(|row| row.model == "archived-distinct-model")
+    );
+    assert!(
+        !rows
+            .iter()
+            .any(|row| row.model == "archived-duplicate-model")
+    );
+
+    let mut cache = SummaryScanCache::new();
+    let cold = aggregate_sessions_by_model_from_paths_with_cache(
+        &home.paths,
+        TimeRange::All,
+        providers,
+        &mut cache,
+    )
+    .unwrap();
+    assert_eq!(cold.diagnostics.candidates, 2);
+    assert_eq!(cold.diagnostics.parsed, 2);
+    assert_eq!(cache.stats().entries, 2);
+    assert_eq!(cache.stats().parsed_sources, 2);
+    assert_analysis_data_eq(&cold.data, &combined_summary);
+
+    let warm = aggregate_sessions_by_model_from_paths_with_cache(
+        &home.paths,
+        TimeRange::All,
+        providers,
+        &mut cache,
+    )
+    .unwrap();
+    assert_eq!(cache.stats().parsed_sources, 0);
+    assert_analysis_data_eq(&warm.data, &combined_summary);
+}
+
+#[test]
 fn cached_analysis_matches_uncached_and_reuses_unchanged_sources() {
     let home = TempHome::new();
     home.put_claude_session(

--- a/src/core/tests/usage.rs
+++ b/src/core/tests/usage.rs
@@ -31,6 +31,19 @@ fn claude_only() -> ProvidersConfig {
     }
 }
 
+fn codex_only() -> ProvidersConfig {
+    ProvidersConfig {
+        claude: false,
+        codex: true,
+        copilot: false,
+        gemini: false,
+        opencode: false,
+        cursor: false,
+        hermes: false,
+        grok: false,
+    }
+}
+
 fn opencode_only() -> ProvidersConfig {
     ProvidersConfig {
         claude: false,
@@ -189,6 +202,115 @@ fn empty_home_yields_no_usage() {
         aggregate_usage_from_paths(&home.paths, TimeRange::All).expect("aggregate empty home");
     assert!(data.models.is_empty(), "empty home has no models");
     assert_eq!(data.provider_days.total, 0);
+}
+
+#[test]
+fn codex_archived_sessions_are_included_and_deduplicated() {
+    let home = TempHome::new();
+    let fixture = fixture_str("sessions/codex.jsonl");
+    let archived_duplicate = fixture.replace("aide-gpt-5", "archived-duplicate-model");
+    home.put_archived_codex_session("rollout-shared.jsonl", &archived_duplicate);
+
+    let archive_only =
+        aggregate_usage_from_paths_with_providers(&home.paths, TimeRange::All, codex_only())
+            .unwrap();
+    assert!(
+        archive_only
+            .per_provider
+            .codex
+            .contains_key("archived-duplicate-model")
+    );
+
+    let mut cache = SummaryScanCache::new();
+    let archive_only_cached = aggregate_usage_from_paths_with_cache(
+        &home.paths,
+        TimeRange::All,
+        codex_only(),
+        &mut cache,
+    )
+    .unwrap();
+    assert_eq!(archive_only_cached.diagnostics.candidates, 1);
+    assert_eq!(archive_only_cached.diagnostics.parsed, 1);
+    assert_eq!(cache.stats().parsed_sources, 1);
+    assert_usage_data_eq(&archive_only_cached.data, &archive_only);
+
+    home.put_codex_session("2026/07/29/rollout-active-copy.jsonl", &fixture);
+    let active_preferred =
+        aggregate_usage_from_paths_with_providers(&home.paths, TimeRange::All, codex_only())
+            .unwrap();
+    assert!(
+        active_preferred
+            .per_provider
+            .codex
+            .contains_key("aide-gpt-5")
+    );
+    assert!(
+        !active_preferred
+            .per_provider
+            .codex
+            .contains_key("archived-duplicate-model")
+    );
+
+    let active_preferred_cached = aggregate_usage_from_paths_with_cache(
+        &home.paths,
+        TimeRange::All,
+        codex_only(),
+        &mut cache,
+    )
+    .unwrap();
+    assert_eq!(active_preferred_cached.diagnostics.candidates, 1);
+    assert_eq!(active_preferred_cached.diagnostics.parsed, 1);
+    assert_eq!(cache.stats().entries, 1);
+    assert_eq!(cache.stats().parsed_sources, 1);
+    assert_usage_data_eq(&active_preferred_cached.data, &active_preferred);
+
+    let distinct_archived = fixture
+        .replace(
+            "01996135-afde-7911-97f0-d863511eca56",
+            "019fae00-0000-7000-8000-000000000124",
+        )
+        .replace("aide-gpt-5", "archived-distinct-model");
+    home.put_archived_codex_session("rollout-distinct.jsonl", &distinct_archived);
+
+    let combined =
+        aggregate_usage_from_paths_with_providers(&home.paths, TimeRange::All, codex_only())
+            .unwrap();
+    assert!(combined.per_provider.codex.contains_key("aide-gpt-5"));
+    assert!(
+        combined
+            .per_provider
+            .codex
+            .contains_key("archived-distinct-model")
+    );
+    assert!(
+        !combined
+            .per_provider
+            .codex
+            .contains_key("archived-duplicate-model")
+    );
+
+    let combined_cached = aggregate_usage_from_paths_with_cache(
+        &home.paths,
+        TimeRange::All,
+        codex_only(),
+        &mut cache,
+    )
+    .unwrap();
+    assert_eq!(combined_cached.diagnostics.candidates, 2);
+    assert_eq!(combined_cached.diagnostics.parsed, 2);
+    assert_eq!(cache.stats().entries, 2);
+    assert_eq!(cache.stats().parsed_sources, 1);
+    assert_usage_data_eq(&combined_cached.data, &combined);
+
+    let warm = aggregate_usage_from_paths_with_cache(
+        &home.paths,
+        TimeRange::All,
+        codex_only(),
+        &mut cache,
+    )
+    .unwrap();
+    assert_eq!(cache.stats().parsed_sources, 0);
+    assert_usage_data_eq(&warm.data, &combined);
 }
 
 #[test]

--- a/src/test-support/src/lib.rs
+++ b/src/test-support/src/lib.rs
@@ -108,6 +108,13 @@ impl TempHome {
         p
     }
 
+    /// Drops an archived Codex rollout log at `~/.codex/archived_sessions/<file>`.
+    pub fn put_archived_codex_session(&self, file: &str, content: &str) -> PathBuf {
+        let p = self.paths.codex_archived_session_dir().join(file);
+        Self::write_file(&p, content);
+        p
+    }
+
     /// Drops a Gemini chat log at `~/.gemini/tmp/<project>/chats/<file>`.
     ///
     /// The `chats` parent segment is required by `is_gemini_session_file`.


### PR DESCRIPTION
## Summary

- scan Codex rollout logs from both active and archived session directories
- deduplicate copies by `session_meta.payload.id`, preferring the active copy
- share the same discovery behavior across analysis, usage, and incremental cache scans
- document the archived source and cover archive-only, duplicate, distinct, and cache refresh cases

## Root cause

VCT resolved and scanned only `~/.codex/sessions`. When Codex moved a rollout to `~/.codex/archived_sessions`, that session disappeared from both analysis and usage totals. The existing cache identity used the full source path, so simply scanning both directories would also have counted duplicate copies twice.

## User impact

Historical Codex activity remains present after a session is archived, and a session that temporarily exists in both directories contributes only once.

## Validation

- `make fmt`
- `cargo test --workspace` (936 passed)
- `uvx pre-commit run -a`
- focused defect-first code review with no findings

Fixes #124