### PR TITLE
docs: sweep comments in the parsing layer (session, scan, models)

### DIFF
--- a/src/core/src/models/aggregate.rs
+++ b/src/core/src/models/aggregate.rs
@@ -1,9 +1,10 @@
 //! Neutral per-provider totals container shared by the `usage` and `analysis`
 //! roll-ups (and their display summaries).
 //!
-//! `ProviderTotals<S>` is pure data over [`Provider`] — no feature or
-//! presentation knowledge — so both core summaries and the display layer build
-//! and read it without either depending on the other.
+//! `ProviderTotals<S>` carries no feature or presentation knowledge, which is
+//! what lets it live in `models`: `usage` and `analysis` each build one without
+//! importing the other, and the display layer re-exports this type instead of
+//! defining a parallel container.
 
 use crate::models::Provider;
 

--- a/src/core/src/models/analysis.rs
+++ b/src/core/src/models/analysis.rs
@@ -1,8 +1,8 @@
 //! Normalized, cross-provider analysis result types.
 //!
-//! These structs are the analyzer's output shape: every provider parser in
-//! `src/session/` produces a [`CodeAnalysis`] regardless of the source
-//! assistant, and the `analysis` / `usage` roll-up layers consume them. The
+//! These structs are the analyzer's output shape: every provider parser
+//! produces a [`CodeAnalysis`] regardless of the source assistant, and the
+//! `analysis` / `usage` roll-up layers consume them. The
 //! `serde` attributes here also define the JSON layout of the golden fixtures,
 //! `vct analysis FILE`, and each element of the batch `vct analysis --json`
 //! array.
@@ -224,7 +224,7 @@ pub struct CodeAnalysis {
 pub struct AggregatedAnalysisRow {
     /// Model name the metrics are grouped under.
     pub model: String,
-    /// Total lines changed by `Edit`/`MultiEdit` operations.
+    /// Total lines changed by `Edit` operations.
     pub edit_lines: usize,
     /// Total lines returned by `Read` operations.
     pub read_lines: usize,
@@ -279,11 +279,10 @@ pub enum ExtensionType {
 }
 
 impl ExtensionType {
-    /// Stable scan / display order shared by every provider fan-out.
+    /// Canonical provider order, used to sort scan diagnostics deterministically.
     ///
-    /// This is the single source of truth for "provider order": diagnostics
-    /// sorting, cached-scan ranking, and the descriptor table all defer to it,
-    /// so a new provider only has to be slotted in here.
+    /// The scan's own provider fan-out does **not** read this — it has its own
+    /// ordered table — so a new provider has to be slotted into both.
     pub fn scan_rank(self) -> u8 {
         match self {
             ExtensionType::ClaudeCode => 0,
@@ -337,7 +336,6 @@ mod tests {
 
     #[test]
     fn test_code_analysis_tool_calls_serialization() {
-        // Test serializing CodeAnalysisToolCalls
         let tool_calls = CodeAnalysisToolCalls {
             read: 10,
             write: 5,
@@ -358,7 +356,6 @@ mod tests {
 
     #[test]
     fn test_code_analysis_tool_calls_default() {
-        // Test default values
         let tool_calls = CodeAnalysisToolCalls::default();
 
         assert_eq!(tool_calls.read, 0);
@@ -370,7 +367,6 @@ mod tests {
 
     #[test]
     fn test_code_analysis_detail_base_serialization() {
-        // Test serializing CodeAnalysisDetailBase
         let detail = CodeAnalysisDetailBase {
             file_path: "/path/to/file.rs".to_string(),
             line_count: 100,
@@ -389,7 +385,6 @@ mod tests {
 
     #[test]
     fn test_code_analysis_write_detail_serialization() {
-        // Test serializing CodeAnalysisWriteDetail
         let write_detail = CodeAnalysisWriteDetail {
             base: CodeAnalysisDetailBase {
                 file_path: "/test/file.rs".to_string(),
@@ -410,7 +405,6 @@ mod tests {
 
     #[test]
     fn test_code_analysis_read_detail_serialization() {
-        // Test serializing CodeAnalysisReadDetail
         let read_detail = CodeAnalysisReadDetail {
             base: CodeAnalysisDetailBase {
                 file_path: "/test/input.txt".to_string(),
@@ -430,7 +424,6 @@ mod tests {
 
     #[test]
     fn test_code_analysis_apply_diff_detail_serialization() {
-        // Test serializing CodeAnalysisApplyDiffDetail
         let edit_detail = CodeAnalysisApplyDiffDetail {
             base: CodeAnalysisDetailBase {
                 file_path: "/test/edit.rs".to_string(),
@@ -452,7 +445,6 @@ mod tests {
 
     #[test]
     fn test_code_analysis_run_command_detail_serialization() {
-        // Test serializing CodeAnalysisRunCommandDetail
         let run_detail = CodeAnalysisRunCommandDetail {
             base: CodeAnalysisDetailBase {
                 file_path: "/workspace".to_string(),
@@ -473,7 +465,6 @@ mod tests {
 
     #[test]
     fn test_extension_type_equality() {
-        // Test ExtensionType equality
         assert_eq!(ExtensionType::ClaudeCode, ExtensionType::ClaudeCode);
         assert_eq!(ExtensionType::Codex, ExtensionType::Codex);
         assert_eq!(ExtensionType::Copilot, ExtensionType::Copilot);
@@ -486,7 +477,6 @@ mod tests {
 
     #[test]
     fn test_extension_type_clone() {
-        // Test ExtensionType can be cloned
         let ext1 = ExtensionType::ClaudeCode;
         let ext2 = ext1;
 
@@ -495,7 +485,6 @@ mod tests {
 
     #[test]
     fn test_extension_type_debug() {
-        // Test ExtensionType debug formatting
         let ext = ExtensionType::ClaudeCode;
         let debug_str = format!("{:?}", ext);
 
@@ -504,7 +493,6 @@ mod tests {
 
     #[test]
     fn test_code_analysis_tool_calls_clone() {
-        // Test cloning CodeAnalysisToolCalls
         let tool_calls1 = CodeAnalysisToolCalls {
             read: 5,
             write: 3,
@@ -521,7 +509,6 @@ mod tests {
 
     #[test]
     fn test_camel_case_serialization() {
-        // Test that serialization uses camelCase
         let detail = CodeAnalysisDetailBase {
             file_path: "/test".to_string(),
             line_count: 10,
@@ -531,7 +518,6 @@ mod tests {
 
         let json = serde_json::to_value(&detail).unwrap();
 
-        // Should have camelCase keys
         assert!(json["filePath"].is_string());
         assert!(json["lineCount"].is_number());
         assert!(json["characterCount"].is_number());
@@ -540,7 +526,6 @@ mod tests {
 
     #[test]
     fn test_pascal_case_tool_calls() {
-        // Test that tool calls use PascalCase
         let tool_calls = CodeAnalysisToolCalls {
             read: 1,
             write: 2,
@@ -551,7 +536,6 @@ mod tests {
 
         let json = serde_json::to_value(&tool_calls).unwrap();
 
-        // Should have PascalCase keys (first letter capitalized)
         assert!(json["Read"].is_number());
         assert!(json["Write"].is_number());
         assert!(json["Edit"].is_number());
@@ -559,7 +543,6 @@ mod tests {
 
     #[test]
     fn test_code_analysis_record_serialization() {
-        // Test serializing full CodeAnalysisRecord
         let record = CodeAnalysisRecord {
             total_unique_files: 5,
             total_write_lines: 100,
@@ -592,7 +575,6 @@ mod tests {
 
     #[test]
     fn test_empty_details_serialization() {
-        // Test serializing empty detail vectors
         let record = CodeAnalysisRecord {
             total_unique_files: 0,
             total_write_lines: 0,

--- a/src/core/src/models/claude.rs
+++ b/src/core/src/models/claude.rs
@@ -10,10 +10,9 @@ use serde_json::Value;
 
 /// Single log entry from a Claude Code session file.
 ///
-/// Only fields the analyzer actually reads are materialised. Large unrelated
-/// payloads — assistant text content, `tool_result` bodies, `parentUuid`,
-/// version metadata — are dropped by serde during parse so they never retain
-/// memory, which is what keeps long sessions from ballooning the working set.
+/// Large unrelated payloads — assistant text content, `parentUuid`, version
+/// metadata — are dropped by serde during parse so they never retain memory,
+/// which is what keeps long sessions from ballooning the working set.
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ClaudeCodeLog {
@@ -38,15 +37,13 @@ pub struct ClaudeCodeLog {
     /// `true` for records inside a subagent JSONL
     /// (`<session>/subagents/agent-*.jsonl`). Subagent records do not carry
     /// the top-level `toolUseResult` field, so the analyzer falls back to
-    /// scanning `message.content[].tool_result` for them. Main-session
-    /// records (`isSidechain == false` or missing) skip the fallback to
-    /// avoid double-counting tool results that already arrived via
-    /// `toolUseResult`.
+    /// scanning `message.content[].tool_result` for them; main-session
+    /// records (`isSidechain == false` or missing) skip that fallback.
     #[serde(default)]
     pub is_sidechain: bool,
 }
 
-/// Assistant/user message with only the fields `session::claude::parse_claude_logs` inspects.
+/// Assistant/user message, carrying only the fields the Claude parser inspects.
 ///
 /// `content` may appear in the source as either an array of typed blocks
 /// (assistant messages) or a plain string (user messages like `"Caveat: ..."`).
@@ -69,9 +66,8 @@ pub struct ClaudeMessage {
 ///
 /// `ToolUse` carries the assistant-side invocation. `ToolResult` carries the
 /// matching result block from the *user*-role record — used as a fallback
-/// when the legacy top-level `toolUseResult` field is absent (Claude Code
-/// subagent JSONL files under `<session>/subagents/agent-*.jsonl` only
-/// embed results inside `message.content[].tool_result` blocks). Anything
+/// when the legacy top-level `toolUseResult` field is absent (subagent JSONL
+/// files embed results only inside `message.content[].tool_result`). Anything
 /// else (text, thinking traces, images, …) collapses to `Other` and is
 /// discarded at parse time.
 #[derive(Debug, Clone, Deserialize)]
@@ -97,7 +93,7 @@ pub enum ClaudeContentItem {
         /// Flattened result text (string or joined array blocks).
         #[serde(default, deserialize_with = "deserialize_tool_result_content")]
         content: String,
-        /// Whether Claude rejected the invocation before the tool ran.
+        /// Whether the call came back as an error rather than a result.
         #[serde(default)]
         is_error: bool,
     },
@@ -106,28 +102,23 @@ pub enum ClaudeContentItem {
     Other,
 }
 
-/// Tool input across all tools we care about. Each tool only populates a
-/// subset of fields; serde silently ignores unknown fields and unset fields
-/// stay `None`. Unrelated tools (Glob, Grep, WebSearch, …) deserialize into
-/// an all-`None` value that the analyzer treats as a no-op.
+/// Tool input across all tools we care about. Each tool populates only a
+/// subset of these fields; unrelated tools (Glob, Grep, WebSearch, …)
+/// deserialize into an all-`None` value the analyzer treats as a no-op.
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct ClaudeToolInput {
-    // Bash
     /// Shell command line (Bash tool).
     #[serde(default)]
     pub command: Option<String>,
     /// Human-readable command description (Bash tool).
     #[serde(default)]
     pub description: Option<String>,
-    // Read / Write / Edit share `file_path`
     /// Target file path (Read / Write / Edit tools).
     #[serde(default)]
     pub file_path: Option<String>,
-    // Write
     /// File content to write (Write tool).
     #[serde(default)]
     pub content: Option<String>,
-    // Edit
     /// Text to replace (Edit tool).
     #[serde(default)]
     pub old_string: Option<String>,

--- a/src/core/src/models/codex.rs
+++ b/src/core/src/models/codex.rs
@@ -27,7 +27,8 @@ where
     }
 }
 
-/// Normalizes string, object, and content-block output shapes into plain text.
+/// Normalizes string, object, and content-block output shapes into one string;
+/// an object stays JSON-encoded for the parser to decode again.
 fn deserialize_tool_output<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
 where
     D: Deserializer<'de>,
@@ -46,6 +47,9 @@ where
     }
 }
 
+/// Flattens a content-block array into text, adding a newline only where the
+/// blocks do not already supply one; `input_image` blocks carry no text and are
+/// skipped, while any other textless block is rejected as an unknown shape.
 fn normalize_output_blocks<E>(blocks: Vec<Value>) -> Result<String, E>
 where
     E: serde::de::Error,

--- a/src/core/src/models/copilot.rs
+++ b/src/core/src/models/copilot.rs
@@ -78,18 +78,19 @@ pub struct CopilotSessionContext {
     /// run inside a git repo.
     #[serde(default)]
     pub repository: String,
-    /// E.g. `"github"`; used together with `repository_host` to reconstruct
-    /// the remote URL when the CLI omits the full URL.
+    /// E.g. `"github"`.
     #[serde(default)]
     pub host_type: String,
-    /// E.g. `"github.com"`.
+    /// E.g. `"github.com"`; used together with `repository` to reconstruct
+    /// the remote URL.
     #[serde(default)]
     pub repository_host: String,
 }
 
-/// `session.model_change` payload — each session may switch between models
-/// at any point, so the analyzer uses the most recent one when attributing
-/// streaming `assistant.message` tokens that arrive before `session.shutdown`.
+/// `session.model_change` payload — each session may switch between models at
+/// any point, so the analyzer attributes the streamed `assistant.message`
+/// output tokens to the most recent one. That fallback only applies to
+/// sessions that never reach `session.shutdown`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CopilotModelChangeData {
@@ -126,17 +127,16 @@ pub struct CopilotModelMetric {
 
 /// Token counts captured by Copilot CLI at session shutdown.
 ///
-/// Field names mirror the camelCase keys the CLI writes to disk — the
-/// usage_processor normalises these into the Claude-style field names
-/// (`input_tokens`, `cache_read_input_tokens`, …) before storing them in
-/// `conversation_usage`.
+/// Field names mirror the camelCase keys the CLI writes to disk — the Copilot
+/// parser normalises these into the flat token keys (`input_tokens`,
+/// `cache_read_input_tokens`, …) before storing them in `conversation_usage`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CopilotModelUsage {
     /// Input (prompt) tokens.
     #[serde(default)]
     pub input_tokens: i64,
-    /// Output (completion) tokens.
+    /// Output (completion) tokens, already **including** `reasoning_tokens`.
     #[serde(default)]
     pub output_tokens: i64,
     /// Tokens served from the prompt cache.
@@ -145,7 +145,8 @@ pub struct CopilotModelUsage {
     /// Tokens written into the prompt cache.
     #[serde(default)]
     pub cache_write_tokens: i64,
-    /// Reasoning tokens billed separately by the model.
+    /// Reasoning tokens, a subset of `output_tokens` rather than a separate
+    /// charge; the parser subtracts them back out so each token bills once.
     #[serde(default)]
     pub reasoning_tokens: i64,
 }

--- a/src/core/src/models/filter.rs
+++ b/src/core/src/models/filter.rs
@@ -2,8 +2,7 @@
 //!
 //! [`TimeRange`] is a core domain concept — the aggregators, scanners, and
 //! provider readers all filter sessions by it — so it lives here in `models`
-//! rather than in the CLI layer. The clap surface re-exports it, and
-//! `cli::resolve_time_range*` collapses the period flags into one.
+//! rather than in the CLI layer.
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -57,8 +56,7 @@ impl TimeRange {
 
 /// Collapses the period flags into a single [`TimeRange`].
 ///
-/// Checks `daily`, then `weekly`, then `monthly`, returning the first that is
-/// set; falls back to [`TimeRange::All`] when none are. The flags are mutually
+/// Falls back to [`TimeRange::All`] when none is set. The flags are mutually
 /// exclusive at the CLI layer (shared `period` group), so at most one is ever
 /// true here.
 pub fn resolve_time_range(daily: bool, weekly: bool, monthly: bool) -> TimeRange {

--- a/src/core/src/models/gemini.rs
+++ b/src/core/src/models/gemini.rs
@@ -1,9 +1,9 @@
 //! Serde models for the Google Gemini CLI chat-log JSONL format.
 //!
 //! The first line of each chat file is a [`GeminiSession`] meta record; the
-//! remaining lines are individual events the parser handles as plain `Value`s,
-//! materializing only assistant turns into [`GeminiMessage`]. The `content`
-//! field is polymorphic and handled by the `deserialize_content` helper.
+//! remaining lines are individual events the parser handles as plain `Value`s.
+//! The `content` field is polymorphic and handled by the `deserialize_content`
+//! helper.
 
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
@@ -44,13 +44,13 @@ pub struct GeminiSession {
     pub kind: Option<String>,
 }
 
-/// Single message within a Gemini session
+/// Single message within a Gemini session.
 ///
-/// Used both for the legacy `messages[]` entries and for JSONL events whose
-/// `type == "gemini"`. Non-assistant events (`"user"`, `"info"`, `$set`
-/// meta-updates, …) are filtered out by the analyzer before reaching this
-/// type, so fields such as `content` and `model` can stay absent without
-/// breaking deserialisation.
+/// A `type == "gemini"` event as written on the wire. No parser in this crate
+/// deserializes into it today — the Gemini parser uses its own narrower
+/// analysis shape — and legacy `messages[]` exports are no longer read at all.
+/// Every field tolerates absence, so a partially populated event still
+/// deserializes.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GeminiMessage {
@@ -124,7 +124,8 @@ pub struct GeminiThought {
 /// Token-usage breakdown for a single Gemini message.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GeminiTokens {
-    /// Input (prompt) tokens.
+    /// Input (prompt) tokens: the full prompt count, with the `cached` subset
+    /// already folded in.
     #[serde(default)]
     pub input: i64,
     /// Output (response) tokens.
@@ -133,7 +134,8 @@ pub struct GeminiTokens {
     /// Tokens served from cache.
     #[serde(default)]
     pub cached: i64,
-    /// Tokens spent on reasoning / thoughts.
+    /// Tokens spent on reasoning / thoughts, disjoint from `output` — every
+    /// observed record satisfies `total == input + output + thoughts`.
     #[serde(default)]
     pub thoughts: i64,
     /// Tokens attributed to tool use.

--- a/src/core/src/models/grok.rs
+++ b/src/core/src/models/grok.rs
@@ -26,7 +26,8 @@ pub struct GrokSummary {
     pub info: GrokSessionInfo,
     /// Last session update time in RFC 3339 format.
     pub updated_at: String,
-    /// Fallback last-activity time in RFC 3339 format.
+    /// Last-activity time in RFC 3339 format; the later of it and `updated_at`
+    /// seeds the session timestamp, which `updates.jsonl` can then push later.
     pub last_active_at: String,
     /// Alias or model id used only when signals omit model attribution.
     pub current_model_id: String,

--- a/src/core/src/models/mod.rs
+++ b/src/core/src/models/mod.rs
@@ -3,12 +3,14 @@
 //!
 //! Each JSON/JSONL provider submodule (`claude`, `codex`, `copilot`, `gemini`,
 //! `grok`) defines the minimal subset of fields the analyzer reads from that
-//! provider's session logs; the SQLite providers (OpenCode / Cursor / Hermes)
-//! deserialize inline in their `session` readers and have no submodule here.
-//! `analysis` and `usage` hold the normalized, cross-provider output shapes;
-//! `provider` carries the [`Provider`] discriminator, `filter` the
-//! [`TimeRange`] session filter, and `aggregate` the per-provider totals
-//! container. All items are re-exported at the module root for convenience.
+//! provider's session logs. The rest define no serde model at all: the SQLite
+//! providers (OpenCode / Cursor / Hermes) and DeepSeek Harness read their
+//! sources directly in `session`. `analysis` and `usage` hold the
+//! normalized, cross-provider output shapes and `quota` the provider
+//! quota/rate-limit ones; `provider` carries the [`Provider`] discriminator,
+//! `filter` the [`TimeRange`] session filter, and `aggregate` the per-provider
+//! totals container. All items are re-exported at the module root for
+//! convenience.
 
 pub mod aggregate;
 pub mod analysis;

--- a/src/core/src/models/provider.rs
+++ b/src/core/src/models/provider.rs
@@ -1,3 +1,5 @@
+//! The [`Provider`] discriminator and its model-name detection.
+
 use std::fmt;
 
 /// Supported AI coding assistant providers.
@@ -58,7 +60,6 @@ impl Provider {
     /// assert_eq!(Provider::from_model_name("mystery-model"), Provider::Unknown);
     /// ```
     pub const fn from_model_name(model: &str) -> Self {
-        // Use byte comparison for better performance
         let bytes = model.as_bytes();
 
         if bytes.len() >= 6 {
@@ -74,7 +75,6 @@ impl Provider {
             }
         }
 
-        // Check for "copilot" prefix
         if bytes.len() >= 7
             && bytes[0] == b'c'
             && bytes[1] == b'o'
@@ -107,7 +107,6 @@ impl Provider {
             return Self::Grok;
         }
 
-        // Check for OpenAI/Codex models
         if bytes.len() >= 3 && bytes[0] == b'g' && bytes[1] == b'p' && bytes[2] == b't' {
             return Self::Codex;
         }

--- a/src/core/src/models/quota.rs
+++ b/src/core/src/models/quota.rs
@@ -1,13 +1,10 @@
 //! Quota / rate-limit data models for the `usage` quota panels.
 //!
-//! Each provider has a raw wire shape that normalizes into one shared output
+//! Each provider has its own raw wire shape — and, where a token is involved,
+//! its own credential file — all normalizing into one shared output
 //! ([`QuotaWindow`] / per-provider `*QuotaSnapshot`) so the TUI gauges render
-//! every provider identically:
-//!
-//! - **Claude** — `GET /api/oauth/usage` ([`ClaudeUsageResponse`]) plus the
-//!   OAuth credentials in `~/.claude/.credentials.json` ([`ClaudeCredentials`]).
-//! - **Codex** — `wham/usage` API ([`WhamUsageResponse`]) with a session-log
-//!   fallback ([`CodexSessionRateLimits`]) and `~/.codex/auth.json`.
+//! every provider identically. The section banners below group each provider's
+//! types with the endpoint they come from.
 //!
 //! Structs holding bearer tokens use a hand-written [`fmt::Debug`] that redacts
 //! the secret so a token can never reach a log or assertion message.
@@ -540,7 +537,7 @@ pub enum QuotaSource {
     /// No data available.
     #[default]
     None,
-    /// Live API (`wham/usage` or Claude usage).
+    /// The provider's live quota API.
     Api,
     /// Newest Codex session-log `rate_limits`.
     SessionFallback,
@@ -582,7 +579,8 @@ pub struct CodexQuotaSnapshot {
     /// The backend may cap this list, so its length is not the total count.
     #[serde(default)]
     pub reset_credit_expirations: Option<Vec<Option<i64>>>,
-    /// Approximate `[low, high]` messages the remaining credits still buy.
+    /// Approximate `[low, high]` local (CLI) messages the remaining credits
+    /// still buy; the cloud-task pair is not carried.
     #[serde(default)]
     pub approx_messages: Option<(i64, i64)>,
     /// Configured spend cap, when set.
@@ -937,7 +935,7 @@ pub struct CursorQuotaSnapshot {
     #[serde(default)]
     pub limit_reached: bool,
     /// Credentials present but the token is unusable (expired / 401); the panel
-    /// shows a `cursor login` hint.
+    /// shows a `cursor-agent login` hint.
     #[serde(default)]
     pub needs_login: bool,
 }

--- a/src/core/src/models/usage.rs
+++ b/src/core/src/models/usage.rs
@@ -5,19 +5,22 @@ use crate::constants::FastHashMap;
 use crate::models::Provider;
 use serde::Serialize;
 
-/// Token usage data aggregated by model (across all dates)
+/// Token usage data aggregated by model name (across all dates).
 ///
-/// Structure: Model Name -> Usage Metrics
-/// - Uses FastHashMap (ahash) for better performance than std HashMap
-/// - Usage format varies by provider:
-///   * Claude/Gemini: `{ input_tokens, output_tokens, cache_read_input_tokens, cache_creation_input_tokens }`
-///   * Codex: `{ total_token_usage: { input_tokens, output_tokens } }`
+/// The value keeps the provider's own token shape, of which there are two:
+/// flat token keys (`input_tokens`, `output_tokens`, …) for every provider
+/// except Codex, which nests its counters under `total_token_usage`. Which
+/// keys a flat value carries still varies — Gemini's reasoning arrives as
+/// `thoughts_tokens` where the others use `reasoning_output_tokens`.
+/// `extract_token_counts` is what reads both shapes into disjoint buckets.
 pub type UsageResult = FastHashMap<String, serde_json::Value>;
 
-/// Tracks the number of active days per AI provider
+/// Tracks the number of active days per AI provider.
 ///
 /// Used for calculating daily averages when data is aggregated by model only.
-/// Day counts are derived from file modification dates during processing.
+/// A day is counted from the session's own date: the file modification date
+/// for the file-backed providers, the stored row timestamp for the
+/// SQLite-backed ones.
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct ProviderActiveDays {
     /// Distinct active days observed for Claude Code.
@@ -42,21 +45,19 @@ pub struct ProviderActiveDays {
     pub total: usize,
 }
 
-/// Per-provider usage data, keyed by source directory rather than by model name.
+/// Per-provider usage data, bucketed by the provider that produced it rather
+/// than by model name.
 ///
 /// The top-level `UsageResult` in `UsageData` intentionally merges same-named
 /// models across providers (so the per-model table shows one row for
 /// `claude-sonnet-4-6` regardless of whether Claude Code, Copilot CLI, or
 /// both invoked it). That merge loses the *source* information though, which
-/// matters for the per-provider summary: once Copilot CLI stopped writing
-/// the `copilot` sentinel and started recording real model names, the old
-/// "classify each row by model-name prefix" logic mis-attributed every
-/// Copilot session to Claude Code.
-///
-/// This struct keeps a separate `UsageResult` per provider so the display
-/// layer can sum tokens and cost by source directory directly, with no
-/// prefix heuristics involved. It is populated in `usage::aggregator` at
-/// the same time the global merged map is built.
+/// matters for the per-provider summary: once Copilot CLI stopped writing the
+/// `copilot` sentinel and started recording real model names, the old
+/// "classify each row by model-name prefix" logic mis-attributed every Copilot
+/// session to Claude Code. Keeping one `UsageResult` per provider lets the
+/// display layer sum tokens and cost by source with no prefix heuristics. It
+/// is populated at the same time as the global merged map.
 #[derive(Debug, Default, Clone, Serialize)]
 pub struct PerProviderUsage {
     /// Per-model usage attributed to Claude Code.

--- a/src/core/src/scan/compact.rs
+++ b/src/core/src/scan/compact.rs
@@ -120,7 +120,7 @@ pub(crate) fn fold_loaded(
 /// Scans one file-backed provider's session roots through the incremental cache.
 ///
 /// Shared verbatim by usage and analysis: discovery, cache lookup, parallel
-/// miss-load, cache insert, and fold. Each feature supplies only its `sink`.
+/// miss-load, cache insert, and fold.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn scan_cached_files<F>(
     dirs: &[&Path],

--- a/src/core/src/scan/descriptor.rs
+++ b/src/core/src/scan/descriptor.rs
@@ -83,8 +83,7 @@ const FILE_PROVIDERS: [FileProviderSpec; 6] = [
 ];
 
 /// Scans every enabled file-backed provider through the incremental cache,
-/// folding each into `sink`. Replaces the per-provider `if` ladder in both the
-/// usage and analysis cached collectors.
+/// folding each into `sink`. Shared by the usage and analysis cached collectors.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn scan_all_cached_files(
     paths: &HelperPaths,

--- a/src/core/src/scan/mod.rs
+++ b/src/core/src/scan/mod.rs
@@ -81,8 +81,7 @@ impl ScanDiagnostics {
     ///
     /// For failures produced anew each scan (directory traversal, fingerprint
     /// I/O, a hard parser error) — not the retained verdicts folded from cache —
-    /// so the log line matches one real failure per scan, as the analysis file
-    /// scan did before it moved onto the shared scanner. The log is file-only
+    /// so the log line matches one real failure per scan. The log is file-only
     /// (never stdout/stderr), so this stays TUI-safe.
     pub(crate) fn record_hard_failure(
         &mut self,

--- a/src/core/src/session/claude.rs
+++ b/src/core/src/session/claude.rs
@@ -17,12 +17,7 @@ use crate::utils::{
 use anyhow::Result;
 use serde_json::Value;
 
-/// Parse Claude Code session records from a `Vec<Value>` fallback.
-///
-/// Used by the pretty-printed single-object JSON fallback path in the
-/// top-level [`parse_session_file_typed`] dispatcher. Records are moved
-/// into the typed iterator form so that the lean [`ClaudeCodeLog`] shape
-/// drops unused payloads at deserialisation.
+/// Parse Claude Code session records already materialised as a `Vec<Value>`.
 ///
 /// Records that fail to deserialise into [`ClaudeCodeLog`] are skipped rather
 /// than aborting the parse.
@@ -32,8 +27,6 @@ use serde_json::Value;
 /// Returns `Err` only if the underlying [`parse_claude_logs`] does; in
 /// practice the Claude parse never fails (malformed records are dropped),
 /// so this is `Ok` for any input.
-///
-/// [`parse_session_file_typed`]: crate::session::parser::parse_session_file_typed
 pub fn parse_claude_log_values(records: Vec<Value>, mode: ParseMode) -> Result<CodeAnalysis> {
     let iter = records
         .into_iter()
@@ -43,9 +36,8 @@ pub fn parse_claude_log_values(records: Vec<Value>, mode: ParseMode) -> Result<C
 
 /// Parse Claude Code session records from any iterator of pre-typed logs.
 ///
-/// This is the streaming entry point: callers that read JSONL one line at a
-/// time (see [`crate::session::parser::parse_session_file_to_value`]) feed records
-/// through here without ever materialising a full `Vec<Value>` of raw JSON.
+/// The streaming entry point: records can be fed in one line at a time,
+/// without ever materialising a full `Vec<Value>` of raw JSON.
 ///
 /// The returned [`CodeAnalysis`] always holds exactly one record; the
 /// runtime metadata fields (`user`, `extension_name`, …) are left blank here
@@ -156,11 +148,11 @@ where
                     // Claude Code's top-level `usage` is the sum of the
                     // `message`-type entries in `usage.iterations` and EXCLUDES any
                     // `advisor_message` iteration (a secondary inference Claude Code
-                    // runs but keeps off its own /cost accounting). Capture those
-                    // advisor tokens — under the advisor's own model so they price
-                    // correctly — in the separate `advisor_usage` map so the
-                    // `usage` cost reflects them without the `analysis` aggregator
-                    // crediting the advisor with the main model's file operations.
+                    // runs but keeps off its own /cost accounting). The sample in
+                    // `advisor_message_usage_is_separated_from_conversation_usage`
+                    // below is what that was read off. Key each advisor iteration by
+                    // the model it names so it prices at that model's rate; one that
+                    // names no model falls back to the main model's key.
                     if let Some(iters) = usage.get("iterations").and_then(|v| v.as_array()) {
                         for iter in iters {
                             if iter.get("type").and_then(|t| t.as_str()) == Some("advisor_message")
@@ -296,12 +288,12 @@ where
         {
             // Subagent JSONL fallback: tool results live inside
             // `message.content[].tool_result` instead of the top-level
-            // `toolUseResult` field. We gate this on `is_sidechain` because
-            // main-session user records can also legitimately have content
-            // tool_result blocks alongside a non-dict (string-shaped)
-            // `toolUseResult` (e.g. user-rejection messages); without the
-            // sidechain guard those would double-count against the
-            // toolUseResult path that runs above.
+            // `toolUseResult` field. Gated on `is_sidechain` because a
+            // main-session user record can carry a content tool_result block
+            // alongside a string-shaped `toolUseResult` (e.g. a user
+            // rejection), which deserializes to `None` and so lands in this
+            // branch; that string result carries no file body, so the content
+            // block's text must not be counted as one.
             for item in &message.content {
                 let ClaudeContentItem::ToolResult {
                     tool_use_id,
@@ -638,9 +630,8 @@ fn dispatch_subagent_tool_result(
 
     match tool_name {
         "Read" => {
-            // The numbered file contents the subagent saw — drives the
-            // read-line tally. Use the result body, not the input, since
-            // Read's input only carries the path.
+            // Read's input carries only the path, so the line tally has to
+            // come from the result body.
             preserve_file_tool_counts(state, |state| {
                 state.add_read_detail(file_path, result_content, ts);
             });
@@ -786,9 +777,9 @@ mod tests {
     fn main_session_string_tool_use_result_does_not_double_count() {
         // Main session records can have a string-shaped toolUseResult
         // (rejection messages) alongside a content tool_result block.
-        // Without `is_sidechain`, the fallback would double-count. Here
-        // we simulate `isSidechain == false` and expect zero read lines
-        // (the string `toolUseResult` carries no file content).
+        // Here we simulate `isSidechain == false` and expect zero read
+        // lines: the string `toolUseResult` carries no file content, so the
+        // content block's text must not be counted as one.
         let raw_assistant = serde_json::json!({
             "type": "assistant",
             "timestamp": "2025-01-01T00:00:00Z",

--- a/src/core/src/session/codex.rs
+++ b/src/core/src/session/codex.rs
@@ -1,13 +1,15 @@
-//! Parser for OpenAI Codex rollout logs (`~/.codex/sessions/**/*.jsonl`).
+//! Parser for OpenAI Codex rollout logs (the `*.jsonl` files under `~/.codex`).
 //!
 //! Codex records carry a `type` discriminator (`session_meta`,
 //! `turn_context`, `event_msg`, `response_item`). File operations are not
-//! first-class: Codex records them as legacy `function_call` pairs or current
-//! `custom_tool_call` pairs. This parser joins each call to its output by
-//! `call_id`. Legacy shell calls retain command-level analysis. A top-level
-//! custom `exec` is counted as one run command because its JavaScript source
-//! does not prove which nested tools actually ran. Direct custom patches are
-//! applied only when their paired output explicitly reports success.
+//! first-class: Codex records them as legacy `function_call` pairs, current
+//! `custom_tool_call` pairs, or `patch_apply_end` events. This parser joins
+//! each call to its output by `call_id`. Legacy shell calls retain
+//! command-level analysis. A top-level custom `exec` is counted as one run
+//! command because its JavaScript source does not prove which nested tools
+//! actually ran. Direct custom patches are applied only when their paired
+//! output explicitly reports success; a successful `patch_apply_end` is folded
+//! in unless the same `call_id` was already counted.
 use crate::constants::FastHashMap;
 use crate::models::*;
 use crate::pricing::{TierClassifier, TierThresholds};
@@ -64,13 +66,11 @@ where
     // Codex publishes whole-session cumulative counters on every token_count
     // event; each model is billed only the delta since the previous snapshot.
     // Pre-context snapshots (a resumed session's replayed totals) advance the
-    // snapshot without attribution, replacing the old replay-baseline hack.
+    // snapshot without attribution.
     let mut prev_totals: Option<CodexTokenTotals> = None;
     let mut shell_calls: FastHashMap<String, PendingCodexShellCall> =
         FastHashMap::with_capacity(50);
     let mut custom_calls: FastHashMap<String, CodexCustomCall> = FastHashMap::with_capacity(32);
-    // Call ids of direct `apply_patch` custom_tool_calls, so a paired
-    // `patch_apply_end` event is not double counted (see the event_msg arm).
     // Call ids whose file ops have already been counted, by either the direct
     // apply_patch output or its authoritative patch_apply_end event. The first
     // to actually count wins; the other is skipped. A direct patch whose output
@@ -106,7 +106,7 @@ where
                 if state.folder_path.is_empty()
                     && let Some(cwd) = &entry.payload.cwd
                 {
-                    state.folder_path.clone_from(cwd); // More efficient than clone()
+                    state.folder_path.clone_from(cwd);
                 }
                 if state.task_id.is_empty()
                     && let Some(id) = &entry.payload.id
@@ -132,7 +132,7 @@ where
                     .as_ref()
                     .filter(|model| !model.is_empty())
                 {
-                    current_model.clone_from(model); // Reuse existing allocation
+                    current_model.clone_from(model);
                 }
             }
             "event_msg" => {
@@ -189,9 +189,8 @@ where
                 // records the resulting file changes in a `patch_apply_end` event.
                 // A successful one is the authoritative source of those file ops.
                 if entry.payload.payload_type.as_deref() == Some("patch_apply_end") {
-                    // Skip only when the paired direct apply_patch already
-                    // counted this call_id; otherwise this event is the
-                    // authoritative record of the change and must be folded in.
+                    // Skip when this call_id's file ops were already counted,
+                    // by the direct apply_patch output or an earlier event.
                     let already_counted = entry
                         .payload
                         .call_id
@@ -326,6 +325,8 @@ where
     Ok(ParsedAnalysis::new(analysis, diagnostics))
 }
 
+/// Whether a `token_count` info blob is a shape this parser can fold; one
+/// carrying no recognized key at all is reported as schema drift.
 fn is_supported_codex_usage(info: &Value) -> bool {
     let Some(info) = info.as_object() else {
         return false;
@@ -384,6 +385,8 @@ enum PendingCodexShellCall {
     InvalidArguments,
 }
 
+/// Whether an output is Codex reporting that the model's arguments failed to
+/// parse, rather than the result of a command that actually ran.
 fn output_reports_argument_error(output: Option<&str>) -> bool {
     let output = shell_output(output).output;
     let output = strip_exec_command_metadata_prefix(&output)
@@ -423,7 +426,9 @@ fn strip_exec_command_metadata_prefix(output: &str) -> &str {
     }
 }
 
-/// Normalizes legacy strings and structured outputs serialized at the model boundary.
+/// Decodes a shell output into a `CodexShellOutput`, falling back to the
+/// object's `output` field and then to the raw text when it is not the
+/// structured envelope.
 fn shell_output(output: Option<&str>) -> CodexShellOutput {
     let Some(output) = output else {
         return CodexShellOutput {
@@ -608,25 +613,21 @@ impl CodexAnalysisExt for SessionParseState {
             return;
         }
 
-        // The legacy `shell` function returned just the raw command output
-        // in `output`. The current `exec_command` function wraps that
-        // output with a metadata header — strip it so line counting sees
-        // only what the model actually saw as the file body.
+        // `exec_command` wraps the captured command output in a metadata
+        // header (legacy `shell` did not); strip it so line counting sees only
+        // the file body.
         let output_body = strip_exec_command_metadata_prefix(&output.output);
 
-        // Check for sed command
         if let Some(path) = extract_sed_file_path(&call.script) {
             self.add_read_detail(&path, output_body, call.timestamp);
             return;
         }
 
-        // Check for cat command
         if let Some((path, content)) = extract_cat_read(&call.script, output_body) {
             self.add_read_detail(&path, &content, call.timestamp);
             return;
         }
 
-        // Record as run command
         self.record_run_command(call);
     }
 
@@ -816,7 +817,6 @@ fn parse_patch_change_entry(path: &str, entry: &Value) -> Option<CodexPatch> {
 /// `@@` hunk headers and `\` no-newline markers are skipped. Both results
 /// have their trailing newline trimmed.
 fn extract_patch_strings(lines: &[String]) -> (String, String) {
-    // Pre-allocate with estimated capacity
     let estimated_size = lines.iter().map(|l| l.len()).sum::<usize>();
     let mut old_str = String::with_capacity(estimated_size / 2);
     let mut new_str = String::with_capacity(estimated_size / 2);
@@ -847,7 +847,6 @@ fn extract_patch_strings(lines: &[String]) -> (String, String) {
         }
     }
 
-    // Trim in-place instead of allocating new strings
     let old_len = old_str.trim_end_matches('\n').len();
     old_str.truncate(old_len);
     let new_len = new_str.trim_end_matches('\n').len();
@@ -892,7 +891,6 @@ fn extract_cat_read(script: &str, output: &str) -> Option<(String, String)> {
 
         let path = path_field.trim_matches(|c| c == '"' || c == '\'');
 
-        // Optimize: avoid multiple allocations
         let clean_output = if let Some(idx) = output.find("\n---") {
             output[..idx].trim_end_matches('\n').to_string()
         } else {

--- a/src/core/src/session/copilot.rs
+++ b/src/core/src/session/copilot.rs
@@ -6,7 +6,7 @@
 //! streamed `assistant.message.outputTokens` as a partial fallback for
 //! sessions that never shut down cleanly. File operations are paired across
 //! `tool.execution_start` / `tool.execution_complete` by `toolCallId` and
-//! only counted on success. See the table below for the full event map.
+//! only counted on success. See the table below for the event map.
 use crate::constants::{FastHashMap, capacity};
 use crate::models::*;
 use crate::session::diagnostics::{ParseDiagnostics, ParsedAnalysis};
@@ -19,20 +19,19 @@ use serde_json::{Value, json};
 // Copilot CLI `events.jsonl` streaming parser
 // =============================================================================
 //
-// Copilot CLI stores every session as
-// `~/.copilot/session-state/<sessionId>/events.jsonl`. Each line is a single
-// `CopilotEvent` whose `event_type` decides how to interpret `data`:
+// Each line is a single `CopilotEvent` whose `event_type` decides how to
+// interpret `data`:
 //
 //   session.start            → session-scoped context (sessionId, cwd, …)
 //   session.model_change     → tracks the currently active model
-//   session.task_complete    → task summary, informational only
 //   session.shutdown         → authoritative per-model token usage
-//   system.message           → system prompt; ignored
-//   user.message             → user-turn content; ignored
 //   assistant.message        → streaming output; only outputTokens is reliable
-//   assistant.turn_start/end → turn bookkeeping; ignored
 //   tool.execution_start     → paired with the matching complete event
 //   tool.execution_complete  → fires the analyzer's file-op handlers
+//
+// Every other entry in the `recognized` list below (system / user messages,
+// turn and hook bookkeeping, subagents, aborts, …) is known-and-ignored; an
+// `event_type` outside that list counts as schema drift.
 //
 // Legacy single-object dumps under `~/.copilot/history-session-state/` are
 // not supported — users with old dumps will see them fall through to the
@@ -70,9 +69,7 @@ where
     let mut state = SessionParseState::with_mode(mode);
     let mut conversation_usage: FastHashMap<String, Value> =
         FastHashMap::with_capacity(capacity::MODELS_PER_SESSION);
-    // Pending tool calls indexed by `toolCallId` — each `tool.execution_start`
-    // stashes its arguments here until the matching `tool.execution_complete`
-    // arrives with the result payload.
+    // Pending tool calls indexed by `toolCallId`.
     let mut pending_tools: FastHashMap<String, PendingTool> = FastHashMap::with_capacity(32);
 
     // Fallback accounting used when the session does not reach
@@ -80,10 +77,9 @@ where
     // want to attribute `assistant.message.outputTokens` to *some* model,
     // so we track the active model switches.
     let mut current_model = String::new();
-    // Set to `true` once we consume a `session.shutdown` event. If so, the
-    // shutdown record is authoritative and we discard the fallback output
-    // tallies built from streamed `assistant.message` events — those would
-    // otherwise double-count.
+    // A consumed `session.shutdown` record is authoritative. The fallback
+    // graft below inserts on the same canonicalized model key, so without
+    // this guard it would replace that row with a zero-`input_tokens` one.
     let mut shutdown_seen = false;
     let mut pending_output_tokens: FastHashMap<String, i64> = FastHashMap::with_capacity(3);
     let mut diagnostics = ParseDiagnostics::default();
@@ -357,6 +353,10 @@ fn copilot_usage_supported(usage: &Value) -> bool {
     recognized
 }
 
+/// Tools whose payloads this parser claims to understand.
+///
+/// An unsupported payload on one of these is schema drift; on any other tool
+/// it is not.
 fn is_tracked_tool(name: &str) -> bool {
     matches!(
         name,
@@ -486,9 +486,8 @@ fn dispatch_tool(
     let args = &pending.arguments;
 
     match pending.tool_name.as_str() {
-        // Current Copilot CLI exposes `view` for reads. Historical versions
-        // used `str_replace_editor` with `command == "view"`, which we no
-        // longer attempt to parse.
+        // Historical releases exposed reads as `str_replace_editor` with
+        // `command == "view"`, which we no longer attempt to parse.
         "view" | "show_file" | "read_file" => {
             let Some(path) = args.get("path").and_then(|p| p.as_str()) else {
                 return;
@@ -501,9 +500,9 @@ fn dispatch_tool(
         // Search and web tools surface content but do not identify one complete
         // file body, so retain the invocation without inventing line totals.
         "rg" | "grep" | "glob" | "web_search" | "web_fetch" => state.tool_counts.read += 1,
-        // `create` is the primary write tool. Historical names are kept for
-        // robustness; a future release that renames the tool will still get
-        // counted if the argument shape stays similar.
+        // `create` is the primary write tool; the other names are ones the CLI
+        // is known or likely to emit. A tool name outside this list is
+        // ignored, however similar its argument shape.
         "create" | "write_file" | "write" => {
             let Some(path) = args.get("path").and_then(|p| p.as_str()) else {
                 return;
@@ -515,8 +514,7 @@ fn dispatch_tool(
                 .unwrap_or("");
             state.add_write_detail(path, content, ts);
         }
-        // Edit-style tool names the CLI is known or likely to emit. Field
-        // shape is assumed to stay `{path, old_string|old_str, new_string|new_str}`.
+        // Edit-style tool names the CLI is known or likely to emit.
         "str_replace" | "edit" | "replace" | "edit_file" => {
             let Some(path) = args.get("path").and_then(|p| p.as_str()) else {
                 return;
@@ -561,6 +559,11 @@ fn dispatch_tool(
     }
 }
 
+/// Attaches the read body without double-counting the invocation.
+///
+/// The caller has already bumped `tool_counts.read` so an empty or
+/// undecodable body still shows up, and `add_read_detail` bumps it again for
+/// a non-empty body, so the count is saved and restored around the call.
 fn attach_read_detail(state: &mut SessionParseState, path: &str, content: &str, ts: i64) {
     let invocation_count = state.tool_counts.read;
     state.add_read_detail(path, content, ts);
@@ -634,6 +637,7 @@ fn parse_apply_patch_text(patch_text: &str) -> Vec<CopilotPatch> {
     patches
 }
 
+/// Splits one patch body's `-` / `+` lines into its removed and added text.
 fn extract_patch_strings(lines: &[String]) -> (String, String) {
     let mut old_string = String::new();
     let mut new_string = String::new();
@@ -656,15 +660,13 @@ fn extract_patch_strings(lines: &[String]) -> (String, String) {
 
 /// Resolve the content a Copilot `view` tool saw.
 ///
-/// Callers can pass us two sources:
+/// Two sources, in order:
 ///
-/// 1. `arguments.view_range` — inclusive `[start, end]` line numbers. When
-///    present we synthesise a `line_count`-line placeholder using a
-///    non-newline character so `add_read_detail`'s `trim_end_matches('\n')`
-///    cannot collapse it back to zero. The actual content is not needed
-///    because we only care about the line count.
-/// 2. `complete.result.content` — the string the model actually received.
-///    Preferred when available and when no `view_range` was supplied.
+/// 1. `arguments.view_range` — inclusive `[start, end]` line numbers. Only
+///    the line count matters downstream, so a placeholder of that many lines
+///    stands in for the body (see the comment on its shape below).
+/// 2. `result.content` — the string the model actually received. Used when
+///    no `view_range` was supplied.
 fn extract_view_content(arguments: &Value, result: &Value) -> String {
     if let Some(range) = arguments.get("view_range").and_then(|v| v.as_array())
         && range.len() >= 2
@@ -759,9 +761,9 @@ mod tests {
     }
 
     fn count_lines_after_trim(s: &str) -> usize {
-        // Mirror src/session/state.rs count_lines + add_read_detail's
-        // trim_end_matches('\n') so the test reflects the actual line
-        // tally the analyzer would record.
+        // Mirror `add_read_detail`'s `trim_end_matches('\n')` + `count_lines`
+        // so the test reflects the actual line tally the analyzer would
+        // record.
         let trimmed = s.trim_end_matches('\n');
         if trimmed.is_empty() {
             0

--- a/src/core/src/session/cursor.rs
+++ b/src/core/src/session/cursor.rs
@@ -3,20 +3,19 @@
 //! Cursor keeps session data in two places under `~/.cursor`:
 //!
 //! - `ai-tracking/ai-code-tracking.db` — one row per AI-authored code line,
-//!   carrying the `model` that wrote it. Used to attribute each conversation to
-//!   a model for the `analysis` view (`conversationId -> model`).
+//!   carrying the `model` that wrote it. Both views use it to attribute a
+//!   conversation to a model (`conversationId -> model`).
 //! - `chats/<projectHash>/<conversationId>/store.db` — a content-addressed blob
 //!   store holding the whole conversation. Assistant turns live in binary
 //!   protobuf DAG nodes (`field 4` = the message JSON, `field 26` = timestamp,
 //!   `field 5` = the running context-window gauge); tool results live in
-//!   standalone JSON blobs. Parsed for `analysis` tool-call metrics.
+//!   standalone JSON blobs. `analysis` reads the tool calls out of it; `usage`
+//!   wants only the gauge, so it never loads the JSON blobs at all.
 //!
-//! Cursor does **not** persist real billing tokens locally (only the context
-//! gauge), so the `usage` view is a deliberately-rough **local estimate** from
-//! that gauge (there is no dashboard-API path here; see `docs/quota.md` for
-//! the raw endpoint if it is ever reintroduced), keeping Cursor consistent with
-//! the other providers whose `usage` is likewise computed from local session
-//! data.
+//! Cursor does **not** persist real billing tokens locally (only that gauge),
+//! so the `usage` view is a deliberately-rough **local estimate**. There is no
+//! dashboard-API path here; see `docs/quota.md` for the raw endpoint if it is
+//! ever reintroduced.
 //!
 //! Both entry points return the same `(local YYYY-MM-DD, CodeAnalysis[, cost])`
 //! shape the OpenCode reader produces, so the `usage` / `analysis` aggregators
@@ -46,10 +45,10 @@ use std::path::{Path, PathBuf};
 
 /// Reads per-model token usage for Cursor.
 ///
-/// Cursor does not persist real billing tokens locally (only a context gauge),
-/// so this is a deliberately-rough estimate from the chat stores: the context
-/// gauge is counted as cache-read tokens. The caller applies the shared
-/// LiteLLM pricing map so a TUI refresh does not rebuild it per reader call.
+/// A deliberately-rough estimate: Cursor persists no billing tokens locally, so
+/// each conversation's context gauge is counted as cache-read tokens instead.
+/// Pricing is left to the caller's shared LiteLLM map so a TUI refresh does not
+/// rebuild one per reader call.
 ///
 /// Each returned tuple is `(local YYYY-MM-DD, CodeAnalysis, 0.0)` with the
 /// analysis carrying one model's `conversation_usage`, matching the shape of
@@ -57,7 +56,10 @@ use std::path::{Path, PathBuf};
 ///
 /// # Errors
 ///
-/// Returns an error only if reading the local chat stores fails.
+/// A store that cannot be read is logged and skipped. Returns an error only
+/// when no candidate decoded at all — a candidate being a discovered store or
+/// a directory that could not be walked, so an unreadable chats root errors on
+/// its own.
 pub fn read_cursor_usage(
     chats_dir: &Path,
     tracking_db: &Path,
@@ -90,11 +92,11 @@ pub fn read_cursor_usage(
 pub(crate) struct CursorUsageRead {
     /// Successfully aggregated date/model rows.
     pub rows: Vec<UsageContribution>,
-    /// Number of discovered stores, or one traversal candidate on failure.
+    /// Discovered stores plus the traversal failures found beside them.
     pub candidates: usize,
     /// Stores decoded successfully, including valid empty stores.
     pub parsed: usize,
-    /// Store-level open or decode failures.
+    /// Traversal, tracking-DB, and per-store decode failures.
     pub failures: Vec<CursorAnalysisFailure>,
 }
 
@@ -116,10 +118,11 @@ pub(crate) fn read_cursor_usage_with_diagnostics(
 /// Reads per-model file-operation metrics for Cursor from the chat stores.
 ///
 /// Walks every `chats/*/*/store.db`, extracts each assistant turn's tool calls
-/// (`Read` / `Write` / `StrReplace`→edit / `Shell`→bash / `TodoWrite`), and
-/// attributes them to the conversation's model (from `ai-code-tracking.db`,
-/// falling back to the store's `lastUsedModel`). Records are bucketed by the
-/// assistant turn's local date and filtered by `time_range`.
+/// (`Read`/`ReadFile` / `Write` / `StrReplace`→edit / `Shell`→bash /
+/// `TodoWrite`), and attributes them to the conversation's model (from
+/// `ai-code-tracking.db`, else the store's `lastUsedModel`, else `"unknown"`).
+/// Records are bucketed by the assistant turn's local date and filtered by
+/// `time_range`.
 ///
 /// # Errors
 ///
@@ -171,14 +174,16 @@ pub(crate) struct CursorStoreDiscovery {
 pub(crate) struct CursorAnalysisRead {
     /// Successfully decoded date/session rows.
     pub rows: Vec<DatabaseAnalysisRow>,
-    /// Number of discovered `store.db` files.
+    /// Discovered `store.db` files plus the traversal failures found beside them.
     pub candidates: usize,
     /// Number of stores decoded successfully, including valid empty stores.
     pub parsed: usize,
-    /// Store-level failures retained for noninteractive diagnostics.
+    /// Traversal, tracking-DB, and per-store failures retained for
+    /// noninteractive diagnostics.
     pub failures: Vec<CursorAnalysisFailure>,
 }
 
+/// One store's analysis rows plus its schema-normalization counts.
 pub(crate) struct CursorStoreAnalysis {
     pub(crate) rows: Vec<(String, CodeAnalysis)>,
     pub(crate) normalized_messages: usize,
@@ -261,8 +266,8 @@ pub(crate) fn read_cursor_analysis_with_diagnostics(
 // usage: local estimate
 // ===========================================================================
 
-/// One usage aggregation row keyed by `(date, model)`, so any time range can
-/// filter it locally. A purely in-memory intermediate — never serialized.
+/// One usage row carrying its own local date, so any time range can filter it
+/// after the fact. A purely in-memory intermediate — never serialized.
 #[derive(Debug)]
 struct UsageEvent {
     date: String,
@@ -335,20 +340,19 @@ pub(crate) fn read_cursor_usage_store(
     })
 }
 
-// ===========================================================================
-// usage: local estimate
-// ===========================================================================
-
 /// Builds all-time usage-estimate events from the local context gauge.
 ///
 /// Cursor stores only the running context-window size per assistant turn, not
 /// billed tokens. Each turn re-sends (and prompt-cache-reads) the accumulated
-/// context, so summing the gauge across a conversation's turns approximates the
-/// **cache-read** token volume — reported in the cache-read bucket both because
-/// that is the honest bucket and because it is then priced at the much cheaper
+/// context, so summing the gauge over a conversation's turns approximates the
+/// **cache-read** token volume. It goes in the cache-read bucket both because
+/// that is the honest bucket and because it is then billed at the much cheaper
 /// cache rate rather than a wildly-inflated full-input rate. Input/output are
-/// unknown (`0`) and the stored cost is `0` (models Cursor prices itself, e.g.
-/// `composer-*`, have no LiteLLM entry and stay `$0`). Deliberately rough.
+/// unknown (`0`) and the stored cost is `0`; the caller prices Cursor on an
+/// exact LiteLLM match alone, so a model Cursor prices itself (e.g.
+/// `composer-*`) stays at `$0` rather than being guessed at from a similar
+/// name. Deliberately rough.
+///
 /// Returns all dates; the caller filters by time range.
 fn approximation_events(chats_dir: &Path, tracking_db: &Path) -> CursorUsageEvents {
     let (conv_models, tracking_failure) = match load_conversation_models(tracking_db) {
@@ -702,7 +706,7 @@ pub(crate) fn read_store_analysis(
         for (date, state) in per_date {
             let mut usage = FastHashMap::default();
             // The analysis aggregator only reads the model key; the value is a
-            // placeholder (real tokens come from the usage API path).
+            // placeholder (tokens come from the usage view's local estimate).
             usage.insert(model.clone(), json!({}));
             let record = state.into_record(usage);
             out.push((date, wrap_record(record, user, machine)));
@@ -716,10 +720,8 @@ pub(crate) fn read_store_analysis(
     })
 }
 
-/// Reads a store's per-turn context-occupancy gauge for the usage approximation.
-///
-/// Returns the conversation's model plus `(timestamp_ms, context_tokens)` for
-/// every assistant turn that carries the gauge.
+/// One store's context-gauge read: the conversation's model plus
+/// `(timestamp_ms, context_tokens)` for every assistant turn carrying the gauge.
 struct CursorStoreContextRead {
     model: String,
     turns: Vec<(i64, i64)>,
@@ -727,6 +729,7 @@ struct CursorStoreContextRead {
     parsed_records: usize,
 }
 
+/// Reads a store's per-turn context-occupancy gauge for the usage estimate.
 fn read_store_context(
     store_db: &Path,
     conv_models: &FastHashMap<String, String>,
@@ -752,9 +755,9 @@ fn read_store_context(
                 continue;
             };
             // Only assistant turns represent a real per-request context. Cursor
-            // also stores intermediate DAG nodes that carry the running gauge but
-            // no assistant message; counting those would roughly double the
-            // approximation's tokens and inflate its active-day count.
+            // also stores intermediate DAG nodes that carry the running gauge on
+            // a non-assistant message; counting those would roughly double the
+            // estimate's tokens and inflate its active-day count.
             let role = message_role(msg_bytes);
             match role.as_deref() {
                 Some("assistant") => {
@@ -832,12 +835,13 @@ fn load_node_blobs(conn: &Connection) -> Result<Vec<Vec<u8>>> {
     Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
 }
 
-/// Returns `(assistant message JSON bytes, timestamp_ms)` for a binary DAG node.
+/// Returns `(embedded message JSON bytes, timestamp_ms)` for a binary DAG node.
 ///
-/// Binary nodes start with `field 1` (`0x0A`) and embed exactly one assistant
-/// message in `field 4`; `field 26` is the epoch-ms timestamp. Non-node blobs
-/// (JSON messages) return `None`, as do nodes missing the timestamp — an
-/// undateable turn is skipped rather than mis-bucketed to the epoch (1970).
+/// Binary nodes start with `field 1` (`0x0A`), carry the message in `field 4`
+/// and the epoch-ms timestamp in `field 26`; the role is not checked here.
+/// Non-node blobs (JSON messages) return `None`, as do nodes missing the
+/// timestamp — an undateable turn is skipped rather than mis-bucketed to the
+/// epoch (1970).
 #[cfg(test)]
 fn assistant_node(data: &[u8]) -> Option<(&[u8], i64)> {
     if data.first() != Some(&0x0A) {
@@ -847,7 +851,7 @@ fn assistant_node(data: &[u8]) -> Option<(&[u8], i64)> {
     Some((node.msg?, node.ts?))
 }
 
-/// Whether a message JSON blob is an assistant turn.
+/// The `role` of a message JSON blob, when it parses and carries one.
 fn message_role(bytes: &[u8]) -> Option<String> {
     serde_json::from_slice::<Value>(bytes)
         .ok()
@@ -860,6 +864,9 @@ fn message_role(bytes: &[u8]) -> Option<String> {
 }
 
 /// Applies one assistant message's tool calls to `state`.
+///
+/// Returns how many tool payloads used an unsupported schema; `Err(())` when
+/// the message itself is not a usable assistant turn.
 fn apply_assistant_tools(
     state: &mut SessionParseState,
     msg: &Value,
@@ -1151,7 +1158,7 @@ fn read_varint(data: &[u8], pos: usize) -> Option<(u64, usize)> {
 // shared helpers
 // ===========================================================================
 
-/// Builds the Claude-style flat usage value the token extractor understands.
+/// Packs Cursor's estimated token counts into the shared usage buckets.
 fn cursor_usage_value(
     input: i64,
     output: i64,

--- a/src/core/src/session/detector.rs
+++ b/src/core/src/session/detector.rs
@@ -31,20 +31,24 @@ pub(crate) fn record_inspections() -> usize {
 /// session data.
 ///
 /// Thin eager wrapper over [`classify_records`]: returns whatever marker the
-/// records carry, falling back to [`ExtensionType::Codex`] when none is
-/// found (a marker-less JSONL stream is almost always a Codex log, whose
-/// `type` discriminators just happen to be absent in this slice).
+/// records carry, falling back to [`ExtensionType::Codex`] when none is found.
+/// That fallback is a tie-break, not a positive identification.
 ///
-/// Detection strategy:
-/// - Grok: a single object with `primaryModelId` + `contextTokensUsed` and
-///   either `contextWindowTokens` or `toolsUsed`
-/// - Gemini: first line is a session-meta record with `sessionId` and
-///   `projectHash` fields but *no* `messages` array (legacy single-object
-///   Gemini exports are no longer supported)
-/// - Copilot: first line is a `type == "session.start"` event whose
-///   `data.producer` field identifies a Copilot agent (e.g.
-///   `copilot-agent`, `copilot-cli`). Legacy single-object dumps under
-///   `~/.copilot/history-session-state/` are no longer supported.
+/// Detection strategy, in the order the classifier applies it. The first four
+/// markers are tested against the first record only; the last two against
+/// every record:
+/// - Grok: `primaryModelId` + `contextTokensUsed` and either
+///   `contextWindowTokens` or `toolsUsed`
+/// - DeepSeek Harness: a session header — `type == "session"` with a numeric
+///   `version` and a string `id`. Only an uncompressed log gets this far; a
+///   zstd-framed one is routed by its frame magic before it is read as text.
+/// - Gemini: a session-meta record with `sessionId` and `projectHash` fields
+///   but *no* `messages` array (legacy single-object Gemini exports are no
+///   longer supported)
+/// - Copilot: a `type == "session.start"` event whose `data.producer` field
+///   identifies a Copilot agent (e.g. `copilot-agent`, `copilot-cli`). Legacy
+///   single-object dumps under `~/.copilot/history-session-state/` are no
+///   longer supported.
 /// - Claude Code: contains `parentUuid` field in log entries
 /// - Codex: contains a record whose `type` is one of `session_meta`,
 ///   `turn_context`, `event_msg`, or `response_item` — **or** as a final
@@ -87,13 +91,12 @@ pub fn detect_extension_type(data: &[Value]) -> Result<ExtensionType> {
 /// `None` signal to decide whether to peek one more JSONL line before
 /// falling back to the default.
 ///
-/// Why this matters: the previous design buffered a fixed `AUTODETECT_PEEK_LINES`
-/// (8) records and then called [`detect_extension_type`], which silently
-/// committed to Codex (the default) once that buffer was exhausted. A Claude
-/// session whose `parentUuid`-bearing record sat past a long metadata
-/// prelude could then be mis-classified as Codex and have its usage
-/// silently dropped. With this function the caller can keep reading until
-/// a positive signal appears, so there is no arbitrary limit to the
+/// Why this matters: the previous design buffered a fixed 8-record peek window
+/// and then called [`detect_extension_type`], which silently committed to Codex
+/// (the default) once that buffer was exhausted. A Claude session whose
+/// `parentUuid`-bearing record sat past a long metadata prelude was then
+/// mis-classified as Codex and had its usage silently dropped. Letting the
+/// caller keep reading until a positive signal appears puts no limit on the
 /// preamble length we tolerate.
 ///
 /// # Examples
@@ -345,7 +348,6 @@ mod tests {
 
     #[test]
     fn test_detect_claude_code_format() {
-        // Test Claude Code format detection with parentUuid field
         let data = vec![
             json!({
                 "parentUuid": "parent-uuid",
@@ -364,7 +366,6 @@ mod tests {
 
     #[test]
     fn test_detect_codex_format_default() {
-        // Test Codex format detection (default when no distinctive markers found)
         let data = vec![json!({
             "timestamp": 1234567890,
             "model": "gpt-4",
@@ -377,10 +378,10 @@ mod tests {
 
     #[test]
     fn test_detect_claude_code_in_first_few_records() {
-        // Test that detection works within first 5 records
+        // A marker that only shows up in a later record still classifies the
+        // whole slice.
         let mut data = vec![json!({"field": "value1"}), json!({"field": "value2"})];
 
-        // Add Claude marker in third record
         data.push(json!({
             "parentUuid": "test-uuid",
             "content": "test"
@@ -484,7 +485,6 @@ mod tests {
 
     #[test]
     fn test_detect_empty_data_error() {
-        // Test that empty data returns an error
         let data: Vec<Value> = vec![];
 
         let result = detect_extension_type(&data);
@@ -494,7 +494,6 @@ mod tests {
 
     #[test]
     fn test_detect_multiple_objects_without_markers() {
-        // Test that multiple objects without distinctive markers default to Codex
         let data = vec![
             json!({"timestamp": 123}),
             json!({"model": "gpt-4"}),

--- a/src/core/src/session/diagnostics.rs
+++ b/src/core/src/session/diagnostics.rs
@@ -71,14 +71,20 @@ impl ParseDiagnostics {
 
 /// Reason string for a source that parsed but skipped some records.
 ///
-/// Worded so every surface that shows it (per-source warnings, stderr
-/// summaries) states that the recognized records were still counted — a
-/// partial skip is not a dropped source.
+/// The `partially parsed:` prefix is a contract, not phrasing:
+/// [`is_partial_failure_reason`] matches it to pick the per-source log wording
+/// that keeps a partial skip from reading as a dropped source. The tail is
+/// shown verbatim in the CLI's stderr scan summary, so it has to stand on its
+/// own there; rewording the tail is free, changing the prefix silently breaks
+/// that match.
 pub(crate) fn partial_failure_reason(count: usize) -> String {
     format!("partially parsed: skipped {count} malformed or unsupported analyzer records")
 }
 
 /// Whether a stored failure reason describes a partial (data-retained) parse.
+///
+/// Recognizes only the prefix [`partial_failure_reason`] writes; any other
+/// reason is a source that produced nothing.
 pub(crate) fn is_partial_failure_reason(reason: &str) -> bool {
     reason.starts_with("partially parsed:")
 }
@@ -99,9 +105,10 @@ pub(crate) struct DatabaseAnalysisRow {
 
 /// Typed token buckets produced by database-backed usage readers.
 ///
-/// SQLite rows stay in this scalar form through the incremental cache. The
-/// compatibility wrappers materialize the historical JSON object only at the
-/// public API boundary.
+/// SQLite rows stay in this scalar form through the incremental cache, so a
+/// cached source costs no per-row JSON object. Callers materialize the
+/// historical JSON shape with [`Self::into_value`] only where they fold into a
+/// map that is already `Value`-keyed.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) struct UsageTokenContribution {
     pub(crate) input_tokens: i64,

--- a/src/core/src/session/dsh.rs
+++ b/src/core/src/session/dsh.rs
@@ -185,8 +185,7 @@ pub(crate) fn parse_dsh_session(
     };
 
     // A foreign format version means the envelope's own semantics may have
-    // moved, so every number derived from it would be a guess. Upstream ships
-    // no migration either and refuses the log outright.
+    // moved, so every number derived from it would be a guess.
     if let Some(version) = parser.unsupported_version {
         bail!(
             "DeepSeek session {} uses format version {version}, but only version {SUPPORTED_FORMAT_VERSION} is supported",

--- a/src/core/src/session/gemini.rs
+++ b/src/core/src/session/gemini.rs
@@ -20,10 +20,9 @@ use serde_json::Value;
 ///
 /// `session` carries the first-line meta record (`sessionId` etc.), and
 /// `events` yields one parsed JSON value per subsequent line. The parser
-/// deduplicates append-only revisions into the historical message set, then
-/// deserializes each `type == "gemini"` message into [`GeminiMessage`]. User
-/// and info messages remain in the set for ordering but do not contribute
-/// metrics.
+/// deduplicates append-only revisions (including `$set.messages` snapshots)
+/// into the historical message set, which holds `type == "gemini"` messages
+/// only; every other event just moves a diagnostics counter.
 ///
 /// This is the only supported Gemini entry point — legacy single-object
 /// exports (`chats/<session>.json` with an inline `messages` array) are no
@@ -33,7 +32,8 @@ use serde_json::Value;
 ///
 /// Returns `anyhow::Result` for parity with the other provider parsers, but
 /// has no fallible step. Non-`gemini` events are skipped, and unsupported
-/// Gemini message schemas are logged before being skipped.
+/// Gemini message schemas only land in the parse diagnostics this wrapper
+/// discards.
 pub fn parse_gemini_events<I>(
     session: GeminiSession,
     events: I,
@@ -89,8 +89,8 @@ struct GeminiMessageAnalysis {
 
 /// Minimal Gemini message shape needed by analysis.
 ///
-/// Deliberately omits user content and thoughts so `UsageOnly` never retains
-/// those large fields while deduplicating revisions.
+/// Deliberately omits `content` and `thoughts` so neither mode retains those
+/// large fields while deduplicating revisions.
 #[derive(Deserialize)]
 struct GeminiAnalysisMessage {
     #[serde(default)]
@@ -358,16 +358,15 @@ fn record_message_diagnostics(message: &GeminiAnalysisMessage, diagnostics: &mut
 }
 
 /// Converts the accumulated state into a single-record [`CodeAnalysis`],
-/// stamping the `task_id` from the session meta and resolving the git remote
-/// from the process working directory when none was captured.
+/// stamping the `task_id` from the session meta.
 fn finalize_record(
     mut state: SessionParseState,
     conversation_usage: FastHashMap<String, Value>,
     session_id: String,
 ) -> CodeAnalysis {
-    // Gemini CLI does not record the invoking `cwd` in its log format today;
-    // fall back to querying git from the process's current dir so the usage
-    // report still stamps a remote URL when running inside a repo.
+    // Gemini CLI does not record the invoking `cwd` in its log format today, so
+    // `folder_path` is empty here and this resolves to an empty remote; it only
+    // yields a URL if a future log format carries a workspace path.
     if state.git_remote.is_empty() {
         state.git_remote = get_git_remote_url(&state.folder_path);
     }
@@ -424,7 +423,6 @@ fn process_gemini_message(state: &mut SessionParseState, message: &GeminiAnalysi
                     .and_then(|p| p.as_str())
                     .unwrap_or("");
 
-                // Content sits at result[0].functionResponse.response.output
                 if let Some(content) = tool_result_output(tool_call) {
                     attach_read_detail(state, file_path, content, ts);
                 }
@@ -475,8 +473,8 @@ fn process_gemini_message(state: &mut SessionParseState, message: &GeminiAnalysi
             }
             "write_todos" => state.tool_counts.todo_write += 1,
             "read_many_files" => state.tool_counts.read += 1,
-            // Meta tools like `update_topic` / `task_complete` carry no
-            // file-operation data; ignore them silently.
+            // Unreachable: `tracked_tool_schema_supported` accepts only the
+            // names matched above.
             _ => {}
         }
     }
@@ -491,10 +489,14 @@ fn record_tool_invocation(state: &mut SessionParseState, name: &str) {
             state.tool_counts.bash += 1;
         }
         "write_todos" => state.tool_counts.todo_write += 1,
+        // Meta tools (`update_topic`, `task_complete`, …) carry no
+        // file-operation data.
         _ => {}
     }
 }
 
+/// Attaches read content without letting `add_read_detail` increment the read
+/// count the caller already recorded.
 fn attach_read_detail(state: &mut SessionParseState, path: &str, content: &str, ts: i64) {
     let invocation_count = state.tool_counts.read;
     state.add_read_detail(path, content, ts);

--- a/src/core/src/session/grok.rs
+++ b/src/core/src/session/grok.rs
@@ -54,6 +54,9 @@ pub(crate) fn parse_grok_session(path: &Path, mode: ParseMode) -> Result<ParsedA
     apply_metadata(&mut state, path, summary.as_ref())?;
     parse_updates(path, &mut state, &mut diagnostics)?;
 
+    // `contextTokensUsed` is a point-in-time context gauge, not billed usage;
+    // the cache-read bucket is what makes `CostSource::GrokGauge` price it at
+    // the model's cache-read rate.
     let estimated_tokens = i64::try_from(signals.context_tokens_used).unwrap_or(i64::MAX);
     let mut usage = FastHashMap::default();
     usage.insert(
@@ -275,9 +278,8 @@ fn parse_updates(
                 }
                 diagnostics.record_recognized_source();
                 if !tracked {
-                    // spawn_subagent / get_command_or_subagent_output orchestrate
-                    // other tools instead of touching files: recognized so they
-                    // never look like schema drift, but mapped to no metric.
+                    // Recognized above so it never looks like schema drift, but
+                    // mapped to no metric.
                     continue;
                 }
                 if status != "completed" {
@@ -346,6 +348,8 @@ fn apply_completed_tool(
             let Some(exit_code) = output.get("exit_code").and_then(Value::as_i64) else {
                 return false;
             };
+            // grep exits 1 for "no matches", which is still a completed search;
+            // any other exit code is a real failure and counts no Read.
             if matches!(exit_code, 0 | 1) {
                 state.tool_counts.read += 1;
             }
@@ -372,6 +376,9 @@ fn apply_completed_tool(
                 return false;
             };
             if let Some(details) = search_replace_details(output) {
+                // One tool lifecycle is one Edit call however many hunks it
+                // applied, so the per-detail increments are rolled back to a
+                // single one below.
                 let edit_calls = state.tool_counts.edit;
                 for detail in details {
                     if let Some((old, new)) = search_replace_detail_strings(detail) {

--- a/src/core/src/session/hermes.rs
+++ b/src/core/src/session/hermes.rs
@@ -1,10 +1,10 @@
 //! Hermes session reader (SQLite, not JSONL).
 //!
-//! Like OpenCode, Hermes stores usage in a single SQLite database at
-//! `~/.hermes/state.db` rather than per-session JSONL files. The
-//! `session_model_usage` table already holds one pre-aggregated row per
-//! `(session, model, billing_provider, ...)`, so this module reads those rows
-//! directly and maps them onto the same flat [`CodeAnalysis`] shape the
+//! Like OpenCode, Hermes stores usage in a single SQLite database (`state.db`
+//! under the Hermes home, `~/.hermes` by default) rather than per-session JSONL
+//! files. The `session_model_usage` table already holds one pre-aggregated row
+//! per `(session, model, billing_provider, ...)`, so this module reads those
+//! rows directly and maps them onto the same flat [`CodeAnalysis`] shape the
 //! file-based providers produce, letting the `usage` aggregator fold Hermes in
 //! alongside everyone else.
 //!
@@ -12,7 +12,7 @@
 //! so there is no `analysis` reader. Rows are keyed by the bare `model` column,
 //! so a model billed through two providers merges into one model row. Each
 //! session is also reconciled against the `sessions` aggregate so partial or
-//! missing per-model rows are not under-counted (see [`collect_usage`]).
+//! missing per-model rows are not under-counted (see `collect_usage`).
 
 use crate::constants::FastHashMap;
 use crate::models::TimeRange;
@@ -29,11 +29,13 @@ use std::path::Path;
 /// Reads per-model token usage from the Hermes database.
 ///
 /// Each returned tuple is `(local YYYY-MM-DD date, CodeAnalysis, stored_cost)`,
-/// where the `CodeAnalysis` holds one `session_model_usage` row's
-/// `conversation_usage` keyed by that row's `model`, and `stored_cost` is
-/// Hermes's own cost for the row (the actual billed cost when known, otherwise
-/// its estimate). The date comes from the row's `last_seen` timestamp and is
-/// filtered by `time_range`, matching the file-walker semantics.
+/// where the `CodeAnalysis` holds one model's `conversation_usage` keyed by that
+/// model, and `stored_cost` is Hermes's own cost for it (the actual billed cost
+/// when positive, otherwise its estimate). A tuple is either one
+/// `session_model_usage` row or one session's residual against the `sessions`
+/// aggregate; its date comes from the last-activity timestamp (`last_seen` /
+/// `ended_at`, falling back to the first-activity one) and is filtered by
+/// `time_range`, matching the file-walker semantics.
 ///
 /// # Errors
 ///
@@ -112,8 +114,9 @@ fn table_exists(conn: &Connection, table: &str) -> Result<bool> {
     .map_err(Into::into)
 }
 
-/// Emits one contribution per `session_model_usage` row and accumulates the raw
-/// per-session sums used by the residual reconciliation.
+/// Emits one contribution per `session_model_usage` row that carries a model, a
+/// timestamp, and a date inside the cutoff, and accumulates the raw per-session
+/// sums used by the residual reconciliation.
 fn collect_per_model_rows(
     conn: &Connection,
     cutoff: &Option<String>,
@@ -183,16 +186,17 @@ fn collect_per_model_rows(
 }
 
 /// Attributes each session's positive residual (aggregate minus the sum of its
-/// per-model rows) to the session's recorded model, mirroring Hermes's insights
-/// view so partial or missing per-model rows are not dropped.
+/// per-model rows) to the session's recorded model.
 fn reconcile_session_residuals(
     conn: &Connection,
     cutoff: &Option<String>,
     summed: &FastHashMap<String, RowSums>,
     out: &mut Vec<UsageContribution>,
 ) -> Result<()> {
-    // The `sessions` table is core to Hermes, but stay defensive: if it is
-    // somehow absent, the per-model rows already collected are still returned.
+    // Opening the connection already probed `sessions`, so a failed prepare
+    // most likely means a column this build names has moved, though a corrupt
+    // or unreadable database lands here too. Either way the per-model rows
+    // already collected are still returned.
     let Ok(mut stmt) = conn.prepare(
         "SELECT id, model, input_tokens, output_tokens, cache_read_tokens, \
                 cache_write_tokens, reasoning_tokens, estimated_cost_usd, \
@@ -270,11 +274,12 @@ fn reconcile_session_residuals(
     Ok(())
 }
 
-/// Builds the Claude-style flat usage value from a row's token columns.
+/// Packs a row's token columns into the disjoint token buckets.
 ///
 /// Hermes records non-cached input separately from cache reads (matching the
-/// Claude convention), so the columns map straight onto the field names
-/// `extract_token_counts` understands.
+/// Claude convention), so no column has to be split apart here. Reasoning is
+/// the one column this reader treats as overlapping, and both callers subtract
+/// it out of `output` before getting here.
 fn session_usage_value(
     input: i64,
     output: i64,

--- a/src/core/src/session/mod.rs
+++ b/src/core/src/session/mod.rs
@@ -1,7 +1,8 @@
 //! Shared session-file parsing layer.
 //!
 //! Every supported provider writes its session history to disk in a
-//! provider-specific JSON, JSONL, or SQLite shape.
+//! provider-specific JSON, JSONL (zstd-framed for DeepSeek Harness), or SQLite
+//! shape.
 //! This module owns the "turn raw bytes into a typed
 //! [`crate::CodeAnalysis`]" boundary so both of the features that consume
 //! session files — [`crate::analysis`] (aggregated tool-call metrics) and

--- a/src/core/src/session/opencode.rs
+++ b/src/core/src/session/opencode.rs
@@ -1,6 +1,6 @@
 //! OpenCode session reader (SQLite, not JSONL).
 //!
-//! Unlike the five file-based providers, OpenCode stores every session in a
+//! Unlike the file-based providers, OpenCode stores every session in a
 //! single SQLite database at `~/.local/share/opencode/opencode.db` (WAL mode).
 //! This module owns the "SQLite rows -> typed [`CodeAnalysis`]" boundary, so
 //! both the `usage` and `analysis` aggregators consume the same shape the
@@ -11,13 +11,16 @@
 //! - [`read_opencode_usage`] reads assistant messages for per-model tokens and
 //!   cost, with an older `session`-table fallback.
 //! - [`read_opencode_analysis`] additionally folds the `part` table's tool
-//!   calls (`read`, `edit`, `write`, `bash`, `todowrite`) into
+//!   calls (`read`, `edit`, `write`, `bash`, `todowrite`, `apply_patch`) into
 //!   per-message file-operation metrics.
 //!
-//! Token columns map onto the Claude-style flat usage shape so the existing
-//! `merge_usage_values` / `extract_token_counts` / LiteLLM cost path works
-//! unchanged. Assistant messages carry their own `providerID` + `modelID`, so
-//! sessions that switch model mid-stream are split before aggregation.
+//! Token columns map onto the Claude-style flat usage shape, so the shared
+//! `merge_usage_values` / `extract_token_counts` path handles them unchanged.
+//! Cost is the exception: the usage layer prices an OpenCode model from tokens
+//! only on an exact LiteLLM match, and otherwise falls back to the per-message
+//! cost this module returns. Assistant messages carry their own `providerID` +
+//! `modelID`, so sessions that switch model mid-stream are split before
+//! aggregation.
 
 use crate::VERSION;
 use crate::constants::FastHashMap;
@@ -44,7 +47,8 @@ use std::path::Path;
 /// `conversation_usage`, keyed by that message's provider-qualified model id,
 /// and `stored_cost` is OpenCode's own cost for that message. The date comes
 /// from the assistant message timestamp and is filtered by `time_range`,
-/// matching the file-walker semantics.
+/// matching the file-walker semantics. Databases with no `message` table fall
+/// back to one row per `session`, dated by `time_updated`.
 ///
 /// # Errors
 ///
@@ -87,13 +91,13 @@ pub(crate) fn read_opencode_usage_contributions(
 
 /// Reads per-session file-operation metrics from the OpenCode database.
 ///
-/// Like [`read_opencode_usage`], but also folds each session's tool calls from
-/// the `part` table into `tool_call_counts` and the `total_*` line/character
+/// Like [`read_opencode_usage`], but also folds each row's tool calls from the
+/// `part` table into `tool_call_counts` and the `total_*` line/character
 /// counts. `mode` controls whether the heavy per-operation detail bodies are
-/// retained ([`ParseMode::Full`]) or skipped ([`ParseMode::UsageOnly`]); the
-/// aggregated `analysis` view uses `UsageOnly`. Message/session metadata and
-/// tool parts are read inside one transaction so a concurrent OpenCode commit
-/// cannot split the result across two SQLite snapshots.
+/// retained ([`ParseMode::Full`]) or skipped ([`ParseMode::UsageOnly`]).
+/// Message/session metadata and tool parts are read inside one transaction so
+/// a concurrent OpenCode commit cannot split the result across two SQLite
+/// snapshots.
 ///
 /// # Errors
 ///
@@ -135,7 +139,7 @@ pub(crate) struct OpenCodeAnalysisRead {
     pub expected_records: usize,
     /// Selected rows that produced a normalized `CodeAnalysis`.
     pub parsed_records: usize,
-    /// Completed known tool parts with unsupported analyzer fields.
+    /// Tool parts the analyzer could not normalize, including unreadable JSON.
     pub failed_tool_parts: usize,
 }
 
@@ -651,12 +655,6 @@ fn collect_message_analysis(
     })
 }
 
-/// Dispatches a single `part` (type `tool`) onto the session parse state.
-///
-/// Only the tools the analyzer tracks across providers are folded in
-/// (`read`, `edit`, `write`, `bash`, `todowrite`, `apply_patch`); auxiliary
-/// tools such as `task`, `grep`, `glob`, `webfetch`, and `question` are ignored
-/// to stay consistent with the other providers' tool-count semantics.
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum ToolPartOutcome {
     Irrelevant,
@@ -664,6 +662,12 @@ enum ToolPartOutcome {
     Unsupported,
 }
 
+/// Dispatches a single `part` (type `tool`) onto the session parse state.
+///
+/// Only the tools the analyzer tracks across providers are folded in
+/// (`read`, `edit`, `write`, `bash`, `todowrite`, `apply_patch`); auxiliary
+/// tools such as `task`, `grep`, `glob`, `webfetch`, and `question` are ignored
+/// to stay consistent with the other providers' tool-count semantics.
 fn apply_tool_part(state: &mut SessionParseState, data: &Value) -> ToolPartOutcome {
     let tool = data.get("tool").and_then(|v| v.as_str()).unwrap_or("");
     if !matches!(
@@ -772,7 +776,7 @@ fn apply_patch_text(state: &mut SessionParseState, patch_text: &str, ts: i64) {
     }
 }
 
-/// One file hunk extracted from an OpenCode `apply_patch` tool call.
+/// One file's patch section extracted from an OpenCode `apply_patch` tool call.
 struct OpenCodePatch {
     action: String,
     file_path: String,
@@ -877,11 +881,11 @@ fn extract_patch_strings(lines: &[String]) -> (String, String) {
     (old_str, new_str)
 }
 
-/// Builds the Claude-style flat usage value from a session's token columns.
+/// Packs OpenCode's token counters into the shared usage buckets.
 ///
 /// OpenCode records non-cached input separately from cache reads (input is
-/// disjoint from cache, matching the Claude convention), so the columns map
-/// straight onto the field names `extract_token_counts` understands.
+/// disjoint from cache, matching the Claude convention), so each counter drops
+/// into one bucket with no adjustment.
 fn session_usage_value(
     input: i64,
     output: i64,
@@ -927,7 +931,7 @@ fn parse_model_id(raw: &str) -> Option<String> {
             let s = s.trim();
             (!s.is_empty()).then(|| s.to_string())
         }
-        // Not valid JSON: treat the column as a plain model name.
+        // Not a JSON object or string: treat the column as a plain model name.
         _ => Some(raw.to_string()),
     }
 }

--- a/src/core/src/session/parser.rs
+++ b/src/core/src/session/parser.rs
@@ -25,8 +25,9 @@ use std::rc::Rc;
 
 /// Content-safe warning summary used by the CLI's single-file path.
 ///
-/// This type is public only because Cargo builds `src/main.rs` as a separate
-/// crate from the library. Provider diagnostics remain crate-private.
+/// Public only because the binary is a separate workspace crate and so can
+/// reach nothing narrower than `pub`. The richer provider diagnostics stay
+/// crate-private.
 #[doc(hidden)]
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct SessionFileParseDiagnostics {
@@ -34,8 +35,9 @@ pub struct SessionFileParseDiagnostics {
 }
 
 impl SessionFileParseDiagnostics {
-    /// Number of malformed, unrecognized, or analyzer-relevant records skipped
-    /// after another record from the same source was recognized successfully.
+    /// Number of malformed, unrecognized, or unsupported analyzer records that
+    /// an otherwise-successful parse skipped. Zero when the whole source
+    /// failed, since that surfaces as an error instead.
     pub fn skipped_records(self) -> usize {
         self.skipped_records
     }
@@ -97,15 +99,12 @@ impl ParseWarningSummary {
 }
 
 /// Parses a session file (JSONL or JSON) and returns the result as a
-/// `serde_json::Value` (the CLI single-file dump path).
+/// `serde_json::Value`.
 ///
-/// Internally this is a thin wrapper over [`parse_session_file_typed`]; the
-/// conversion to `Value` happens once at the edge here rather than inside the
-/// cache, which keeps long sessions from being duplicated between typed and
-/// `Value` forms when multiple commands run against the same file.
-///
-/// An empty input yields `{}` (not a populated-but-empty `CodeAnalysis`), to
-/// preserve historical CLI behaviour.
+/// A thin wrapper over [`parse_session_file_typed`], kept for library callers
+/// and the golden tests; the CLI's own single-file path goes through
+/// `parse_session_file_with_diagnostics`. An empty input yields `{}` (not a
+/// populated-but-empty `CodeAnalysis`), to preserve historical CLI behaviour.
 ///
 /// # Errors
 ///
@@ -125,8 +124,8 @@ impl ParseWarningSummary {
 pub fn parse_session_file_to_value<P: AsRef<Path>>(path: P) -> Result<Value> {
     let analysis = parse_session_file_typed(path)?;
     if analysis.records.is_empty() && analysis.extension_name.is_empty() {
-        // Preserve historical behaviour: empty input → `{}` rather than a
-        // fully-populated but empty `CodeAnalysis` object.
+        // Empty input never reaches `finalize`, so a blank `extension_name`
+        // is what marks it.
         return Ok(serde_json::json!({}));
     }
     Ok(serde_json::to_value(&analysis)?)
@@ -524,18 +523,18 @@ where
 ///
 /// Reads JSONL records one line at a time and feeds a stateful classifier that
 /// commits to a provider as soon as any record carries a distinctive marker.
-/// Because the classifier returns `None` when it has not seen a positive
-/// signal yet, we simply keep peeking until one appears (or EOF). There is
-/// no arbitrary upper bound on how long a Claude metadata preamble may
-/// be — previously a 7+ line preamble silently mis-classified the whole
-/// session as Codex because the 8-record peek window ran out before the
-/// first `parentUuid` record was read.
+/// The classifier returns `None` until it sees a positive signal, so this loop
+/// keeps peeking until one appears (or EOF): a Claude metadata preamble has no
+/// bounded length, and the previous fixed 8-record peek window silently
+/// mis-classified any session whose first `parentUuid` record sat past it as
+/// Codex, dropping that session's usage.
 ///
-/// If the entire file is consumed without any marker firing, the default
-/// is Codex: Codex rollout logs usually contain one of the recognised
-/// `type` values (`session_meta`, `turn_context`, …) so a synthetic file
-/// with no markers is most likely a deliberately-empty Codex fixture
-/// rather than a silently-broken Claude log.
+/// If the entire file is consumed without any marker firing, the default is
+/// Codex. The recorded reason is a likelihood tradeoff rather than a proof: a
+/// real Codex rollout log does carry one of the recognised `type` values, so a
+/// file with no marker at all is more likely a deliberately-empty Codex fixture
+/// than a silently-broken Claude log. Nothing in the marker set forces that
+/// answer — treat it as the tie-break it is.
 ///
 /// Returns `Ok(None)` when the file is empty or its first line is not JSON
 /// (a pretty-printed dump), signalling the caller to use the `read_json`
@@ -570,21 +569,17 @@ fn stream_parse_autodetect(path: &Path, mode: ParseMode) -> Result<Option<Parsed
                 first_line_was_json.get_or_insert(true);
                 let classification = classifier.push(&v);
                 buffered.push(v);
-                // Each record is inspected once by the stateful classifier.
-                // As soon as it has a confident verdict, hand the buffered
-                // prefix and remaining reader to the dispatcher.
                 if let Some(found) = classification {
                     ext = Some(found);
                     break;
                 }
             }
             Err(err) => {
-                // A non-JSON line on the very first record means the file
-                // is a pretty-printed single-object dump (Copilot legacy
-                // shape or similar); let the caller fall through to
-                // `read_json`. Otherwise we have buffered at least one
-                // valid record already — stop peeking and let the
-                // dispatcher decide.
+                // A non-JSON line on the very first record means the file is a
+                // pretty-printed single-object document (Grok's
+                // `signals.json`); let the caller fall through to `read_json`.
+                // Past that, at least one valid record is already buffered —
+                // stop peeking and let the dispatcher decide.
                 if buffered.is_empty() {
                     first_line_was_json = Some(false);
                     break;
@@ -603,9 +598,6 @@ fn stream_parse_autodetect(path: &Path, mode: ParseMode) -> Result<Option<Parsed
         return Ok(None);
     }
 
-    // If the whole file was consumed without any distinctive marker, fall
-    // back to Codex — a JSONL file with no Claude / Gemini / Copilot / Grok
-    // markers is almost certainly a Codex log (or a synthetic fixture).
     let ext = ext.unwrap_or(ExtensionType::Codex);
     let parsed = dispatch_streaming_buffered(
         ext,
@@ -673,9 +665,10 @@ fn trim_ascii_whitespace(bytes: &[u8]) -> &[u8] {
 
 /// Streams the rest of the file, prepending any already-parsed records.
 ///
-/// JSONL providers feed buffered records through their typed shape and chain
-/// the remaining reader. Grok reopens its single aggregate JSON object so its
-/// sibling session files remain available to the provider parser.
+/// Claude / Codex / Copilot turn each buffered `Value` into their typed record
+/// and chain the remaining reader; Gemini's parser consumes `Value`s directly.
+/// Grok drops the reader and reopens by path, because its parser also reads the
+/// sibling `summary.json` and `updates.jsonl`.
 #[allow(clippy::too_many_arguments)] // parse plumbing; a struct would obscure the seams
 fn dispatch_streaming_buffered(
     ext: ExtensionType,
@@ -717,10 +710,6 @@ fn dispatch_streaming_buffered(
                 .map(|parsed| merge_extra_diagnostics(parsed, &extra_diagnostics))
         }
         ExtensionType::Copilot => {
-            // Copilot CLI emits one event per line under
-            // `session-state/<uuid>/events.jsonl`. The streaming path sees
-            // this as a sequence of parseable `Value`s whose very first
-            // line is `type == "session.start"`.
             let rest = iter_jsonl_values(
                 &mut reader,
                 Rc::clone(&extra_diagnostics),
@@ -734,11 +723,9 @@ fn dispatch_streaming_buffered(
                 .map(|parsed| merge_extra_diagnostics(parsed, &extra_diagnostics))
         }
         ExtensionType::Gemini => {
-            // Gemini sessions are line-delimited event streams: the first
-            // line is a session-meta record carrying `sessionId` etc.,
-            // and every subsequent line is an individual event. Feed the
-            // already-buffered lines plus the rest of the reader into
-            // `parse_gemini_events`.
+            // Gemini's first line is the session-meta record and every later
+            // line an event, so the first buffered value is peeled off before
+            // the rest of the stream reaches the event parser.
             (|| {
                 let mut iter = buffered.into_iter();
                 let first = iter
@@ -770,9 +757,8 @@ fn dispatch_streaming_buffered(
         // OpenCode stores sessions in a SQLite database, not a JSONL file, so
         // it never flows through the file parser. See `session::opencode`.
         ExtensionType::OpenCode => Ok(empty_parsed_analysis()),
-        // Cursor sessions live in per-conversation SQLite blob stores (analysis)
-        // and its billing tokens come from an API (usage), never a JSONL file.
-        // See `session::cursor`.
+        // Cursor sessions live in per-conversation SQLite blob stores, never a
+        // JSONL file. See `session::cursor`.
         ExtensionType::Cursor => Ok(empty_parsed_analysis()),
         // Hermes stores usage in a single SQLite database, not a JSONL file, so
         // it never flows through the file parser. See `session::hermes`.
@@ -855,9 +841,12 @@ where
 
 /// Iterator that yields raw [`Value`]s, one per non-empty line in the reader.
 ///
-/// Used by parsers (Gemini / Copilot) that need to dispatch per-event on a
-/// runtime-typed shape before committing to a strongly-typed struct, since
-/// different event types carry completely different payloads.
+/// Gemini's parser consumes `Value`s directly, which is how a walked Gemini
+/// session is parsed: `stream_parse_known`'s `_` arm routes it here with no
+/// classifier involved. The auto-detect path sends Claude / Codex / Copilot
+/// through this too, since the classifier has already materialized their
+/// buffered prefix as `Value`s; those three convert each one into their typed
+/// record straight away.
 fn iter_jsonl_values<'a>(
     reader: &'a mut BufReader<File>,
     diagnostics: Rc<RefCell<ParseDiagnostics>>,
@@ -865,7 +854,7 @@ fn iter_jsonl_values<'a>(
     io_failure: Rc<RefCell<Option<String>>>,
 ) -> impl Iterator<Item = Value> + 'a {
     // Reuse one byte buffer via `read_until` instead of allocating a `String`
-    // per line (`reader.lines()`), mirroring `iter_jsonl_typed`.
+    // per line (`reader.lines()`).
     let mut line = Vec::with_capacity(buffer::AVG_JSONL_LINE_SIZE);
     let mut line_number = 0_usize;
 
@@ -1087,9 +1076,11 @@ fn merge_extra_diagnostics(
     parsed
 }
 
-/// Legacy dispatch used by the pretty-printed JSON fallback. Operates on an
-/// already-materialised `Vec<Value>` — preferred to be avoided in the hot
-/// path, but needed for Gemini/Copilot dumps that span multiple lines.
+/// Whole-file dispatch over an already-materialised `Vec<Value>`.
+///
+/// Reached only when the streaming peek could not read line one as JSON, which
+/// in practice means a pretty-printed single-object document such as Grok's
+/// `signals.json`.
 fn dispatch_by_vec(
     data: Vec<Value>,
     ext_type: ExtensionType,
@@ -1122,9 +1113,8 @@ fn dispatch_by_vec(
         | ExtensionType::OpenCode
         | ExtensionType::Cursor
         | ExtensionType::Hermes => {
-            // Copilot/Gemini only support the JSONL event stream, while OpenCode,
-            // Cursor, and Hermes are read from SQLite (see `session::opencode` /
-            // `session::cursor` / `session::hermes`), not a file. A file that
+            // Gemini only supports the JSONL event stream, while OpenCode,
+            // Cursor, and Hermes are read from SQLite, not a file. A file that
             // falls through to this branch (e.g. a stray pretty-printed export)
             // has no parser for its shape — return an empty analysis instead of
             // silently mis-parsing.
@@ -1158,7 +1148,7 @@ fn empty_parsed_analysis() -> ParsedAnalysis {
     ParsedAnalysis::new(empty_analysis(), ParseDiagnostics::default())
 }
 
-/// Attaches runtime metadata (user, machine, version) expected in the output.
+/// Stamps the output-level metadata: user, provider name, machine, version.
 fn finalize(mut parsed: ParsedAnalysis, ext_type: ExtensionType) -> ParsedAnalysis {
     parsed.analysis.user = get_current_user();
     parsed.analysis.extension_name = ext_type.to_string();

--- a/src/core/src/session/state.rs
+++ b/src/core/src/session/state.rs
@@ -97,12 +97,10 @@ impl SessionParseState {
     /// Creates an empty parse state with the given detail-retention `mode`.
     ///
     /// In [`ParseMode::Full`] the detail `Vec`s are pre-sized to typical session
-    /// sizes. `unique_files` is pre-sized in both modes because
-    /// `total_unique_files` is a scalar total that must stay exact.
+    /// sizes; in [`ParseMode::UsageOnly`] they stay empty, so pre-sizing them is
+    /// skipped. `unique_files` is populated in both modes — `total_unique_files`
+    /// is a scalar total that must stay exact — so it is pre-sized in both.
     pub fn with_mode(mode: ParseMode) -> Self {
-        // Pre-allocate Vecs with reasonable capacity estimates based on
-        // typical session sizes. In `UsageOnly` mode we skip the
-        // pre-allocation because the vecs stay empty.
         let pre = matches!(mode, ParseMode::Full);
         Self {
             mode,
@@ -228,7 +226,6 @@ impl SessionParseState {
     /// [`SessionParseState::add_write_detail`]. Otherwise delegates to
     /// [`SessionParseState::add_edit_detail_raw`].
     pub fn add_edit_detail(&mut self, path: &str, old: &str, new: &str, ts: i64) {
-        // If old is empty and new has content, treat as write
         if old.trim_end_matches('\n').is_empty() && !new.trim_end_matches('\n').is_empty() {
             self.add_write_detail(path, new, ts);
             return;
@@ -408,7 +405,6 @@ mod tests {
 
     #[test]
     fn test_session_parse_state_new() {
-        // Test creating a new SessionParseState
         let state = SessionParseState::new();
 
         assert_eq!(state.total_write_lines, 0);
@@ -423,7 +419,6 @@ mod tests {
 
     #[test]
     fn test_add_read_detail() {
-        // Test adding a read operation
         let mut state = SessionParseState::new();
         state.folder_path = "/test/folder".to_string();
 
@@ -437,7 +432,6 @@ mod tests {
 
     #[test]
     fn test_add_read_detail_ignores_empty() {
-        // Test that empty content is ignored
         let mut state = SessionParseState::new();
 
         state.add_read_detail("test.rs", "", 1234567890);
@@ -449,7 +443,6 @@ mod tests {
 
     #[test]
     fn test_add_write_detail() {
-        // Test adding a write operation
         let mut state = SessionParseState::new();
         state.folder_path = "/test/folder".to_string();
 
@@ -463,7 +456,6 @@ mod tests {
 
     #[test]
     fn test_add_edit_detail() {
-        // Test adding an edit operation
         let mut state = SessionParseState::new();
         state.folder_path = "/test".to_string();
 
@@ -482,7 +474,6 @@ mod tests {
 
     #[test]
     fn test_add_edit_detail_empty_old_becomes_write() {
-        // Test that edit with empty old content becomes a write
         let mut state = SessionParseState::new();
         state.folder_path = "/test".to_string();
 
@@ -497,7 +488,6 @@ mod tests {
 
     #[test]
     fn test_add_run_command() {
-        // Test adding a run command
         let mut state = SessionParseState::new();
         state.folder_path = "/workspace".to_string();
 
@@ -510,7 +500,6 @@ mod tests {
 
     #[test]
     fn test_add_run_command_ignores_empty() {
-        // Test that empty commands are ignored
         let mut state = SessionParseState::new();
 
         state.add_run_command("", "description", 1234567890);
@@ -522,7 +511,6 @@ mod tests {
 
     #[test]
     fn test_normalize_path_absolute() {
-        // Test normalizing absolute paths
         let mut state = SessionParseState::new();
         state.folder_path = "/workspace".to_string();
 
@@ -532,7 +520,6 @@ mod tests {
 
     #[test]
     fn test_normalize_path_relative() {
-        // Test normalizing relative paths
         let mut state = SessionParseState::new();
         state.folder_path = "/workspace".to_string();
 
@@ -542,7 +529,6 @@ mod tests {
 
     #[test]
     fn test_normalize_path_empty_folder() {
-        // Test normalizing when folder_path is empty
         let state = SessionParseState::new();
 
         let result = state.normalize_path("file.rs");
@@ -551,7 +537,6 @@ mod tests {
 
     #[test]
     fn test_normalize_path_empty_input() {
-        // Test normalizing empty path
         let mut state = SessionParseState::new();
         state.folder_path = "/workspace".to_string();
 
@@ -561,16 +546,13 @@ mod tests {
 
     #[test]
     fn test_unique_files_tracking() {
-        // Test that unique files are tracked correctly
         let mut state = SessionParseState::new();
         state.folder_path = "/project".to_string();
 
-        // Add operations on same file
         state.add_read_detail("file1.rs", "content", 1);
         state.add_write_detail("file1.rs", "content", 2);
         state.add_edit_detail("file1.rs", "old", "new", 3);
 
-        // Add operations on different file
         state.add_read_detail("file2.rs", "content", 4);
 
         assert_eq!(state.unique_files.len(), 2);
@@ -580,7 +562,6 @@ mod tests {
 
     #[test]
     fn test_character_counting() {
-        // Test that character counts are correct
         let mut state = SessionParseState::new();
 
         state.add_read_detail("file.txt", "hello", 1);
@@ -595,7 +576,6 @@ mod tests {
 
     #[test]
     fn test_into_record() {
-        // Test converting state into a record
         let mut state = SessionParseState::new();
         state.folder_path = "/test".to_string();
         state.git_remote = "https://github.com/test/repo".to_string();
@@ -619,7 +599,6 @@ mod tests {
 
     #[test]
     fn test_default_trait() {
-        // Test Default trait implementation
         let state = SessionParseState::default();
 
         assert_eq!(state.total_write_lines, 0);
@@ -629,23 +608,18 @@ mod tests {
 
     #[test]
     fn test_multiple_operations() {
-        // Test handling multiple operations
         let mut state = SessionParseState::new();
         state.folder_path = "/workspace".to_string();
 
-        // Multiple reads
         state.add_read_detail("a.rs", "line1", 1);
         state.add_read_detail("b.rs", "line1\nline2", 2);
         state.add_read_detail("c.rs", "line1\nline2\nline3", 3);
 
-        // Multiple writes
         state.add_write_detail("out1.txt", "content1", 4);
         state.add_write_detail("out2.txt", "content2", 5);
 
-        // Multiple edits
         state.add_edit_detail("edit1.rs", "old", "new", 6);
 
-        // Multiple commands
         state.add_run_command("ls", "list files", 7);
         state.add_run_command("pwd", "print dir", 8);
 


### PR DESCRIPTION
Slice 1 of the comment sweep tracked in #157. Closes #158.

The parsing layer: `src/core/src/session/`, `src/core/src/scan/`, `src/core/src/models/`. All 30 files read in full, 29 changed.

## What this is

A **comments-only** diff. Not one non-comment character changed in any file — asserted mechanically, not by eye: every changed file's source was stripped of comments (string-, char- and raw-string-aware, so a `//` inside a URL literal is not mistaken for one) on both `main` and this branch, and the results compared byte for byte.

Three problems were mixed together in this layer, all three addressed: comments stating something the code no longer does, comments restating the line below them, and comments spending four paragraphs where one sentence would do.

## Method

Ten workers, one disjoint file slice each, grouped so a provider's parser and its model types landed with the same reader. Every worker read its files in full with the Read tool — no script produced any edit — and reported a ledger covering every file it held.

Then three review passes, because they fail differently and only the first is visible in `git diff`:

1. **Deletions.** 191 distinctive tokens were removed by the diff; 9 no longer resolve anywhere in the tree. Each was read: 4 are deliberate removals of names the code genuinely dropped, 3 are corrections made in place, 2 are artifacts of the extraction regex. No reason was lost.
2. **Rewrites.** A rewritten sentence is a new factual claim nobody reviewed. Three refute-first reviewers went over every `+` line with the implementation open, defaulting to "refuted" where a claim could not be established. **They killed 16 claims this sweep itself introduced** — the full list is below. All 16 went back to the worker that wrote them; 15 were conceded and fixed, 1 was defended with an argument that held up.
3. **Files reported clean.** Four files came back "no change needed" and so never entered the diff, where a miss is structurally unreviewable. An independent pass found real defects in **three of the four**.

## The claims the sweep got wrong, and what they became

These are the expensive kind: a confidently wrong replacement reads as freshly maintained.

| Where | What the sweep wrote | Why it failed |
| --- | --- | --- |
| `session/copilot.rs` | streamed output tokens sum to the shutdown total, "so keeping both would double-count" | The graft `insert`s on the same key, so dropping the guard **overwrites** the authoritative row — an under-count. Premise was also an invented provider fact. |
| `session/codex.rs` | "Skip **only** when the paired direct `apply_patch` already counted this call id" | The set has two writers, so a repeat event is skipped too — and it contradicted a comment kept 115 lines up in the same function. |
| `session/claude.rs` | folding it in would credit lines "to a tool the main session never reported a result for" | The record *does* report a result; it is just string-shaped, which the same sentence's first half says. |
| `session/cursor.rs` | errors "only when stores were found and every one failed" | A traversal failure alone errors with no store found — contradicting the field doc two lines above, corrected in the same diff. |
| `session/hermes.rs` | a failed prepare "means a column has moved" | Also fires on a corrupt or unreadable database, both silently swallowed. |
| `models/filter.rs` | the CLI "re-exports it along with the period-flag resolvers" | The CLI re-exports neither the type nor a plural set — one item, `resolve_time_range_with_default`. |
| `session/parser.rs` | the Codex default is "almost always a Codex log whose `type` values happen to be absent" | Circular: Codex logs are identified *by* those values. The original's real tradeoff had been deleted and now reads as an explicit tie-break. |

Plus nine narrower ones: invented rationales ("because the CLI's tool set is open-ended"), false universals ("every other name already went through X"), claims about what a provider does or does not send stated as if the code proved them, and one qualifier that turned a true sentence false.

## The four files reported clean

- `session/diagnostics.rs` — a doc claimed its **wording** guarantees every surface says recognized records were still counted. On one surface that is delivered by a `starts_with("partially parsed:")` prefix test in another file, undocumented and untested. Reword the tail and the log silently starts calling partial parses dropped sources.
- `session/diagnostics.rs` — "materializes the historical JSON object only at the public API boundary" is false for 3 of 4 call sites.
- `models/aggregate.rs` — "the display layer builds and reads it without either depending on the other". The display layer depends on core directly and heavily.
- `session/mod.rs` — the on-disk shapes sentence omitted DeepSeek's zstd-framed case, though `dsh` is listed as a module three lines below.
- `session/sqlite.rs` — genuinely held up, verified claim by claim.

## Verification

Local, all green on the final tree:

- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- `cargo test --workspace` — all suites pass, including the **31 doctests in `vct-core`**
- `cargo doc --no-deps --workspace` — 12 warnings against a captured baseline of 13; the difference is exactly the one this PR fixes (`session/hermes.rs:15` linked to a private item). No new warning.
- `uvx pre-commit run -a` clean

Two of those cover gaps CI has: nothing in `test.yml` compiles a doctest (`cargo build`, `llvm-cov` and `cargo check --all-targets` all skip them), and rustdoc warnings are warn-by-default against pre-existing noise. Six files here carry compiled doctests, so green CI alone would not have proved they still build.

## Two things worth a reviewer's attention

**A restored comment.** `models/provider.rs:66` keeps `// Check for "claude" prefix`, which reads inconsistent beside its three deleted siblings. It is load-bearing for the build: that branch is the only one of six written as a nested `if`, and the comment sits between the two, suppressing `collapsible_if`. Removing it turned CI red. Restoring it is a zero delta against `main`; flattening the branch is a code change and belongs in its own PR.

**Two schemars traps, not one.** `config/mod.rs` is documented as the place where a doc comment compiles into a committed artifact. `models/filter.rs` is a second: `TimeRange`'s four variant docs are emitted verbatim into `vct.schema.json` (lines 40, 45, 50, 55) and guarded by a drift test. They were left untouched deliberately.

## Bugs found, not fixed

Reading 2,685 comment lines against the code they describe surfaced **23 defects**, filed separately per the working agreement so that no behavior change hides inside a comments-only diff. The two worth naming here are a possible reasoning-token double count for OpenCode, and a missing join that makes `vct analysis --all` report bogus schema drift.

`CLAUDE.md` disagreements were recorded rather than edited, for #162 to spend.

---

Opened-by: Claude Opus 5
