### PR TITLE
refactor(models): flatten claude prefix branch to match siblings (#196)

### DIFF
--- a/src/core/src/models/provider.rs
+++ b/src/core/src/models/provider.rs
@@ -62,17 +62,15 @@ impl Provider {
     pub const fn from_model_name(model: &str) -> Self {
         let bytes = model.as_bytes();
 
-        if bytes.len() >= 6 {
-            // Check for "claude" prefix
-            if bytes[0] == b'c'
-                && bytes[1] == b'l'
-                && bytes[2] == b'a'
-                && bytes[3] == b'u'
-                && bytes[4] == b'd'
-                && bytes[5] == b'e'
-            {
-                return Self::ClaudeCode;
-            }
+        if bytes.len() >= 6
+            && bytes[0] == b'c'
+            && bytes[1] == b'l'
+            && bytes[2] == b'a'
+            && bytes[3] == b'u'
+            && bytes[4] == b'd'
+            && bytes[5] == b'e'
+        {
+            return Self::ClaudeCode;
         }
 
         if bytes.len() >= 7


### PR DESCRIPTION
## Summary
Flattens the nested `if` for the claude prefix detection in `Provider::from_model_name` to match the style of all five sibling branches.

## Changes
- Replaced the two-level `if bytes.len() >= 6 { if ... { ... } }` with a single flat `if bytes.len() >= 6 && ...` block
- Removed the `// Check for "claude" prefix` comment that was load-bearing only because it suppressed `clippy::collapsible_if`

## Why
All five other prefix checks (copilot, gemini, grok, gpt, o1/o3) are written as flat `if` blocks. The claude branch was the sole nested form, kept only because a comment between the two `if` levels suppressed the clippy lint. Flattening it makes the code consistent and removes the comment dependency.

Closes #196