### PR TITLE
feat(update): add safe startup auto-update

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,9 +461,13 @@ Codex code-mode sessions expose a completed JavaScript `exec` cell but no struct
 
 ## Update Command
 
-**Keep your installation up-to-date automatically.**
+**Keep supported direct installations up to date automatically.**
 
-The update command works for **all installation methods** (npm/pip/cargo/manual) by directly downloading and replacing the binary from GitHub releases.
+At startup, vct silently checks for a newer release at most once per UTC day. A newer release is downloaded and applied only when the current binary was installed by the official `scripts/install.sh` or `scripts/install.ps1` installer and carries its `.vct-managed` marker. The check, download, and replacement never print to stdout or stderr. A network failure, rate limit, read-only directory, or another running vct process only leaves the current command running; the reason is recorded in the diagnostic log. `VCT_OFFLINE=1` skips the check completely.
+
+After a Unix update, vct re-executes the current command with the new binary. On Windows, the current command finishes and a helper applies the replacement afterwards. The automatic path never modifies installs from cargo, npm, PyPI, a distro package, or an unmarked manual or development build. Update those through their package manager instead. To add automatic updates to an existing direct install, run the current official installer once more so it creates the marker.
+
+Set `general.auto_update = false` in `~/.vct/config.toml` to disable startup checks and automatic updates. The explicit `vct update` command retains its existing manual behavior.
 
 ### Basic Usage
 
@@ -560,9 +564,12 @@ vct keeps its user settings in `~/.vct/config.toml`. The file is **created with 
 # Default time range when no --daily/--weekly/--monthly/--all flag is given.
 # One of: "daily" | "weekly" | "monthly" | "all".
 default_time_range = "all"
+# Check for a newer release at startup and automatically update supported direct installs.
+# Set to false to disable this behavior.
+auto_update = true
 # Layout version of this file, stamped by vct. Only the upgrade pass reads it;
 # leave it alone unless you want a past upgrade to run again.
-version = 2
+version = 3
 
 [usage]
 # Start the usage dashboard with models merged across provider prefixes.
@@ -610,6 +617,7 @@ retention_days = 7
 | Setting                        | Effect                                                                                                                          |
 | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
 | `general.default_time_range`   | Period used when you pass no `--daily/--weekly/--monthly/--all`. An explicit flag always wins.                                  |
+| `general.auto_update`          | Check once per UTC day at startup and automatically update only official-installer direct installs. Set to `false` to disable.  |
 | `general.version`              | Layout version vct stamps on the file, so a panel added by a later release is offered to you exactly once.                      |
 | `usage.merge_models`           | Seeds the dashboard merged; the `m` toggle saves your last choice back here. `--merge-providers` forces on.                     |
 | `usage.refresh_interval`       | Redraw cadence of the `usage` dashboard (seconds).                                                                              |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -461,9 +461,13 @@ Codex code mode session 会提供已完成的 JavaScript `exec` cell, 但没有 
 
 ## Update 命令
 
-**自动保持安装版本为最新。**
+**自动让受支持的直接安装保持最新版本.**
 
-update 命令适用于**所有安装方式**（npm/pip/cargo/手动安装），它会直接从 GitHub releases 下载并替换二进制文件。
+vct 启动时每天 UTC 日期最多检查一次新版. 只有通过官方 `scripts/install.sh` 或 `scripts/install.ps1` 安装, 并且带有 `.vct-managed` marker 的二进制文件, 才会下载并应用新版. 检查, 下载和替换都不会输出到 stdout 或 stderr. 网络失败, rate limit, 只读目录或另一个 vct process 正在运行时, 当前命令仍会照常继续, 原因只会写入 diagnostic log. `VCT_OFFLINE=1` 会完全跳过检查.
+
+Unix 应用更新后, vct 会用新版 binary 重新执行当前命令. Windows 会先让当前命令结束, 再由 helper 应用替换. 自动流程绝不会修改通过 cargo, npm, PyPI, distro package 安装的版本, 也不会修改没有 marker 的手动安装或 development build. 请通过相应的 package manager 更新. 现有直接安装只要再运行一次当前官方 installer, 就会创建 marker 并启用自动更新.
+
+在 `~/.vct/config.toml` 中设置 `general.auto_update = false` 可以关闭启动检查和自动更新. 显式执行的 `vct update` 会保留原有手动行为.
 
 ### 基本用法
 
@@ -560,9 +564,12 @@ vct 会把用户设置保存在 `~/.vct/config.toml` 中。该文件会在**首�
 # 未指定 --daily/--weekly/--monthly/--all flag 时使用的默认时间范围
 # 取值之一: "daily" | "weekly" | "monthly" | "all"
 default_time_range = "all"
+# 启动时检查新版, 并自动更新由官方 installer 创建的受支持直接安装.
+# 设为 false 可关闭此行为.
+auto_update = true
 # 该文件的布局版本, 由 vct 标记. 只有升级流程会读取它;
 # 除非你想让某次过去的升级再跑一遍, 否则不要动它.
-version = 2
+version = 3
 
 [usage]
 # 启动 usage 面板时就把跨 provider 前缀的 model 合并显示
@@ -609,6 +616,7 @@ retention_days = 7
 | 设置项                         | 作用                                                                                                            |
 | ------------------------------ | --------------------------------------------------------------------------------------------------------------- |
 | `general.default_time_range`   | 当你没有传入 `--daily/--weekly/--monthly/--all` 时使用的时间范围。显式传入的 flag 始终优先。                    |
+| `general.auto_update`          | 启动时每天 UTC 日期最多检查一次, 并且只更新官方 installer 的直接安装. 设为 `false` 可关闭.                      |
 | `general.version`              | vct 标记在文件上的布局版本，让后续版本新增的面板只会向你提供一次。                                              |
 | `usage.merge_models`           | 让面板启动时就处于合并状态；`m` 切换会把你上次的选择保存回这里。`--merge-providers` 会强制开启。                |
 | `usage.refresh_interval`       | `usage` 面板的自动刷新间隔（秒）。                                                                              |

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -461,9 +461,13 @@ Codex code mode session 會提供已完成的 JavaScript `exec` cell, 但沒有 
 
 ## Update 指令
 
-**自動保持安裝為最新版本。**
+**自動讓受支援的直接安裝維持最新版本.**
 
-Update 指令適用於**所有安裝方式**（npm/pip/cargo/手動安裝），透過直接從 GitHub releases 下載並替換執行檔來完成更新。
+vct 啟動時最多每天 UTC 日期檢查一次新版. 只有透過官方 `scripts/install.sh` 或 `scripts/install.ps1` 安裝, 且帶有 `.vct-managed` marker 的執行檔, 才會下載並套用新版. 檢查, 下載與替換都不會印到 stdout 或 stderr. 網路失敗, rate limit, 唯讀目錄或另一個 vct process 正在執行時, 目前指令仍會照常繼續, 原因只會寫入 diagnostic log. `VCT_OFFLINE=1` 會完全略過檢查.
+
+Unix 套用更新後, vct 會用新版 binary 重新執行目前指令. Windows 則會讓目前指令結束, 再由 helper 套用替換. 自動流程絕不會修改透過 cargo, npm, PyPI, distro package 安裝的版本, 或沒有 marker 的手動與 development build. 請透過對應 package manager 更新. 既有的直接安裝只要再執行一次目前的官方 installer, 就會建立 marker 並啟用自動更新.
+
+在 `~/.vct/config.toml` 設定 `general.auto_update = false` 可關閉啟動檢查與自動更新. 明確執行的 `vct update` 會保留原有的手動行為.
 
 ### 基本用法
 
@@ -560,9 +564,12 @@ vct 會把使用者設定存放在 `~/.vct/config.toml`。這個檔案會在**�
 # 未指定 --daily/--weekly/--monthly/--all flag 時使用的預設時間範圍。
 # 可選值："daily" | "weekly" | "monthly" | "all"
 default_time_range = "all"
+# 啟動時檢查新版, 並自動更新由官方 installer 建立的受支援直接安裝.
+# 設為 false 可關閉此行為.
+auto_update = true
 # 這個檔案的版面版本，由 vct 標記。只有升級流程會讀取它;
 # 除非你想讓過去的升級再跑一次，否則別去動它。
-version = 2
+version = 3
 
 [usage]
 # 啟動 usage 儀表板時，是否先把不同 provider 前綴的 model 合併。
@@ -609,6 +616,7 @@ retention_days = 7
 | 設定項                         | 效果                                                                                                          |
 | ------------------------------ | ------------------------------------------------------------------------------------------------------------- |
 | `general.default_time_range`   | 未指定 `--daily/--weekly/--monthly/--all` 時使用的時間範圍。明確指定的 flag 一律優先。                        |
+| `general.auto_update`          | 啟動時每天 UTC 日期最多檢查一次, 並只更新官方 installer 的直接安裝. 設為 `false` 可關閉.                      |
 | `general.version`              | vct 標記在檔案上的版面版本，讓後續版本新增的面板只會向你提議一次。                                            |
 | `usage.merge_models`           | 讓儀表板一開始就是合併狀態;`m` 切換會把你最後的選擇存回這裡。`--merge-providers` 會強制開啟。                 |
 | `usage.refresh_interval`       | `usage` 儀表板自動刷新的間隔（秒）。                                                                          |

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -59,8 +59,30 @@ function Install-Binary {
         }
 
         $target = Join-Path $installDir "$BinaryName.exe"
-        Copy-Item -Path $binary.FullName -Destination $target -Force
-        Copy-Item -Path $target -Destination (Join-Path $installDir "vct.exe") -Force
+        $stagedTarget = Join-Path $installDir ".$BinaryName.$PID.new"
+        Copy-Item -Path $binary.FullName -Destination $stagedTarget -Force
+        Move-Item -LiteralPath $stagedTarget -Destination $target -Force
+
+        $wrapper = Join-Path $installDir "vct.cmd"
+        $stagedWrapper = Join-Path $installDir ".vct.$PID.cmd"
+        [System.IO.File]::WriteAllText(
+            $stagedWrapper,
+            "@echo off`r`n`"%~dp0$BinaryName.exe`" %*`r`n",
+            [System.Text.Encoding]::ASCII
+        )
+        Move-Item -LiteralPath $stagedWrapper -Destination $wrapper -Force
+        $legacyAlias = Join-Path $installDir "vct.exe"
+        if (Test-Path -LiteralPath $legacyAlias) {
+            Remove-Item -LiteralPath $legacyAlias -Force
+        }
+
+        $markerPath = [System.IO.Path]::GetFullPath($target) + ".vct-managed"
+        $stagedMarker = "$markerPath.$PID.new"
+        [System.IO.File]::WriteAllBytes(
+            $stagedMarker,
+            [System.Text.Encoding]::ASCII.GetBytes("vct-release-installer-v1`n")
+        )
+        Move-Item -LiteralPath $stagedMarker -Destination $markerPath -Force
 
         Write-Host "Installed $BinaryName $Version to $installDir"
         if ($env:Path -notlike "*$installDir*") {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -75,9 +75,20 @@ install_binary() {
     install_dir="$(select_install_dir)"
     mkdir -p "$install_dir"
 
-    chmod +x "$binary"
-    cp "$binary" "${install_dir}/${BINARY_NAME}"
-    ln -sf "${install_dir}/${BINARY_NAME}" "${install_dir}/vct"
+    local target="${install_dir}/${BINARY_NAME}"
+    local canonical_install_dir
+    canonical_install_dir="$(cd -P "$install_dir" && pwd)"
+    local staged_target
+    staged_target="$(mktemp "${canonical_install_dir}/.${BINARY_NAME}.XXXXXX")"
+    local staged_marker
+    staged_marker="$(mktemp "${canonical_install_dir}/.${BINARY_NAME}.marker.XXXXXX")"
+
+    cp "$binary" "$staged_target"
+    chmod +x "$staged_target"
+    mv -f "$staged_target" "$target"
+    printf 'vct-release-installer-v1\n' > "$staged_marker"
+    mv -f "$staged_marker" "${canonical_install_dir}/${BINARY_NAME}.vct-managed"
+    ln -sf "$target" "${install_dir}/vct"
 
     echo "Installed ${BINARY_NAME} ${version} to ${install_dir}"
 

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -37,6 +37,8 @@ use vct_tui::display::usage::{
     display_usage_interactive_with_pool, display_usage_table, display_usage_text,
 };
 
+const AUTO_UPDATE_REEXEC_ENV: &str = "VCT_AUTO_UPDATE_REEXEC";
+
 /// Parses the CLI and runs the selected subcommand.
 ///
 /// Two steps run before `Cli::parse()` and must stay in this order:
@@ -91,6 +93,7 @@ fn main() -> Result<()> {
 /// Parses the CLI and dispatches the selected subcommand.
 fn run() -> Result<()> {
     let cli = Cli::parse();
+    run_startup_auto_update(&cli);
 
     match cli.command {
         Commands::Analysis {
@@ -132,8 +135,8 @@ fn run() -> Result<()> {
                 }
                 None => {
                     // Settings are only needed for the batch (all-sessions) path,
-                    // so `analysis FILE`, `version`, `quota`, etc. never read or
-                    // create `~/.vct/config.toml`.
+                    // so `analysis FILE`, `version`, `quota`, etc. never create
+                    // or rewrite `~/.vct/config.toml`.
                     let config = vct_core::config::load();
                     vct_core::logging::apply(&config.logging);
                     let time_range = resolve_time_range_with_default(
@@ -317,6 +320,54 @@ fn run() -> Result<()> {
 
     Ok(())
 }
+
+/// Runs the silent startup updater before any command emits output or enters a
+/// terminal session.
+fn run_startup_auto_update(cli: &Cli) {
+    if std::env::var_os(AUTO_UPDATE_REEXEC_ENV).is_some()
+        || matches!(
+            &cli.command,
+            Commands::Update { .. } | Commands::Config { .. }
+        )
+    {
+        return;
+    }
+
+    let config = vct_core::config::load_read_only();
+    let reexec_path = std::env::current_exe()
+        .ok()
+        .and_then(|path| path.canonicalize().ok());
+    if vct_core::update::maybe_auto_update(config.general.auto_update)
+        == vct_core::update::AutoUpdateOutcome::Updated
+    {
+        reexec_current_command(reexec_path);
+    }
+}
+
+#[cfg(unix)]
+fn reexec_current_command(current_exe: Option<std::path::PathBuf>) {
+    use std::os::unix::process::CommandExt;
+
+    let Some(current_exe) = current_exe else {
+        log::warn!("auto-update succeeded but the current executable could not be resolved");
+        return;
+    };
+    let error = build_reexec_command(&current_exe, std::env::args_os().skip(1)).exec();
+    log::warn!("auto-update succeeded but re-exec failed: {error}");
+}
+
+#[cfg(unix)]
+fn build_reexec_command(
+    current_exe: &std::path::Path,
+    args: impl IntoIterator<Item = std::ffi::OsString>,
+) -> std::process::Command {
+    let mut command = std::process::Command::new(current_exe);
+    command.args(args).env(AUTO_UPDATE_REEXEC_ENV, "1");
+    command
+}
+
+#[cfg(not(unix))]
+fn reexec_current_command(_current_exe: Option<std::path::PathBuf>) {}
 
 /// Handles the `config` subcommand: print the path, show current settings, open
 /// the file in the user's editor, or print the JSON schema.
@@ -502,4 +553,37 @@ fn report_usage_collection(diagnostics: &vct_core::usage::ScanDiagnostics) -> Re
 /// The fallback editor when neither `$VISUAL` nor `$EDITOR` is set.
 fn default_editor() -> &'static str {
     if cfg!(windows) { "notepad" } else { "vi" }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::{AUTO_UPDATE_REEXEC_ENV, build_reexec_command};
+    use std::ffi::{OsStr, OsString};
+    use std::path::Path;
+
+    #[test]
+    fn reexec_preserves_every_original_argument_and_sets_the_sentinel() {
+        let args = [
+            OsString::from("analysis"),
+            OsString::from("path with spaces/session.jsonl"),
+            OsString::from("--json"),
+        ];
+        let command = build_reexec_command(Path::new("/tmp/vct next"), args.clone());
+
+        assert_eq!(command.get_program(), OsStr::new("/tmp/vct next"));
+        assert_eq!(
+            command
+                .get_args()
+                .map(OsStr::to_os_string)
+                .collect::<Vec<_>>(),
+            args
+        );
+        assert_eq!(
+            command
+                .get_envs()
+                .find(|(name, _)| *name == OsStr::new(AUTO_UPDATE_REEXEC_ENV))
+                .and_then(|(_, value)| value),
+            Some(OsStr::new("1"))
+        );
+    }
 }

--- a/src/cli/tests/cli.rs
+++ b/src/cli/tests/cli.rs
@@ -818,6 +818,51 @@ fn readonly_commands_do_not_create_config() {
         !home.home().join(".vct/config.toml").exists(),
         "version must not create config.toml"
     );
+    assert!(
+        !home.home().join(".vct/version.json").exists(),
+        "offline startup must not create version.json"
+    );
+}
+
+#[test]
+fn startup_reads_auto_update_preference_without_rewriting_config() {
+    let home = TempHome::new();
+    let original = "#:schema https://example.test/vct.schema.json\n[general]\nauto_update = false\nversion = 3\n";
+    home.put(".vct/config.toml", original);
+
+    child_cmd(&home)
+        .arg("version")
+        .arg("--json")
+        .assert()
+        .success();
+
+    assert_eq!(
+        std::fs::read_to_string(home.home().join(".vct/config.toml")).unwrap(),
+        original
+    );
+    assert!(!home.home().join(".vct/version.json").exists());
+}
+
+#[test]
+fn package_managed_binary_skips_startup_update_before_network_or_cache_writes() {
+    let home = TempHome::new();
+    let output = child_cmd(&home)
+        .env_remove("VCT_OFFLINE")
+        .env("HTTPS_PROXY", "http://127.0.0.1:9")
+        .env("HTTP_PROXY", "http://127.0.0.1:9")
+        .env_remove("NO_PROXY")
+        .arg("version")
+        .arg("--json")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    serde_json::from_slice::<serde_json::Value>(&output.stdout).unwrap();
+    assert!(output.stderr.is_empty());
+    assert!(
+        !home.home().join(".vct/version.json").exists(),
+        "an unmarked binary must skip before claiming the daily check"
+    );
 }
 
 #[test]
@@ -856,6 +901,7 @@ fn config_show_creates_and_prints_settings() {
         .success()
         .stdout(predicate::str::contains("[usage]"))
         .stdout(predicate::str::contains("merge_models"))
+        .stdout(predicate::str::contains("auto_update"))
         .stdout(predicate::str::contains("[providers]"))
         .stdout(predicate::str::contains("[usage.quota]"));
 
@@ -886,6 +932,7 @@ fn config_migrate_upgrades_a_legacy_file() {
     let text = std::fs::read_to_string(home.home().join(".vct/config.toml")).unwrap();
     assert!(text.starts_with("#:schema "));
     assert!(text.contains("[usage.quota]"));
+    assert!(text.contains("auto_update = true"));
     assert!(!text.contains("quota_panels"));
     assert!(!text.contains("refresh_interval_secs"));
 

--- a/src/core/src/config/mod.rs
+++ b/src/core/src/config/mod.rs
@@ -17,14 +17,15 @@
 //! [`migrate_document`] rewrites a standard-`[header]`-table file in place —
 //! adding the `#:schema` directive, renaming `refresh_interval_secs` to
 //! `refresh_interval`, and moving `[usage].quota_panels` into the nested
-//! `[usage.quota]` table — so an existing user actually gets the new layout
-//! (`vct config migrate` forces the same pass). A read-time [`migrate_legacy`]
+//! `[usage.quota]` table, and adding the startup auto-update preference, so an
+//! existing user actually gets the new layout (`vct config migrate` forces the
+//! same pass). A read-time [`migrate_legacy`]
 //! shim then backstops any residual legacy form the structural pass leaves alone
 //! (e.g. a hand-edited inline `usage = { ... }` table), so the returned [`Config`]
 //! is always correct even when the file was not rewritten.
 
 use crate::models::TimeRange;
-use crate::utils::{get_cache_dir, write_string_atomic};
+use crate::utils::{get_cache_dir, resolve_paths, write_string_atomic};
 use anyhow::Result;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -42,7 +43,7 @@ const SCHEMA_URL: &str =
 ///
 /// It exists so an upgrade can add a setting to an existing file exactly once.
 /// Version 1 is any file written before the key existed.
-const CONFIG_VERSION: u32 = 2;
+const CONFIG_VERSION: u32 = 3;
 
 /// Quota panels introduced after version 1, back-filled once into a file older
 /// than the version that shipped them.
@@ -115,6 +116,9 @@ pub struct GeneralConfig {
     /// One of: "daily" | "weekly" | "monthly" | "all".
     #[serde(default)]
     pub default_time_range: TimeRange,
+    /// Check for a newer vct release when the CLI starts.
+    #[serde(default = "default_true")]
+    pub auto_update: bool,
     /// Layout version of this file, stamped by vct. Only the upgrade pass reads
     /// it; leave it alone unless you want a past upgrade to run again.
     #[serde(
@@ -128,6 +132,7 @@ impl Default for GeneralConfig {
     fn default() -> Self {
         Self {
             default_time_range: TimeRange::default(),
+            auto_update: true,
             // A file this tool writes is current by construction; only a file
             // read from disk without the key is legacy (see the serde default).
             version: CONFIG_VERSION,
@@ -375,6 +380,27 @@ pub fn load() -> Config {
     }
 }
 
+/// Reads settings from `~/.vct/config.toml` without creating or modifying any
+/// files. Legacy layouts are migrated in memory only.
+///
+/// Infallible: any error resolving, reading, or parsing degrades to
+/// [`Config::default`].
+pub fn load_read_only() -> Config {
+    match resolve_paths() {
+        Ok(paths) => load_read_only_in(&paths.cache_dir),
+        Err(_) => Config::default(),
+    }
+}
+
+/// [`load_read_only`] rooted at an explicit directory (test seam).
+pub fn load_read_only_in(dir: &Path) -> Config {
+    let path = dir.join("config.toml");
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return Config::default();
+    };
+    parse_config_text(&text)
+}
+
 /// [`load`] rooted at an explicit directory (test seam).
 pub fn load_in(dir: &Path) -> Config {
     let path = dir.join("config.toml");
@@ -394,16 +420,30 @@ pub fn load_in(dir: &Path) -> Config {
             Ok(None) => text,
             Err(_) => return Config::default(),
         };
-        let mut config: Config = toml_edit::de::from_str(&effective).unwrap_or_default();
-        // Backstop for any residual legacy form the structural migration leaves
-        // alone (e.g. an inline `usage = { ... }` table).
-        migrate_legacy(&mut config, &effective);
-        return config;
+        return parse_effective_config(&effective);
     }
     // First run: materialize the generated commented template.
     let text = default_document().to_string();
     let _ = write_string_atomic(&path, &text);
     toml_edit::de::from_str(&text).unwrap_or_default()
+}
+
+/// Parses text after the same in-memory structural migration used by the
+/// writable loader, without persisting the result.
+fn parse_config_text(text: &str) -> Config {
+    match migrate_text(text) {
+        Ok(Some(migrated)) => parse_effective_config(&migrated),
+        Ok(None) => parse_effective_config(text),
+        Err(_) => Config::default(),
+    }
+}
+
+fn parse_effective_config(text: &str) -> Config {
+    let mut config: Config = toml_edit::de::from_str(text).unwrap_or_default();
+    // Backstop for any residual legacy form the structural migration leaves
+    // alone (e.g. a hand-edited inline table).
+    migrate_legacy(&mut config, text);
+    config
 }
 
 /// Outcome of an explicit [`migrate_config_file`] run, surfaced by
@@ -567,9 +607,13 @@ fn backfill_new_quota_panels(doc: &mut DocumentMut, schema: &Value) -> bool {
     // cannot be back-filled — and stamping the marker anyway would retire the
     // upgrade without having run it.
     if panels_out_of_reach(doc) {
-        return false;
+        // This upgrade may still safely add an unrelated leaf to a standard
+        // `[general]` table. Do not stamp the version though: the quota upgrade
+        // has not run and must remain eligible for a future safe migration.
+        return backfill_auto_update(doc, schema);
     }
 
+    let mut changed = false;
     if let Some(panels) = doc
         .get_mut("usage")
         .and_then(Item::as_table_mut)
@@ -593,11 +637,36 @@ fn backfill_new_quota_panels(doc: &mut DocumentMut, schema: &Value) -> bool {
             .collect();
         for name in missing {
             panels.push(name);
+            changed = true;
         }
     }
 
-    stamp_config_version(doc, schema);
-    true
+    changed |= stamp_config_version(doc, schema);
+    changed |= backfill_auto_update(doc, schema);
+    changed
+}
+
+/// Adds the startup update preference to a legacy standard `[general]` table.
+///
+/// Inline tables are deliberately left untouched: changing their shape here
+/// risks discarding hand-edited formatting or sibling keys. Serde supplies the
+/// same `true` default when such a table is read.
+fn backfill_auto_update(doc: &mut DocumentMut, schema: &Value) -> bool {
+    let Some(general) = doc.get_mut("general").and_then(Item::as_table_mut) else {
+        return false;
+    };
+    if !general.contains_key("auto_update") {
+        general.insert("auto_update", value(true));
+        apply_comment(
+            general,
+            "auto_update",
+            "",
+            schema,
+            &["general", "auto_update"],
+        );
+        return true;
+    }
+    false
 }
 
 /// Whether the effective panel list sits inside an inline table.
@@ -637,7 +706,8 @@ fn panels_out_of_reach(doc: &DocumentMut) -> bool {
 
 /// Writes `[general].version` (creating the table when a hand-written file has
 /// no `[general]` section at all).
-fn stamp_config_version(doc: &mut DocumentMut, schema: &Value) {
+fn stamp_config_version(doc: &mut DocumentMut, schema: &Value) -> bool {
+    let mut changed = false;
     if doc.get("general").is_none() {
         let mut table = Table::new();
         table.set_implicit(false);
@@ -647,15 +717,21 @@ fn stamp_config_version(doc: &mut DocumentMut, schema: &Value) {
                 .set_prefix(format!("\n{}", comment_block(&desc)));
         }
         doc.insert("general", Item::Table(table));
+        changed = true;
     }
     let Some(general) = doc.get_mut("general").and_then(Item::as_table_mut) else {
-        return;
+        return changed;
     };
     let had_key = general.contains_key("version");
+    let version_is_current = general
+        .get("version")
+        .and_then(Item::as_integer)
+        .is_some_and(|version| version == i64::from(CONFIG_VERSION));
     general.insert("version", value(i64::from(CONFIG_VERSION)));
     if !had_key {
         apply_comment(general, "version", "", schema, &["general", "version"]);
     }
+    changed || !version_is_current
 }
 
 /// Whether the document already carries a `#:schema` directive line.
@@ -1167,7 +1243,7 @@ mod tests {
     fn migrate_document_adds_only_the_schema_directive_when_keys_are_current() {
         // Current key names, nested quota and version marker, but missing the
         // `#:schema` directive.
-        let text = "[general]\nversion = 2\n\n[usage]\nrefresh_interval = 10\n\n[usage.quota]\npanels = [\"claude\"]\n";
+        let text = "[general]\nversion = 3\n\n[usage]\nrefresh_interval = 10\n\n[usage.quota]\npanels = [\"claude\"]\n";
         let migrated = migrate_text(text).unwrap().expect("adds #:schema");
         assert!(migrated.starts_with("#:schema "));
         assert!(migrated.contains("refresh_interval = 10"));
@@ -1193,6 +1269,15 @@ mod tests {
         assert!(migrated.contains("quota_panels"));
         // Still idempotent for the untouched inline table.
         assert!(migrate_text(&migrated).unwrap().is_none());
+    }
+
+    #[test]
+    fn migrate_document_leaves_an_inline_general_table_unmodified() {
+        let text = "#:schema x\ngeneral = { default_time_range = \"weekly\", version = 2 }\n";
+        assert!(migrate_text(text).unwrap().is_none());
+        let cfg = parse_config_text(text);
+        assert_eq!(cfg.general.default_time_range, TimeRange::Weekly);
+        assert!(cfg.general.auto_update);
     }
 
     #[test]
@@ -1284,7 +1369,7 @@ mod tests {
             .unwrap()
             .expect("version 1 file upgrades");
         assert!(migrated.contains("panels = [\"claude\", \"codex\", \"grok\"]"));
-        assert!(migrated.contains("version = 2"));
+        assert!(migrated.contains("version = 3"));
         assert!(migrate_text(&migrated).unwrap().is_none());
 
         // The user removes it again: the marker keeps the upgrade from re-running.
@@ -1347,7 +1432,7 @@ mod tests {
                 .unwrap()
                 .expect("an empty file is stamped");
             assert!(migrated.starts_with("#:schema "));
-            assert!(migrated.contains("version = 2"));
+            assert!(migrated.contains("version = 3"));
             assert!(
                 migrate_text(&migrated).unwrap().is_none(),
                 "one pass must be enough"

--- a/src/core/src/update/github.rs
+++ b/src/core/src/update/github.rs
@@ -6,6 +6,7 @@
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
 
 /// GitHub REST endpoint for the repository's latest release.
 const GITHUB_API_RELEASES_URL: &str =
@@ -14,6 +15,9 @@ const GITHUB_API_RELEASES_URL: &str =
 // Pinned to the product name (not the crate name, which is `vct-core`) so the
 // GitHub API sees a stable identifier across the workspace rename.
 const USER_AGENT: &str = concat!("vibe_coding_tracker/", env!("CARGO_PKG_VERSION"));
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
+const RELEASE_TIMEOUT: Duration = Duration::from_secs(5);
+const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// A GitHub release, deserialized from the Releases API.
 #[derive(Debug, Deserialize, Serialize)]
@@ -62,8 +66,14 @@ pub fn fetch_latest_release() -> Result<GitHubRelease> {
 /// if the server responds with a non-success status, or if the response body is
 /// not the expected release JSON.
 pub fn fetch_latest_release_from(url: &str) -> Result<GitHubRelease> {
+    fetch_latest_release_from_with_timeout(url, RELEASE_TIMEOUT)
+}
+
+fn fetch_latest_release_from_with_timeout(url: &str, timeout: Duration) -> Result<GitHubRelease> {
     let client = reqwest::blocking::Client::builder()
         .user_agent(USER_AGENT)
+        .connect_timeout(CONNECT_TIMEOUT.min(timeout))
+        .timeout(timeout)
         .build()
         .context("Failed to create HTTP client")?;
 
@@ -86,16 +96,22 @@ pub fn fetch_latest_release_from(url: &str) -> Result<GitHubRelease> {
 /// Downloads the file at `url` and writes it to `dest`.
 ///
 /// Streams the response body straight to the destination file rather than
-/// buffering it in memory.
+/// buffering it in memory, and returns the number of bytes written.
 ///
 /// # Errors
 ///
 /// Returns an error if the HTTP client cannot be built, if the request fails,
 /// if the server responds with a non-success status, if `dest` cannot be
 /// created, or if writing the body to disk fails.
-pub fn download_file(url: &str, dest: &std::path::Path) -> Result<()> {
+pub fn download_file(url: &str, dest: &std::path::Path) -> Result<u64> {
+    download_file_with_timeout(url, dest, DOWNLOAD_TIMEOUT)
+}
+
+fn download_file_with_timeout(url: &str, dest: &std::path::Path, timeout: Duration) -> Result<u64> {
     let client = reqwest::blocking::Client::builder()
         .user_agent(USER_AGENT)
+        .connect_timeout(CONNECT_TIMEOUT.min(timeout))
+        .timeout(timeout)
         .build()
         .context("Failed to create HTTP client")?;
 
@@ -108,11 +124,11 @@ pub fn download_file(url: &str, dest: &std::path::Path) -> Result<()> {
     let mut file = std::fs::File::create(dest)
         .context(format!("Failed to create file: {}", dest.display()))?;
 
-    response
+    let bytes = response
         .copy_to(&mut file)
         .context("Failed to write downloaded content to file")?;
 
-    Ok(())
+    Ok(bytes)
 }
 
 #[cfg(test)]
@@ -169,7 +185,9 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let dest = dir.path().join("asset.bin");
 
-        download_file(&server.url("/asset.bin"), &dest).expect("download should succeed");
+        let bytes =
+            download_file(&server.url("/asset.bin"), &dest).expect("download should succeed");
+        assert_eq!(bytes, 15);
         assert_eq!(std::fs::read_to_string(&dest).unwrap(), "binary-contents");
     }
 
@@ -183,5 +201,47 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let dest = dir.path().join("missing.bin");
         assert!(download_file(&server.url("/missing.bin"), &dest).is_err());
+    }
+
+    #[test]
+    fn release_fetch_has_a_bounded_timeout() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET).path("/slow");
+            then.status(200)
+                .delay(Duration::from_millis(200))
+                .json_body(json!({
+                    "tag_name": "v1.2.3",
+                    "name": "Release 1.2.3",
+                    "body": null,
+                    "assets": []
+                }));
+        });
+
+        let error =
+            fetch_latest_release_from_with_timeout(&server.url("/slow"), Duration::from_millis(20))
+                .expect_err("slow response must time out");
+        assert!(error.to_string().contains("Failed to fetch release"));
+    }
+
+    #[test]
+    fn asset_download_has_a_bounded_timeout() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET).path("/slow-asset");
+            then.status(200)
+                .delay(Duration::from_millis(200))
+                .body("binary-contents");
+        });
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("asset.bin");
+
+        let error = download_file_with_timeout(
+            &server.url("/slow-asset"),
+            &dest,
+            Duration::from_millis(20),
+        )
+        .expect_err("slow download must time out");
+        assert!(error.to_string().contains("Failed to download file"));
     }
 }

--- a/src/core/src/update/lock.rs
+++ b/src/core/src/update/lock.rs
@@ -1,0 +1,87 @@
+//! Non-blocking cross-process lock for update work.
+
+use anyhow::{Context, Result};
+use std::fs::{File, OpenOptions, TryLockError};
+use std::path::{Path, PathBuf};
+
+const LOCK_FILE: &str = ".vct-update.lock";
+
+/// An acquired update lock. Dropping it releases the lock for another process.
+pub(super) struct UpdateLock {
+    _file: File,
+}
+
+impl UpdateLock {
+    /// Tries to acquire the update lock without waiting.
+    pub(super) fn try_acquire(lock_dir: &Path) -> Result<Option<Self>> {
+        let path = update_lock_path(lock_dir);
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&path)
+            .with_context(|| format!("Failed to open update lock: {}", path.display()))?;
+        match file.try_lock() {
+            Ok(()) => Ok(Some(Self { _file: file })),
+            Err(TryLockError::WouldBlock) => Ok(None),
+            Err(TryLockError::Error(error)) => Err(error).context("Failed to claim update lock"),
+        }
+    }
+}
+
+pub(super) fn update_lock_path(lock_dir: &Path) -> PathBuf {
+    lock_dir.join(LOCK_FILE)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_one_process_claims_the_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = UpdateLock::try_acquire(dir.path())
+            .unwrap()
+            .expect("first lock");
+        assert!(UpdateLock::try_acquire(dir.path()).unwrap().is_none());
+        drop(first);
+        assert!(UpdateLock::try_acquire(dir.path()).unwrap().is_some());
+    }
+
+    #[test]
+    fn concurrent_claims_have_one_winner() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::{Arc, Barrier};
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = Arc::new(dir.path().to_path_buf());
+        let start = Arc::new(Barrier::new(3));
+        let attempted = Arc::new(Barrier::new(3));
+        let winners = Arc::new(AtomicUsize::new(0));
+        let mut threads = Vec::new();
+
+        for _ in 0..2 {
+            let path = Arc::clone(&path);
+            let start = Arc::clone(&start);
+            let attempted = Arc::clone(&attempted);
+            let winners = Arc::clone(&winners);
+            threads.push(std::thread::spawn(move || {
+                start.wait();
+                let lock = UpdateLock::try_acquire(&path).unwrap();
+                if lock.is_some() {
+                    winners.fetch_add(1, Ordering::SeqCst);
+                }
+                attempted.wait();
+                drop(lock);
+            }));
+        }
+
+        start.wait();
+        attempted.wait();
+        for thread in threads {
+            thread.join().unwrap();
+        }
+        assert_eq!(winners.load(Ordering::SeqCst), 1);
+    }
+}

--- a/src/core/src/update/mod.rs
+++ b/src/core/src/update/mod.rs
@@ -8,21 +8,55 @@
 //! subcommand calls.
 //!
 //! Submodules: `github` (Releases API + download), `archive` (extraction with
-//! path-traversal guards), and `platform` (asset-name derivation and the
-//! OS-specific binary swap).
+//! path-traversal guards), `lock` (cross-process serialization), `ownership`
+//! (official-installer marker), `platform` (asset-name derivation and the
+//! OS-specific binary swap), and `version_cache` (daily check cadence).
 
 mod archive;
 mod github;
+mod lock;
+mod ownership;
 mod platform;
 mod version_cache;
 
 use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
 use semver::Version;
 use std::env;
 use std::fs;
+use std::io::{Read, Seek};
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
 
 // Re-export public types for backward compatibility
 pub use github::{GitHubAsset, GitHubRelease};
+
+/// Result of the best-effort startup update hook.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AutoUpdateOutcome {
+    /// The hook was disabled, ineligible, already claimed, or not due today.
+    Skipped,
+    /// A daily check completed and the running version is current.
+    UpToDate,
+    /// The executable was replaced. Unix callers should re-exec their command.
+    Updated,
+    /// Windows staged a replacement that will run after this process exits.
+    Deferred,
+    /// A best-effort check or install failed; the caller should continue.
+    Failed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InstallationDisposition {
+    #[cfg(unix)]
+    Applied,
+    #[cfg(windows)]
+    Deferred,
+}
+
+const CANDIDATE_VALIDATION_TIMEOUT: Duration = Duration::from_secs(5);
+const MAX_VERSION_OUTPUT_BYTES: u64 = 256;
 
 /// Strips git metadata from a `BUILD_VERSION` string, leaving the base semver.
 ///
@@ -64,6 +98,14 @@ fn get_current_version() -> Result<(String, Version)> {
     Ok((full_version.to_string(), semver_version))
 }
 
+fn parse_latest_version(release: &GitHubRelease) -> Result<Version> {
+    let latest_version_str = release.tag_name.trim_start_matches('v');
+    Version::parse(latest_version_str).context(format!(
+        "Failed to parse latest version: {}",
+        latest_version_str
+    ))
+}
+
 /// Fetches the latest release and compares it against the running version.
 ///
 /// Returns `Some((current_display, current, latest, release))` when the latest
@@ -82,15 +124,10 @@ fn get_version_comparison() -> Result<Option<(String, Version, Version, GitHubRe
 
     let (current_version_display, current_version) = get_current_version()?;
 
-    // Remove 'v' prefix if present and parse as semver
-    let latest_version_str = release.tag_name.trim_start_matches('v');
-    let latest_version = Version::parse(latest_version_str).context(format!(
-        "Failed to parse latest version: {}",
-        latest_version_str
-    ))?;
+    let latest_version = parse_latest_version(&release)?;
 
-    // Record the check for the future auto-update prompt, regardless of whether
-    // a newer version exists. Best-effort: a write failure never blocks update.
+    // Record the check regardless of whether a newer version exists.
+    // Best-effort: a write failure never blocks an explicit update.
     let _ = version_cache::record_version_check(&latest_version.to_string());
 
     if latest_version <= current_version {
@@ -136,26 +173,22 @@ pub fn check_update() -> Result<Option<String>> {
 
 /// Downloads, extracts, and installs a specific `release`, no version check.
 ///
-/// Selects the asset matching the current platform, downloads it to the temp
-/// dir, extracts it into a freshly recreated `vct_update/` staging directory,
-/// swaps the new binary in over the running executable (Unix rename or the
-/// Windows deferred-batch strategy), and then best-effort cleans up the
-/// downloaded archive and staging dir. `current_version` is the display string
-/// used only in the success message; `latest_version` is what the binary will
-/// become.
+/// Selects the asset matching the current platform, downloads it into a unique
+/// temporary directory, checks its exact size, extracts it, and executes its
+/// bounded `--version` probe before swapping it over the running executable.
+/// Unix uses an atomic rename; Windows stages a post-exit helper.
 ///
 /// # Errors
 ///
 /// Returns an error if no release asset matches this `(os, arch)`, if the
-/// current executable path cannot be resolved, if the staging directory cannot
-/// be cleaned or created, if the download fails, if the archive format is
-/// unsupported or extraction fails, or if replacing the binary fails. Cleanup
-/// of the temporary files is best-effort and never surfaced as an error.
-fn perform_installation(
-    current_version: &str,
+/// staging directory cannot be created, if the download size is wrong, if the
+/// archive is invalid, if the candidate cannot report the expected version
+/// within the timeout, or if replacing the binary fails.
+fn perform_installation_at(
+    current_exe: &Path,
     latest_version: &Version,
     release: &GitHubRelease,
-) -> Result<()> {
+) -> Result<InstallationDisposition> {
     // Find the asset for current platform
     let asset_pattern = platform::get_asset_pattern(&latest_version.to_string())?;
     let asset = release
@@ -168,23 +201,24 @@ fn perform_installation(
             std::env::consts::ARCH
         ))?;
 
-    // Get current executable path
-    let current_exe =
-        env::current_exe().context("Update failed: Cannot locate current executable")?;
+    let staging = tempfile::Builder::new()
+        .prefix("vct-update-")
+        .tempdir()
+        .context("Update failed: Cannot create temporary directory")?;
+    let archive_path = staging.path().join(&asset.name);
 
-    // Download to temporary location
-    let temp_dir = env::temp_dir();
-    let archive_path = temp_dir.join(&asset.name);
-
-    github::download_file(&asset.browser_download_url, &archive_path)
+    let downloaded = github::download_file(&asset.browser_download_url, &archive_path)
         .context("Update failed: Download error")?;
+    if downloaded != asset.size {
+        anyhow::bail!(
+            "Update failed: Downloaded asset size mismatch (expected {}, got {})",
+            asset.size,
+            downloaded
+        );
+    }
 
     // Extract the archive
-    let extract_dir = temp_dir.join("vct_update");
-    if extract_dir.exists() {
-        fs::remove_dir_all(&extract_dir)
-            .context("Update failed: Cannot clean temporary directory")?;
-    }
+    let extract_dir = staging.path().join("extracted");
     fs::create_dir_all(&extract_dir).context("Update failed: Cannot create temporary directory")?;
 
     let new_binary = if asset.name.ends_with(".tar.gz") {
@@ -199,23 +233,127 @@ fn perform_installation(
 
     // Perform platform-specific update
     #[cfg(unix)]
-    platform::perform_update_unix(&current_exe, &new_binary)
-        .context("Update failed: Cannot replace binary")?;
+    {
+        let staged = platform::stage_update_unix(current_exe, &new_binary)
+            .context("Update failed: Cannot stage binary replacement")?;
+        validate_candidate_binary(&staged, latest_version)
+            .context("Update failed: Candidate binary validation failed")?;
+        platform::commit_update_unix(current_exe, staged)
+            .context("Update failed: Cannot replace binary")?;
+        Ok(InstallationDisposition::Applied)
+    }
 
     #[cfg(windows)]
-    platform::perform_update_windows(&current_exe, &new_binary)
-        .context("Update failed: Cannot replace binary")?;
+    {
+        validate_candidate_binary(&new_binary, latest_version)
+            .context("Update failed: Candidate binary validation failed")?;
+        let lock_dir = current_exe
+            .parent()
+            .context("Update failed: Current executable has no parent directory")?;
+        platform::perform_update_windows(
+            current_exe,
+            &new_binary,
+            &latest_version.to_string(),
+            &lock::update_lock_path(lock_dir),
+        )
+        .context("Update failed: Cannot stage binary replacement")?;
+        Ok(InstallationDisposition::Deferred)
+    }
+}
 
-    // Clean up
-    let _ = fs::remove_file(&archive_path);
-    let _ = fs::remove_dir_all(&extract_dir);
+fn validate_candidate_binary(candidate: &Path, expected_version: &Version) -> Result<()> {
+    validate_candidate_binary_with_timeout(
+        candidate,
+        expected_version,
+        CANDIDATE_VALIDATION_TIMEOUT,
+    )
+}
 
-    // Display success message
-    println!(
-        "Upgraded from v{} to v{}",
-        extract_semver_version(current_version),
-        latest_version
-    );
+fn validate_candidate_binary_with_timeout(
+    candidate: &Path,
+    expected_version: &Version,
+    timeout: Duration,
+) -> Result<()> {
+    let mut stdout =
+        tempfile::tempfile().context("Failed to create candidate validation output")?;
+    let child_stdout = stdout
+        .try_clone()
+        .context("Failed to prepare candidate validation output")?;
+    let mut command = Command::new(candidate);
+    command
+        .arg("--version")
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(child_stdout))
+        .stderr(Stdio::null());
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        command.creation_flags(CREATE_NO_WINDOW);
+    }
+    let mut child = command
+        .spawn()
+        .context("Failed to execute candidate binary")?;
+    let deadline = Instant::now() + timeout;
+    let status = loop {
+        if let Some(status) = child
+            .try_wait()
+            .context("Failed to wait for candidate binary")?
+        {
+            break status;
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            anyhow::bail!("Candidate binary version check timed out");
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    };
+    if !status.success() {
+        anyhow::bail!("Candidate binary exited with {status}");
+    }
+
+    stdout
+        .rewind()
+        .context("Failed to read candidate version output")?;
+    let mut reported = String::new();
+    (&mut stdout)
+        .take(MAX_VERSION_OUTPUT_BYTES + 1)
+        .read_to_string(&mut reported)
+        .context("Candidate version output was not valid UTF-8")?;
+    if reported.len() as u64 > MAX_VERSION_OUTPUT_BYTES {
+        anyhow::bail!("Candidate version output was unexpectedly large");
+    }
+    let reported = reported.trim().trim_start_matches('v');
+    let reported = Version::parse(extract_semver_version(reported))
+        .context("Candidate reported an invalid version")?;
+    if reported != *expected_version {
+        anyhow::bail!("Candidate reported version {reported}, expected {expected_version}");
+    }
+
+    Ok(())
+}
+
+fn print_installation_success(
+    current_version: &str,
+    latest_version: &Version,
+    release: &GitHubRelease,
+    disposition: InstallationDisposition,
+) {
+    match disposition {
+        #[cfg(unix)]
+        InstallationDisposition::Applied => println!(
+            "Upgraded from v{} to v{}",
+            extract_semver_version(current_version),
+            latest_version
+        ),
+        #[cfg(windows)]
+        InstallationDisposition::Deferred => println!(
+            "Staged upgrade from v{} to v{}; it will be applied after this command exits",
+            extract_semver_version(current_version),
+            latest_version
+        ),
+    }
     println!(
         "https://github.com/Mai0313/VibeCodingTracker/releases/tag/{}",
         release.tag_name
@@ -223,7 +361,19 @@ fn perform_installation(
     println!(
         "If you like this tool, please star us on GitHub: https://github.com/Mai0313/VibeCodingTracker"
     );
+}
 
+fn install_and_report(
+    current_version: &str,
+    latest_version: &Version,
+    release: &GitHubRelease,
+) -> Result<()> {
+    let current_exe = env::current_exe()
+        .context("Update failed: Cannot locate current executable")?
+        .canonicalize()
+        .context("Update failed: Cannot resolve current executable")?;
+    let disposition = perform_installation_at(&current_exe, latest_version, release)?;
+    print_installation_success(current_version, latest_version, release, disposition);
     Ok(())
 }
 
@@ -236,15 +386,20 @@ fn perform_installation(
 /// # Errors
 ///
 /// Returns an error if the version comparison fails (GitHub fetch or version
-/// parse) or if the subsequent install fails (see `perform_installation`).
+/// parse) or if the subsequent install fails (see `perform_installation_at`).
 pub fn perform_update() -> Result<()> {
+    let _lock = acquire_update_lock()?;
+    perform_update_unlocked()
+}
+
+fn perform_update_unlocked() -> Result<()> {
     // Get version comparison
     let Some((current_version, _, latest_version, release)) = get_version_comparison()? else {
         // Already on latest version
         return Ok(());
     };
 
-    perform_installation(&current_version, &latest_version, &release)
+    install_and_report(&current_version, &latest_version, &release)
 }
 
 /// Installs the latest release unconditionally, skipping the freshness check.
@@ -256,23 +411,129 @@ pub fn perform_update() -> Result<()> {
 ///
 /// Returns an error if the GitHub release fetch fails, if the current or
 /// latest version cannot be parsed, or if the install fails (see
-/// `perform_installation` — notably when no asset matches this platform).
+/// `perform_installation_at`, notably when no asset matches this platform).
 pub fn perform_force_update() -> Result<()> {
+    let _lock = acquire_update_lock()?;
+    perform_force_update_unlocked()
+}
+
+fn perform_force_update_unlocked() -> Result<()> {
     let release =
         github::fetch_latest_release().context("Failed to fetch latest release information")?;
 
     let (current_version_display, _) = get_current_version()?;
 
-    // Remove 'v' prefix if present and parse as semver
-    let latest_version_str = release.tag_name.trim_start_matches('v');
-    let latest_version = Version::parse(latest_version_str).context(format!(
-        "Failed to parse latest version: {}",
-        latest_version_str
-    ))?;
+    let latest_version = parse_latest_version(&release)?;
 
     let _ = version_cache::record_version_check(&latest_version.to_string());
 
-    perform_installation(&current_version_display, &latest_version, &release)
+    install_and_report(&current_version_display, &latest_version, &release)
+}
+
+fn acquire_update_lock() -> Result<lock::UpdateLock> {
+    let current_exe = env::current_exe()
+        .context("Update failed: Cannot locate current executable")?
+        .canonicalize()
+        .context("Update failed: Cannot resolve current executable")?;
+    acquire_update_lock_at(&current_exe)
+}
+
+fn acquire_update_lock_at(current_exe: &Path) -> Result<lock::UpdateLock> {
+    let lock_dir = current_exe
+        .parent()
+        .context("Update failed: Current executable has no parent directory")?;
+    lock::UpdateLock::try_acquire(lock_dir)?
+        .context("Another vct update is already running; try again after it exits")
+}
+
+/// Checks for and silently installs a newer release when startup policy allows.
+///
+/// This is a best-effort hook for ordinary commands. It performs no work when
+/// disabled, offline, already checked on the current UTC date, or when the
+/// executable lacks the official release installer's ownership marker. Every
+/// error is logged and converted to [`AutoUpdateOutcome::Failed`] so it can
+/// never block the requested command.
+pub fn maybe_auto_update(enabled: bool) -> AutoUpdateOutcome {
+    let offline = crate::utils::network_disabled();
+    let Ok(current_exe) = env::current_exe() else {
+        return AutoUpdateOutcome::Failed;
+    };
+    let managed = ownership::is_release_managed(&current_exe);
+    if !auto_update_allowed(enabled, offline, managed) {
+        return AutoUpdateOutcome::Skipped;
+    }
+
+    let result = (|| -> Result<AutoUpdateOutcome> {
+        let current_exe = current_exe
+            .canonicalize()
+            .context("Failed to resolve release-managed executable")?;
+        let lock_dir = current_exe
+            .parent()
+            .context("Release-managed executable has no parent directory")?;
+        let cache_dir = crate::utils::get_cache_dir()?;
+        let (_, current_version) = get_current_version()?;
+        auto_update_with(
+            &cache_dir,
+            lock_dir,
+            &current_version,
+            Utc::now(),
+            github::fetch_latest_release,
+            |release, latest| perform_installation_at(&current_exe, latest, release),
+        )
+    })();
+
+    match result {
+        Ok(outcome) => outcome,
+        Err(error) => {
+            log::warn!("startup auto-update failed: {error:#}");
+            AutoUpdateOutcome::Failed
+        }
+    }
+}
+
+fn auto_update_allowed(enabled: bool, offline: bool, release_managed: bool) -> bool {
+    enabled && !offline && release_managed
+}
+
+fn auto_update_with(
+    cache_dir: &Path,
+    lock_dir: &Path,
+    current_version: &Version,
+    now: DateTime<Utc>,
+    fetch_release: impl FnOnce() -> Result<GitHubRelease>,
+    install_release: impl FnOnce(&GitHubRelease, &Version) -> Result<InstallationDisposition>,
+) -> Result<AutoUpdateOutcome> {
+    let Some(_lock) = lock::UpdateLock::try_acquire(lock_dir)? else {
+        log::warn!("startup auto-update skipped because another update is running");
+        return Ok(AutoUpdateOutcome::Skipped);
+    };
+
+    let record = version_cache::read_self_version_in(cache_dir);
+    if !version_cache::check_is_due(&record, now) {
+        return Ok(AutoUpdateOutcome::Skipped);
+    }
+
+    // Claim today's attempt before touching the network. If GitHub is down, the
+    // failed request is still throttled until the next UTC date.
+    version_cache::record_check_attempt_in(cache_dir, now)?;
+    let release = fetch_release().context("Failed to fetch latest release information")?;
+    let latest_version = parse_latest_version(&release)?;
+    if let Err(error) =
+        version_cache::record_version_result_in(cache_dir, &latest_version.to_string(), now)
+    {
+        log::warn!("failed to record startup update result: {error:#}");
+    }
+
+    if latest_version <= *current_version {
+        return Ok(AutoUpdateOutcome::UpToDate);
+    }
+
+    match install_release(&release, &latest_version)? {
+        #[cfg(unix)]
+        InstallationDisposition::Applied => Ok(AutoUpdateOutcome::Updated),
+        #[cfg(windows)]
+        InstallationDisposition::Deferred => Ok(AutoUpdateOutcome::Deferred),
+    }
 }
 
 /// Runs the `vct update` flow, optionally prompting for confirmation.
@@ -295,7 +556,15 @@ pub fn update_interactive(force: bool) -> Result<()> {
         perform_force_update()
     } else {
         // Normal update: check version and prompt for confirmation
-        if check_update()?.is_some() {
+        if crate::utils::network_disabled() {
+            return Ok(());
+        }
+        if let Some((current_version, _, latest_version, _release)) = get_version_comparison()? {
+            println!(
+                "Update available: v{} → v{}",
+                extract_semver_version(&current_version),
+                latest_version
+            );
             print!("Continue? (y/N): ");
             std::io::Write::flush(&mut std::io::stdout())?;
 
@@ -322,6 +591,61 @@ pub use platform::get_asset_pattern;
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
+    use flate2::{Compression, write::GzEncoder};
+    #[cfg(unix)]
+    use httpmock::prelude::*;
+    use std::cell::Cell;
+
+    fn release(tag: &str) -> GitHubRelease {
+        GitHubRelease {
+            tag_name: tag.into(),
+            name: tag.into(),
+            body: None,
+            assets: Vec::new(),
+        }
+    }
+
+    #[cfg(unix)]
+    fn release_archive(contents: &[u8]) -> Vec<u8> {
+        let encoder = GzEncoder::new(Vec::new(), Compression::default());
+        let mut archive = tar::Builder::new(encoder);
+        let mut header = tar::Header::new_gnu();
+        header.set_size(contents.len() as u64);
+        header.set_mode(0o755);
+        header.set_cksum();
+        archive
+            .append_data(&mut header, "vibe_coding_tracker", contents)
+            .unwrap();
+        archive.into_inner().unwrap().finish().unwrap()
+    }
+
+    #[cfg(unix)]
+    fn release_binary(version: &str) -> Vec<u8> {
+        format!("#!/bin/sh\nprintf '%s\\n' '{version}'\n").into_bytes()
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn candidate_validation_has_a_bounded_timeout() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let candidate = dir.path().join("candidate");
+        fs::write(&candidate, b"#!/bin/sh\nwhile :; do :; done\n").unwrap();
+        fs::set_permissions(&candidate, fs::Permissions::from_mode(0o755)).unwrap();
+        let started = Instant::now();
+
+        let error = validate_candidate_binary_with_timeout(
+            &candidate,
+            &Version::new(1, 1, 0),
+            Duration::from_millis(20),
+        )
+        .expect_err("a hanging candidate must be rejected");
+
+        assert!(error.to_string().contains("timed out"));
+        assert!(started.elapsed() < Duration::from_secs(1));
+    }
 
     #[test]
     fn test_extract_semver_version_clean() {
@@ -442,5 +766,293 @@ mod tests {
         // Test with patch version zero
         assert_eq!(extract_semver_version("1.5.0"), "1.5.0");
         assert_eq!(extract_semver_version("2.0.0-rc1"), "2.0.0");
+    }
+
+    #[test]
+    fn startup_policy_requires_all_three_guards() {
+        assert!(auto_update_allowed(true, false, true));
+        assert!(!auto_update_allowed(false, false, true));
+        assert!(!auto_update_allowed(true, true, true));
+        assert!(!auto_update_allowed(true, false, false));
+    }
+
+    #[test]
+    fn current_day_cache_skips_fetch_and_install() {
+        let dir = tempfile::tempdir().unwrap();
+        let now = "2026-07-30T12:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        version_cache::record_check_attempt_in(dir.path(), now).unwrap();
+
+        let outcome = auto_update_with(
+            dir.path(),
+            dir.path(),
+            &Version::new(1, 0, 0),
+            now,
+            || panic!("fetch must be skipped"),
+            |_, _| panic!("install must be skipped"),
+        )
+        .unwrap();
+
+        assert_eq!(outcome, AutoUpdateOutcome::Skipped);
+    }
+
+    #[test]
+    fn failed_fetch_is_throttled_for_the_rest_of_the_day() {
+        let dir = tempfile::tempdir().unwrap();
+        let now = "2026-07-30T12:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let fetches = Cell::new(0);
+
+        let first = auto_update_with(
+            dir.path(),
+            dir.path(),
+            &Version::new(1, 0, 0),
+            now,
+            || {
+                fetches.set(fetches.get() + 1);
+                anyhow::bail!("offline")
+            },
+            |_, _| panic!("install must be skipped"),
+        );
+        assert!(first.is_err());
+
+        let second = auto_update_with(
+            dir.path(),
+            dir.path(),
+            &Version::new(1, 0, 0),
+            now,
+            || {
+                fetches.set(fetches.get() + 1);
+                Ok(release("v2.0.0"))
+            },
+            |_, _| panic!("install must be skipped"),
+        )
+        .unwrap();
+        assert_eq!(second, AutoUpdateOutcome::Skipped);
+        assert_eq!(fetches.get(), 1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn newer_release_installs_once_and_records_the_version() {
+        let dir = tempfile::tempdir().unwrap();
+        let now = "2026-07-30T12:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let installs = Cell::new(0);
+
+        let outcome = auto_update_with(
+            dir.path(),
+            dir.path(),
+            &Version::new(1, 0, 0),
+            now,
+            || Ok(release("v1.1.0")),
+            |_, latest| {
+                installs.set(installs.get() + 1);
+                assert_eq!(latest, &Version::new(1, 1, 0));
+                Ok(InstallationDisposition::Applied)
+            },
+        )
+        .unwrap();
+
+        assert_eq!(outcome, AutoUpdateOutcome::Updated);
+        assert_eq!(installs.get(), 1);
+        assert_eq!(
+            version_cache::read_self_version_in(dir.path())
+                .latest_version
+                .as_deref(),
+            Some("1.1.0")
+        );
+
+        let second = auto_update_with(
+            dir.path(),
+            dir.path(),
+            &Version::new(1, 0, 0),
+            now,
+            || panic!("the same UTC date must not fetch twice"),
+            |_, _| panic!("the same UTC date must not install twice"),
+        )
+        .unwrap();
+        assert_eq!(second, AutoUpdateOutcome::Skipped);
+        assert_eq!(installs.get(), 1);
+    }
+
+    #[test]
+    fn current_release_never_calls_installer() {
+        let dir = tempfile::tempdir().unwrap();
+        let now = "2026-07-30T12:00:00Z".parse::<DateTime<Utc>>().unwrap();
+
+        let outcome = auto_update_with(
+            dir.path(),
+            dir.path(),
+            &Version::new(1, 1, 0),
+            now,
+            || Ok(release("v1.1.0")),
+            |_, _| panic!("current release must not install"),
+        )
+        .unwrap();
+
+        assert_eq!(outcome, AutoUpdateOutcome::UpToDate);
+    }
+
+    #[test]
+    fn lock_contention_skips_without_fetching() {
+        let dir = tempfile::tempdir().unwrap();
+        let _lock = lock::UpdateLock::try_acquire(dir.path())
+            .unwrap()
+            .expect("lock");
+        let now = "2026-07-30T12:00:00Z".parse::<DateTime<Utc>>().unwrap();
+
+        let outcome = auto_update_with(
+            dir.path(),
+            dir.path(),
+            &Version::new(1, 0, 0),
+            now,
+            || panic!("contended process must not fetch"),
+            |_, _| panic!("contended process must not install"),
+        )
+        .unwrap();
+
+        assert_eq!(outcome, AutoUpdateOutcome::Skipped);
+    }
+
+    #[test]
+    fn manual_update_lock_lives_beside_the_executable() {
+        let install_dir = tempfile::tempdir().unwrap();
+        let executable = install_dir.path().join("vibe_coding_tracker");
+        fs::write(&executable, b"binary").unwrap();
+
+        let first = acquire_update_lock_at(&executable).unwrap();
+        assert!(install_dir.path().join(".vct-update.lock").exists());
+        assert!(acquire_update_lock_at(&executable).is_err());
+        drop(first);
+        assert!(acquire_update_lock_at(&executable).is_ok());
+    }
+
+    #[test]
+    fn invalid_cache_path_fails_before_fetch() {
+        let root = tempfile::tempdir().unwrap();
+        let missing = root.path().join("missing");
+        fs::write(&missing, b"not a directory").unwrap();
+        let now = "2026-07-30T12:00:00Z".parse::<DateTime<Utc>>().unwrap();
+
+        let result = auto_update_with(
+            &missing,
+            root.path(),
+            &Version::new(1, 0, 0),
+            now,
+            || panic!("failed claim must not fetch"),
+            |_, _| panic!("failed claim must not install"),
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn installation_downloads_and_atomically_replaces_the_target() {
+        let candidate = release_binary("1.1.0");
+        let archive = release_archive(&candidate);
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET).path("/asset");
+            then.status(200).body(archive.clone());
+        });
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("vibe_coding_tracker");
+        fs::write(&target, b"old binary").unwrap();
+        let latest = Version::new(1, 1, 0);
+        let release = GitHubRelease {
+            tag_name: "v1.1.0".into(),
+            name: "v1.1.0".into(),
+            body: None,
+            assets: vec![GitHubAsset {
+                name: platform::get_asset_pattern("1.1.0").unwrap(),
+                browser_download_url: server.url("/asset"),
+                size: archive.len() as u64,
+            }],
+        };
+
+        let disposition = perform_installation_at(&target, &latest, &release).unwrap();
+
+        assert_eq!(disposition, InstallationDisposition::Applied);
+        assert_eq!(fs::read(&target).unwrap(), candidate);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn invalid_candidate_never_replaces_the_target() {
+        let archive = release_archive(b"not an executable format");
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET).path("/asset");
+            then.status(200).body(archive.clone());
+        });
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("vibe_coding_tracker");
+        fs::write(&target, b"old binary").unwrap();
+        let release = GitHubRelease {
+            tag_name: "v1.1.0".into(),
+            name: "v1.1.0".into(),
+            body: None,
+            assets: vec![GitHubAsset {
+                name: platform::get_asset_pattern("1.1.0").unwrap(),
+                browser_download_url: server.url("/asset"),
+                size: archive.len() as u64,
+            }],
+        };
+
+        assert!(perform_installation_at(&target, &Version::new(1, 1, 0), &release).is_err());
+        assert_eq!(fs::read(&target).unwrap(), b"old binary");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn wrong_candidate_version_never_replaces_the_target() {
+        let archive = release_archive(&release_binary("1.0.0"));
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET).path("/asset");
+            then.status(200).body(archive.clone());
+        });
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("vibe_coding_tracker");
+        fs::write(&target, b"old binary").unwrap();
+        let release = GitHubRelease {
+            tag_name: "v1.1.0".into(),
+            name: "v1.1.0".into(),
+            body: None,
+            assets: vec![GitHubAsset {
+                name: platform::get_asset_pattern("1.1.0").unwrap(),
+                browser_download_url: server.url("/asset"),
+                size: archive.len() as u64,
+            }],
+        };
+
+        assert!(perform_installation_at(&target, &Version::new(1, 1, 0), &release).is_err());
+        assert_eq!(fs::read(&target).unwrap(), b"old binary");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn size_mismatch_never_replaces_the_target() {
+        let archive = release_archive(b"truncated binary");
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET).path("/asset");
+            then.status(200).body(archive.clone());
+        });
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("vibe_coding_tracker");
+        fs::write(&target, b"old binary").unwrap();
+        let release = GitHubRelease {
+            tag_name: "v1.1.0".into(),
+            name: "v1.1.0".into(),
+            body: None,
+            assets: vec![GitHubAsset {
+                name: platform::get_asset_pattern("1.1.0").unwrap(),
+                browser_download_url: server.url("/asset"),
+                size: archive.len() as u64 + 1,
+            }],
+        };
+
+        assert!(perform_installation_at(&target, &Version::new(1, 1, 0), &release).is_err());
+        assert_eq!(fs::read(&target).unwrap(), b"old binary");
     }
 }

--- a/src/core/src/update/ownership.rs
+++ b/src/core/src/update/ownership.rs
@@ -1,0 +1,99 @@
+//! Ownership marker for binaries installed by the release installers.
+
+use std::ffi::OsString;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+const RELEASE_MANAGED_MARKER: &[u8] = b"vct-release-installer-v1\n";
+
+/// Returns the marker path beside the canonical executable path.
+///
+/// Canonicalizing first makes an invocation through a symlink use the marker
+/// owned by the real executable rather than a marker beside the symlink.
+pub(crate) fn release_managed_marker_path(executable: &Path) -> io::Result<PathBuf> {
+    let canonical_executable = executable.canonicalize()?;
+    let mut marker = OsString::from(canonical_executable.as_os_str());
+    marker.push(".vct-managed");
+    Ok(PathBuf::from(marker))
+}
+
+/// Returns whether `executable` was installed by a VCT release installer.
+///
+/// The marker is intentionally strict. Any missing, unreadable, or malformed
+/// marker means the executable is treated as not release-managed.
+pub(crate) fn is_release_managed(executable: &Path) -> bool {
+    let Ok(marker_path) = release_managed_marker_path(executable) else {
+        return false;
+    };
+
+    matches!(fs::read(marker_path), Ok(contents) if contents == RELEASE_MANAGED_MARKER)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RELEASE_MANAGED_MARKER, is_release_managed, release_managed_marker_path};
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn executable(dir: &std::path::Path) -> std::path::PathBuf {
+        let executable = dir.join("vibe_coding_tracker");
+        fs::write(&executable, b"binary").unwrap();
+        executable
+    }
+
+    #[test]
+    fn accepts_an_exact_release_installer_marker() {
+        let dir = tempdir().unwrap();
+        let executable = executable(dir.path());
+        fs::write(
+            release_managed_marker_path(&executable).unwrap(),
+            RELEASE_MANAGED_MARKER,
+        )
+        .unwrap();
+
+        assert!(is_release_managed(&executable));
+    }
+
+    #[test]
+    fn rejects_an_absent_marker() {
+        let dir = tempdir().unwrap();
+
+        assert!(!is_release_managed(&executable(dir.path())));
+    }
+
+    #[test]
+    fn rejects_a_malformed_marker() {
+        let dir = tempdir().unwrap();
+        let executable = executable(dir.path());
+        fs::write(
+            release_managed_marker_path(&executable).unwrap(),
+            b"vct-release-installer-v1",
+        )
+        .unwrap();
+
+        assert!(!is_release_managed(&executable));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolves_a_symlink_to_the_canonical_executable_marker() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempdir().unwrap();
+        let executable = executable(dir.path());
+        let alias = dir.path().join("vct");
+        symlink(&executable, &alias).unwrap();
+        fs::write(
+            release_managed_marker_path(&executable).unwrap(),
+            RELEASE_MANAGED_MARKER,
+        )
+        .unwrap();
+
+        assert!(is_release_managed(&alias));
+        assert_eq!(
+            release_managed_marker_path(&alias).unwrap(),
+            release_managed_marker_path(&executable).unwrap()
+        );
+    }
+}

--- a/src/core/src/update/platform.rs
+++ b/src/core/src/update/platform.rs
@@ -2,7 +2,7 @@
 //!
 //! Derives the release asset file name for the host `(os, arch)` and performs
 //! the OS-specific binary swap. Unix can rename over the running executable;
-//! Windows cannot, so it stages the new binary and writes a batch script that
+//! Windows cannot, so it stages the new binary and launches a quiet helper that
 //! finishes the replacement after the process exits.
 
 use anyhow::{Context, Result};
@@ -12,6 +12,8 @@ use std::path::Path;
 
 #[cfg(windows)]
 use std::io::Write;
+#[cfg(windows)]
+use std::process::{Command, Stdio};
 
 /// Builds the release asset file name for the current platform and `version`.
 ///
@@ -51,82 +53,310 @@ pub fn get_asset_pattern(version: &str) -> Result<String> {
     Ok(pattern)
 }
 
-/// Swaps in `new_binary` over `current_exe` on Unix by renaming.
+/// Copies `new_binary` into an executable sibling staging file on Unix.
 ///
-/// Renames the running binary to a sibling `.old` backup (when it exists), then
-/// renames `new_binary` into its place. On Unix an executable can be replaced
-/// while running, so this takes effect immediately.
+/// The downloaded candidate may live on a `noexec` temporary filesystem, so
+/// validation must run from this sibling file before it is committed.
 ///
 /// # Errors
 ///
-/// Returns an error if backing up the current binary fails or if moving the new
-/// binary into place fails (for example, across filesystems where rename is not
-/// atomic).
+/// Returns an error if the sibling staging file cannot be created, copied,
+/// assigned the candidate permissions, or synced.
 #[cfg(unix)]
-pub fn perform_update_unix(current_exe: &Path, new_binary: &Path) -> Result<()> {
-    let backup_path = current_exe.with_extension("old");
+pub fn stage_update_unix(current_exe: &Path, new_binary: &Path) -> Result<tempfile::TempPath> {
+    let parent = current_exe
+        .parent()
+        .context("Current executable has no parent directory")?;
+    let staged = tempfile::Builder::new()
+        .prefix(".vct-update-")
+        .tempfile_in(parent)
+        .context("Failed to create sibling update file")?;
 
-    // Rename current binary to .old
-    if current_exe.exists() {
-        fs::rename(current_exe, &backup_path).context("Failed to backup current binary")?;
-    }
+    fs::copy(new_binary, staged.path()).context("Failed to stage new binary")?;
+    fs::set_permissions(staged.path(), fs::metadata(new_binary)?.permissions())
+        .context("Failed to preserve new binary permissions")?;
+    staged
+        .as_file()
+        .sync_all()
+        .context("Failed to sync new binary")?;
 
-    // Move new binary to current location
-    fs::rename(new_binary, current_exe).context("Failed to replace binary with new version")?;
+    Ok(staged.into_temp_path())
+}
+
+/// Atomically commits a validated Unix sibling staging file.
+///
+/// # Errors
+///
+/// Returns an error if the single rename over `current_exe` fails.
+#[cfg(unix)]
+pub fn commit_update_unix(current_exe: &Path, staged: tempfile::TempPath) -> Result<()> {
+    fs::rename(&staged, current_exe)
+        .context("Failed to atomically replace binary with new version")?;
 
     Ok(())
 }
 
-/// Stages `new_binary` and writes a batch script to finish the swap on Windows.
+/// Stages `new_binary` and starts a quiet helper to finish the swap on Windows.
 ///
-/// Windows will not let a running executable be replaced, so the new binary is
-/// moved to a sibling `.new` file and an `update_vct.bat` is written that, once
-/// the process exits, deletes the old binary, moves `.new` into place, relaunches
-/// it, and deletes itself. The user is told to close the app and run the script;
-/// the replacement does not happen within this call.
+/// Windows will not let a running executable be replaced. The PowerShell helper
+/// acquires the updater's exclusive lock, waits for this process to exit,
+/// refuses to replace a newer installed version, retries the replacement while
+/// another process still has the executable open, and then deletes itself. The
+/// command already in progress is not relaunched.
 ///
 /// # Errors
 ///
-/// Returns an error if moving the new binary to the `.new` path fails, or if the
-/// batch script cannot be created or written.
+/// Returns an error if the sibling staging/helper files cannot be created or if
+/// the helper process cannot be started.
 #[cfg(windows)]
-pub fn perform_update_windows(current_exe: &Path, new_binary: &Path) -> Result<()> {
-    // On Windows, we can't replace the running executable directly
-    // Strategy: download as .new, create a batch script to replace after exit
+pub fn perform_update_windows(
+    current_exe: &Path,
+    new_binary: &Path,
+    expected_version: &str,
+    lock_path: &Path,
+) -> Result<()> {
+    use std::os::windows::process::CommandExt;
 
-    let new_path = current_exe.with_extension("new");
-    let batch_path = current_exe.with_file_name("update_vct.bat");
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    let parent = current_exe
+        .parent()
+        .context("Current executable has no parent directory")?;
+    let mut staged = tempfile::Builder::new()
+        .prefix(".vct-update-")
+        .suffix(".new")
+        .tempfile_in(parent)
+        .context("Failed to create sibling update file")?;
+    let mut source = fs::File::open(new_binary).context("Failed to open new binary")?;
+    std::io::copy(&mut source, staged.as_file_mut()).context("Failed to stage new binary")?;
+    staged
+        .as_file()
+        .sync_all()
+        .context("Failed to sync new binary")?;
+    let staged_path = staged.path().to_path_buf();
 
-    // Move downloaded file to .new
-    fs::rename(new_binary, &new_path).context("Failed to move new binary to .new extension")?;
+    let mut helper = tempfile::Builder::new()
+        .prefix(".vct-update-")
+        .suffix(".ps1")
+        .tempfile_in(parent)
+        .context("Failed to create update helper")?;
+    helper
+        .write_all(
+            windows_update_script(
+                current_exe,
+                &staged_path,
+                expected_version,
+                lock_path,
+                std::process::id(),
+            )
+            .as_bytes(),
+        )
+        .context("Failed to write update helper")?;
+    helper
+        .as_file()
+        .sync_all()
+        .context("Failed to sync update helper")?;
+    let (_, staged_path) = staged.keep().context("Failed to retain staged binary")?;
+    let (_, helper_path) = match helper.keep() {
+        Ok(kept) => kept,
+        Err(error) => {
+            let _ = fs::remove_file(&staged_path);
+            return Err(error).context("Failed to retain update helper");
+        }
+    };
 
-    // Create batch script
-    let batch_script = format!(
-        r#"@echo off
-echo Waiting for application to exit...
-timeout /t 2 /nobreak >nul
-echo Applying update...
-del /F "{old}"
-move /Y "{new}" "{old}"
-echo Update complete!
-echo Starting new version...
-start "" "{old}"
-del "%~f0"
-"#,
-        old = current_exe.display(),
-        new = new_path.display()
-    );
-
-    let mut batch_file =
-        fs::File::create(&batch_path).context("Failed to create update batch script")?;
-    batch_file
-        .write_all(batch_script.as_bytes())
-        .context("Failed to write batch script")?;
-
-    println!();
-    println!("To complete the update on Windows:");
-    println!("   1. Close this application");
-    println!("   2. Run: {}", batch_path.display());
+    let spawn = Command::new("powershell.exe")
+        .args([
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-WindowStyle",
+            "Hidden",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+        ])
+        .arg(&helper_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .creation_flags(CREATE_NO_WINDOW)
+        .spawn();
+    if let Err(error) = spawn {
+        let _ = fs::remove_file(&staged_path);
+        let _ = fs::remove_file(&helper_path);
+        return Err(error).context("Failed to start update helper");
+    }
 
     Ok(())
+}
+
+#[cfg(any(windows, test))]
+fn windows_update_script(
+    current_exe: &Path,
+    staged: &Path,
+    expected_version: &str,
+    lock_path: &Path,
+    parent_pid: u32,
+) -> String {
+    const TEMPLATE: &str = r#"$ErrorActionPreference = 'Stop'
+$target = '__TARGET__'
+$staged = '__STAGED__'
+$lockPath = '__LOCK_PATH__'
+$expected = [Version]'__EXPECTED_VERSION__'
+$parentPid = __PARENT_PID__
+$lock = $null
+$replaced = $false
+
+try {
+  for ($attempt = 0; $attempt -lt 1200 -and $null -eq $lock; $attempt++) {
+    try {
+      $lock = [System.IO.File]::Open(
+        $lockPath,
+        [System.IO.FileMode]::OpenOrCreate,
+        [System.IO.FileAccess]::ReadWrite,
+        [System.IO.FileShare]::None
+      )
+    } catch [System.IO.IOException] {
+      Start-Sleep -Milliseconds 100
+    }
+  }
+  if ($null -eq $lock) {
+    throw 'Timed out while waiting for the update lock'
+  }
+
+  while (Get-Process -Id $parentPid -ErrorAction SilentlyContinue) {
+    Start-Sleep -Milliseconds 250
+  }
+
+  $installed = $null
+  try {
+    $reported = & $target --version 2>$null | Select-Object -First 1
+    if ($LASTEXITCODE -eq 0 -and $null -ne $reported) {
+      $baseVersion = ([string]$reported).Trim().TrimStart('v').Split('-')[0]
+      $installed = [Version]::Parse($baseVersion)
+    }
+  } catch {
+    $installed = $null
+  }
+
+  if ($null -eq $installed -or $installed -le $expected) {
+    for ($attempt = 0; $attempt -lt 120 -and -not $replaced; $attempt++) {
+      try {
+        Move-Item -LiteralPath $staged -Destination $target -Force
+        $replaced = $true
+      } catch [System.IO.IOException] {
+        Start-Sleep -Seconds 1
+      } catch [System.UnauthorizedAccessException] {
+        Start-Sleep -Seconds 1
+      }
+    }
+  }
+} catch {
+  $replaced = $false
+} finally {
+  if (-not $replaced) {
+    Remove-Item -LiteralPath $staged -Force -ErrorAction SilentlyContinue
+  }
+  if ($null -ne $lock) {
+    $lock.Dispose()
+  }
+  Remove-Item -LiteralPath $MyInvocation.MyCommand.Path -Force -ErrorAction SilentlyContinue
+}
+"#;
+
+    TEMPLATE
+        .replace("__TARGET__", &powershell_literal(current_exe))
+        .replace("__STAGED__", &powershell_literal(staged))
+        .replace("__LOCK_PATH__", &powershell_literal(lock_path))
+        .replace("__EXPECTED_VERSION__", expected_version)
+        .replace("__PARENT_PID__", &parent_pid.to_string())
+}
+
+#[cfg(any(windows, test))]
+fn powershell_literal(path: &Path) -> String {
+    path.to_string_lossy().replace('\'', "''")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_replacement_is_atomic_and_leaves_no_fixed_backup() {
+        let dir = tempfile::tempdir().unwrap();
+        let current = dir.path().join("vibe_coding_tracker");
+        let candidate = dir.path().join("candidate");
+        fs::write(&current, b"old").unwrap();
+        fs::write(&candidate, b"new").unwrap();
+
+        let staged = stage_update_unix(&current, &candidate).unwrap();
+        assert_eq!(staged.parent(), current.parent());
+        commit_update_unix(&current, staged).unwrap();
+
+        assert_eq!(fs::read(&current).unwrap(), b"new");
+        assert!(!current.with_extension("old").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_staging_failure_keeps_the_old_binary() {
+        let dir = tempfile::tempdir().unwrap();
+        let current = dir.path().join("vibe_coding_tracker");
+        fs::write(&current, b"old").unwrap();
+
+        assert!(stage_update_unix(&current, &dir.path().join("missing")).is_err());
+        assert_eq!(fs::read(&current).unwrap(), b"old");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_rename_failure_keeps_the_old_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let current = dir.path().join("vibe_coding_tracker");
+        let candidate = dir.path().join("candidate");
+        fs::create_dir(&current).unwrap();
+        fs::write(current.join("sentinel"), b"old").unwrap();
+        fs::write(&candidate, b"new").unwrap();
+
+        let staged = stage_update_unix(&current, &candidate).unwrap();
+        assert!(commit_update_unix(&current, staged).is_err());
+        assert_eq!(fs::read(current.join("sentinel")).unwrap(), b"old");
+    }
+
+    #[test]
+    fn windows_helper_holds_the_lock_and_prevents_downgrades() {
+        let script = windows_update_script(
+            Path::new(r"C:\Program Files\VCT\vibe_coding_tracker.exe"),
+            Path::new(r"C:\Program Files\VCT\candidate.new"),
+            "2.5.0",
+            Path::new(r"C:\Program Files\VCT\.vct-update.lock"),
+            4242,
+        );
+
+        assert!(script.contains("$parentPid = 4242"));
+        assert!(script.contains("[System.IO.FileShare]::None"));
+        assert!(script.contains("Start-Sleep -Milliseconds 250"));
+        assert!(script.contains("$installed -le $expected"));
+        assert!(script.contains("$attempt -lt 120"));
+        assert!(script.contains("$target = 'C:\\Program Files\\VCT\\vibe_coding_tracker.exe'"));
+        assert!(script.contains("$staged = 'C:\\Program Files\\VCT\\candidate.new'"));
+        assert!(script.contains("$lockPath = 'C:\\Program Files\\VCT\\.vct-update.lock'"));
+        assert!(script.contains("$expected = [Version]'2.5.0'"));
+        assert!(!script.contains("timeout /T"));
+    }
+
+    #[test]
+    fn windows_helper_escapes_single_quotes_in_paths() {
+        let script = windows_update_script(
+            Path::new(r"C:\Wei's Tools\vibe_coding_tracker.exe"),
+            Path::new(r"C:\Wei's Tools\candidate.new"),
+            "2.5.0",
+            Path::new(r"C:\Wei's Tools\.vct-update.lock"),
+            4242,
+        );
+
+        assert!(script.contains(r"$target = 'C:\Wei''s Tools\vibe_coding_tracker.exe'"));
+        assert!(script.contains(r"$staged = 'C:\Wei''s Tools\candidate.new'"));
+    }
 }

--- a/src/core/src/update/version_cache.rs
+++ b/src/core/src/update/version_cache.rs
@@ -1,12 +1,14 @@
 //! This tool's own version record (`~/.vct/version.json`).
 //!
-//! Written on every update check as groundwork for a future auto-update prompt.
-//! It holds the latest release seen on GitHub, when the check last ran, and a
-//! release the user has chosen to dismiss (reserved for that future prompt).
+//! Written on every update check and used to throttle startup checks to one
+//! attempt per UTC date. It holds the latest release seen on GitHub, when the
+//! check last ran, and a release the user has chosen to dismiss.
 
 use crate::utils::{get_self_version_cache_path, now_rfc3339_utc_nanos, write_json_atomic};
 use anyhow::Result;
+use chrono::{DateTime, SecondsFormat, Utc};
 use serde::{Deserialize, Serialize};
+use std::path::Path;
 
 /// The `~/.vct/version.json` payload, e.g.
 /// `{"latest_version":"0.142.5","last_checked_at":"2026-07-07T05:34:50.563606999Z","dismissed_version":null}`.
@@ -23,11 +25,12 @@ pub struct SelfVersion {
     pub dismissed_version: Option<String>,
 }
 
-/// Reads the existing record, or a default when it is absent / unreadable.
-pub fn read_self_version() -> SelfVersion {
-    let Ok(path) = get_self_version_cache_path() else {
-        return SelfVersion::default();
-    };
+/// Reads the version record under an explicit cache directory.
+pub(super) fn read_self_version_in(dir: &Path) -> SelfVersion {
+    read_self_version_from(&dir.join("version.json"))
+}
+
+fn read_self_version_from(path: &Path) -> SelfVersion {
     std::fs::read_to_string(path)
         .ok()
         .and_then(|t| serde_json::from_str(&t).ok())
@@ -48,8 +51,39 @@ fn with_check(mut prev: SelfVersion, latest: &str, now: String) -> SelfVersion {
 /// write failure as non-fatal so it never blocks the update flow.
 pub fn record_version_check(latest: &str) -> Result<()> {
     let path = get_self_version_cache_path()?;
-    let record = with_check(read_self_version(), latest, now_rfc3339_utc_nanos());
+    let record = with_check(
+        read_self_version_from(&path),
+        latest,
+        now_rfc3339_utc_nanos(),
+    );
     write_json_atomic(path, &record)
+}
+
+/// Whether a startup check is due on `now`'s UTC date.
+pub(super) fn check_is_due(record: &SelfVersion, now: DateTime<Utc>) -> bool {
+    let Ok(last) = DateTime::parse_from_rfc3339(&record.last_checked_at) else {
+        return true;
+    };
+    last.with_timezone(&Utc).date_naive() < now.date_naive()
+}
+
+/// Records a startup check attempt before any network request.
+pub(super) fn record_check_attempt_in(dir: &Path, now: DateTime<Utc>) -> Result<()> {
+    let path = dir.join("version.json");
+    let mut record = read_self_version_from(&path);
+    record.last_checked_at = format_timestamp(now);
+    write_json_atomic(path, &record)
+}
+
+/// Records the release seen by a startup check without changing its attempt date.
+pub(super) fn record_version_result_in(dir: &Path, latest: &str, now: DateTime<Utc>) -> Result<()> {
+    let path = dir.join("version.json");
+    let record = with_check(read_self_version_from(&path), latest, format_timestamp(now));
+    write_json_atomic(path, &record)
+}
+
+fn format_timestamp(now: DateTime<Utc>) -> String {
+    now.to_rfc3339_opts(SecondsFormat::Nanos, true)
 }
 
 #[cfg(test)]
@@ -89,5 +123,60 @@ mod tests {
         assert_eq!(record.latest_version.as_deref(), Some("0.9.0"));
         assert!(record.last_checked_at.is_empty());
         assert!(record.dismissed_version.is_none());
+    }
+
+    #[test]
+    fn daily_due_check_uses_utc_date() {
+        let now = "2026-07-30T00:00:01Z".parse::<DateTime<Utc>>().unwrap();
+        for last in ["", "not-a-date", "2026-07-29T23:59:59Z"] {
+            let record = SelfVersion {
+                last_checked_at: last.into(),
+                ..SelfVersion::default()
+            };
+            assert!(check_is_due(&record, now), "last = {last}");
+        }
+        for last in ["2026-07-30T00:00:00Z", "2026-07-31T00:00:00Z"] {
+            let record = SelfVersion {
+                last_checked_at: last.into(),
+                ..SelfVersion::default()
+            };
+            assert!(!check_is_due(&record, now), "last = {last}");
+        }
+    }
+
+    #[test]
+    fn attempt_preserves_release_and_dismissal() {
+        let dir = tempfile::tempdir().unwrap();
+        let original = SelfVersion {
+            latest_version: Some("1.2.3".into()),
+            last_checked_at: "old".into(),
+            dismissed_version: Some("1.2.2".into()),
+        };
+        write_json_atomic(dir.path().join("version.json"), &original).unwrap();
+        let now = "2026-07-30T01:02:03Z".parse::<DateTime<Utc>>().unwrap();
+
+        record_check_attempt_in(dir.path(), now).unwrap();
+
+        let record = read_self_version_in(dir.path());
+        assert_eq!(record.latest_version.as_deref(), Some("1.2.3"));
+        assert_eq!(record.dismissed_version.as_deref(), Some("1.2.2"));
+        assert_eq!(record.last_checked_at, "2026-07-30T01:02:03.000000000Z");
+    }
+
+    #[test]
+    fn result_updates_release_and_preserves_dismissal() {
+        let dir = tempfile::tempdir().unwrap();
+        let original = SelfVersion {
+            dismissed_version: Some("1.2.2".into()),
+            ..SelfVersion::default()
+        };
+        write_json_atomic(dir.path().join("version.json"), &original).unwrap();
+        let now = "2026-07-30T01:02:03Z".parse::<DateTime<Utc>>().unwrap();
+
+        record_version_result_in(dir.path(), "1.3.0", now).unwrap();
+
+        let record = read_self_version_in(dir.path());
+        assert_eq!(record.latest_version.as_deref(), Some("1.3.0"));
+        assert_eq!(record.dismissed_version.as_deref(), Some("1.2.2"));
     }
 }

--- a/src/core/tests/config.rs
+++ b/src/core/tests/config.rs
@@ -18,6 +18,7 @@ fn load_in_creates_default_commented_file_when_absent() {
 
     assert_eq!(cfg, Config::default());
     assert_eq!(cfg.general.default_time_range, TimeRange::All);
+    assert!(cfg.general.auto_update);
     assert!(cfg.usage.shows_quota_panel("cursor"));
     assert!(!cfg.usage.merge_models);
     // New sections default sensibly.
@@ -40,6 +41,7 @@ fn load_in_creates_default_commented_file_when_absent() {
     assert!(text.contains("[performance]"));
     assert!(text.contains("[logging]"));
     assert!(text.contains("merge_models = false"));
+    assert!(text.contains("auto_update = true"));
     assert!(text.contains("grok = true"));
     // A generated comment must survive so the file is self-documenting.
     assert!(text.contains("# Toggled live"));
@@ -137,11 +139,12 @@ fn existing_current_file_is_parsed_and_left_in_place() {
     fs::create_dir_all(dir).unwrap();
     // Already in the current format (new keys + `#:schema` + version marker), so
     // load must not rewrite it.
-    let original = "#:schema https://example.test/vct.schema.json\n[general]\ndefault_time_range = \"weekly\"\nversion = 2\n\n[usage]\nmerge_models = true\n\n[usage.quota]\npanels = [\"claude\"]\n\n[providers]\ncursor = false\n";
+    let original = "#:schema https://example.test/vct.schema.json\n[general]\ndefault_time_range = \"weekly\"\nauto_update = false\nversion = 3\n\n[usage]\nmerge_models = true\n\n[usage.quota]\npanels = [\"claude\"]\n\n[providers]\ncursor = false\n";
     fs::write(dir.join("config.toml"), original).unwrap();
 
     let cfg = config::load_in(dir);
     assert_eq!(cfg.general.default_time_range, TimeRange::Weekly);
+    assert!(!cfg.general.auto_update);
     assert!(cfg.usage.merge_models);
     assert!(cfg.usage.shows_quota_panel("claude"));
     assert!(!cfg.usage.shows_quota_panel("cursor"));
@@ -191,6 +194,7 @@ fn load_in_migrates_a_legacy_file_in_place() {
     );
     assert_eq!(cfg.usage.refresh_interval, 15);
     assert_eq!(cfg.analysis.refresh_interval, 20);
+    assert!(cfg.general.auto_update);
 
     // The file on disk is upgraded to the current layout.
     let text = fs::read_to_string(dir.join("config.toml")).unwrap();
@@ -198,10 +202,70 @@ fn load_in_migrates_a_legacy_file_in_place() {
     assert!(text.contains("[usage.quota]"));
     assert!(!text.contains("quota_panels"));
     assert!(!text.contains("refresh_interval_secs"));
+    assert!(text.contains("auto_update = true"));
 
     // A second load leaves the now-current file untouched.
     config::load_in(dir);
     assert_eq!(fs::read_to_string(dir.join("config.toml")).unwrap(), text);
+}
+
+#[test]
+fn load_in_preserves_an_explicit_auto_update_preference() {
+    let th = TempHome::new();
+    let dir = &th.paths.cache_dir;
+    fs::create_dir_all(dir).unwrap();
+    fs::write(
+        dir.join("config.toml"),
+        "[general]\ndefault_time_range = \"weekly\"\nauto_update = false\nversion = 2\n",
+    )
+    .unwrap();
+
+    let cfg = config::load_in(dir);
+    assert!(!cfg.general.auto_update);
+    let text = fs::read_to_string(dir.join("config.toml")).unwrap();
+    assert!(text.contains("auto_update = false"));
+    assert!(text.contains("version = 3"));
+    config::load_in(dir);
+    assert_eq!(fs::read_to_string(dir.join("config.toml")).unwrap(), text);
+}
+
+#[test]
+fn load_in_backfills_auto_update_for_a_legacy_general_table_once() {
+    let th = TempHome::new();
+    let dir = &th.paths.cache_dir;
+    fs::create_dir_all(dir).unwrap();
+    fs::write(
+        dir.join("config.toml"),
+        "[general]\ndefault_time_range = \"weekly\"\nversion = 2\n",
+    )
+    .unwrap();
+
+    let cfg = config::load_in(dir);
+    assert!(cfg.general.auto_update);
+    let text = fs::read_to_string(dir.join("config.toml")).unwrap();
+    assert!(text.contains("auto_update = true"));
+    assert!(text.contains("version = 3"));
+    config::load_in(dir);
+    assert_eq!(fs::read_to_string(dir.join("config.toml")).unwrap(), text);
+}
+
+#[test]
+fn load_read_only_in_never_writes_or_creates_config() {
+    let th = TempHome::new();
+    let dir = &th.paths.cache_dir;
+
+    assert_eq!(config::load_read_only_in(dir), Config::default());
+    assert!(!dir.exists());
+
+    fs::create_dir_all(dir).unwrap();
+    let path = dir.join("config.toml");
+    let original = "[general]\ndefault_time_range = \"weekly\"\nversion = 2\n";
+    fs::write(&path, original).unwrap();
+
+    let cfg = config::load_read_only_in(dir);
+    assert_eq!(cfg.general.default_time_range, TimeRange::Weekly);
+    assert!(cfg.general.auto_update);
+    assert_eq!(fs::read_to_string(path).unwrap(), original);
 }
 
 #[test]

--- a/vct.schema.json
+++ b/vct.schema.json
@@ -20,11 +20,17 @@
     },
     "general": {
       "default": {
+        "auto_update": true,
         "default_time_range": "all",
-        "version": 2
+        "version": 3
       },
       "description": "`[general]` — settings shared across subcommands.",
       "properties": {
+        "auto_update": {
+          "default": true,
+          "description": "Check for a newer vct release when the CLI starts.",
+          "type": "boolean"
+        },
         "default_time_range": {
           "default": "all",
           "description": "Default time range when no --daily/--weekly/--monthly/--all flag is given.\nOne of: \"daily\" | \"weekly\" | \"monthly\" | \"all\".",


### PR DESCRIPTION
## Summary

- add a default-on, once-per-UTC-day startup update check with a persistent config opt-out
- restrict automatic replacement to binaries marked by the official release installers
- validate release assets and serialize replacement across processes, with Unix re-exec and a deferred Windows PowerShell helper
- update the shell and PowerShell installers, generated config schema, regression tests, and all three READMEs

## Safety

- unmarked package-manager, manual, and development builds skip before update network or cache work
- offline, rate-limited, read-only, and contended update paths continue the requested command without terminal output
- downloads use bounded timeouts, exact asset-size checks, and a bounded candidate version probe
- Unix validates from a closed sibling staging file before atomic rename
- Windows holds the shared lock through replacement and refuses to overwrite a newer installed version

## Testing

- `make fmt`
- `VCT_OFFLINE=1 cargo test --workspace --all-targets --all-features --locked --no-fail-fast`
- `uvx pre-commit run -a`
- `VCT_OFFLINE=1 cargo build --profile dist --locked`
- `bash -n scripts/install.sh`
- local defect-focused review: no findings

The generated Windows helper is covered by construction tests. An end-to-end PowerShell helper run was not available on the Linux development host.

Closes #131