### PR TITLE
ci: use pull_request_target so labeler works on fork PRs

### DIFF
--- a/.github/workflows/auto_labeler.yml
+++ b/.github/workflows/auto_labeler.yml
@@ -1,14 +1,7 @@
 name: Pull Request Labeler
 
-# pull_request_target, because GitHub hands a pull_request run a read-only
-# GITHUB_TOKEN when the pull request comes from a fork, whatever permissions
-# this workflow asks for. Labeling an outside contribution died there with
-# "Resource not accessible by integration".
-#
-# That event grants write access, which is why this job must never check out
-# the pull request's own code. It does not need a working tree anyway: with no
-# configuration file on the runner, the action reads this repository's copy
-# over the API.
+# pull_request_target because a fork's pull_request run gets a read-only token;
+# never check out the PR's own code under it.
 
 on:
   pull_request_target:

--- a/.github/workflows/auto_labeler.yml
+++ b/.github/workflows/auto_labeler.yml
@@ -1,9 +1,22 @@
 name: Pull Request Labeler
 
-on:
-  pull_request:
+# pull_request_target, because GitHub hands a pull_request run a read-only
+# GITHUB_TOKEN when the pull request comes from a fork, whatever permissions
+# this workflow asks for. Labeling an outside contribution died there with
+# "Resource not accessible by integration".
+#
+# That event grants write access, which is why this job must never check out
+# the pull request's own code. It does not need a working tree anyway: with no
+# configuration file on the runner, the action reads this repository's copy
+# over the API.
 
-permissions: write-all
+on:
+  pull_request_target:
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
 
 jobs:
   labeler:
@@ -11,12 +24,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 1
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Labeler
         id: labeler
         uses: actions/labeler@v7


### PR DESCRIPTION
## Problem

The Labeler job fails on every pull request opened from a fork:

```
##[error]HttpError: Resource not accessible by integration
```

`permissions: write-all` cannot fix this. GitHub caps the token before the run starts:

> With the exception of `GITHUB_TOKEN`, secrets are not passed to the runner when a workflow is triggered from a forked repository. The `GITHUB_TOKEN` has read-only permissions in pull requests from forked repositories.

So outside contributions land with no type label, and their PR shows a red check that the contributor cannot do anything about.

## Change

Switch the trigger to `pull_request_target`, which runs in the context of the base repository's default branch and therefore carries a writable token. This is what `actions/labeler` recommends for exactly this error.

Two things follow from that event, and both are part of the fix rather than incidental tidying:

- **The checkout step is removed.** `pull_request_target` gives the job write access, so checking out the pull request's own code is the classic pwn-request shape. The action does not need a working tree: with no configuration file on the runner it reads this repository's copy over the API.
- **`permissions: write-all` is narrowed** to the three the action actually uses.

Labeling behaviour is unchanged. `pull_request_target` fires on the same activity types, and the head-branch and changed-files rules in `.github/labeler.yml` come from the API either way.

## On verifying this

Green CI on this PR is **not** evidence the fix works, for two independent reasons:

1. This PR does not come from a fork, so the old workflow would have passed here too.
2. The Labeler check does not run on this PR at all. `pull_request` takes its definition from the head branch, which no longer declares that trigger; `pull_request_target` takes its definition from the base branch, which does not declare it yet. The new trigger starts working on the pull request after this one.

The real check is the next pull request from a fork.

---

Opened-by: Claude Opus 5
