### PR TITLE
fix(gemini): drop the no-op git-remote fallback

### DIFF
--- a/src/core/src/session/gemini.rs
+++ b/src/core/src/session/gemini.rs
@@ -11,7 +11,7 @@ use crate::models::*;
 use crate::pricing::{TierClassifier, TierThresholds};
 use crate::session::diagnostics::{ParseDiagnostics, ParsedAnalysis};
 use crate::session::state::{ParseMode, SessionParseState};
-use crate::utils::{get_git_remote_url, parse_iso_timestamp, process_gemini_usage};
+use crate::utils::{parse_iso_timestamp, process_gemini_usage};
 use anyhow::Result;
 use serde::Deserialize;
 use serde_json::Value;
@@ -359,18 +359,14 @@ fn record_message_diagnostics(message: &GeminiAnalysisMessage, diagnostics: &mut
 
 /// Converts the accumulated state into a single-record [`CodeAnalysis`],
 /// stamping the `task_id` from the session meta.
+///
+/// Gemini CLI records no workspace path, so `folder_path` and `git_remote`
+/// both stay empty; there is nothing to resolve a remote against.
 fn finalize_record(
-    mut state: SessionParseState,
+    state: SessionParseState,
     conversation_usage: FastHashMap<String, Value>,
     session_id: String,
 ) -> CodeAnalysis {
-    // Gemini CLI does not record the invoking `cwd` in its log format today, so
-    // `folder_path` is empty here and this resolves to an empty remote; it only
-    // yields a URL if a future log format carries a workspace path.
-    if state.git_remote.is_empty() {
-        state.git_remote = get_git_remote_url(&state.folder_path);
-    }
-
     let last_ts = state.last_ts;
     let mut record = state.into_record(conversation_usage);
     record.task_id = session_id;

--- a/src/core/tests/parser.rs
+++ b/src/core/tests/parser.rs
@@ -3,8 +3,7 @@
 // `insightsVersion`, `machineId` and `user` are excluded everywhere: each is
 // stamped from the machine running the test. Claude Code / Codex / Copilot also
 // exclude `gitRemoteUrl`, which is a git lookup against the workspace the
-// session recorded. Gemini excludes `gitRemoteUrl` and `folderPath` for a
-// different reason, given at that test.
+// session recorded.
 
 use serde_json::Value;
 use vct_core::session::parser::parse_session_file_to_value;
@@ -273,17 +272,9 @@ fn test_gemini_parser() {
 
     let actual_json = actual_result.unwrap();
 
-    // Neither of Gemini's two extra exclusions varies by machine: the logs
-    // carry no cwd, so `folderPath` stays empty and the git lookup it feeds
-    // returns nothing. They are excluded because the committed golden still
-    // records a `gitRemoteUrl` that an older build produced (see #167).
-    let ignore_fields = [
-        "insightsVersion",
-        "machineId",
-        "user",
-        "gitRemoteUrl",
-        "folderPath",
-    ];
+    // Gemini logs carry no cwd, so `folderPath` and `gitRemoteUrl` are both
+    // empty on every machine and the golden asserts them like any other field.
+    let ignore_fields = ["insightsVersion", "machineId", "user"];
     let matches = compare_json_ignore_fields(&actual_json, &expected_json, &ignore_fields);
 
     if !matches {
@@ -303,7 +294,7 @@ fn test_gemini_parser() {
 
     assert!(
         matches,
-        "Gemini analysis output does not match expected result (ignoring insightsVersion, machineId, user, gitRemoteUrl, folderPath)"
+        "Gemini analysis output does not match expected result (ignoring insightsVersion, machineId, user)"
     );
 }
 

--- a/tests/fixtures/sessions/gemini.expected.json
+++ b/tests/fixtures/sessions/gemini.expected.json
@@ -33,7 +33,7 @@
         }
       ],
       "folderPath": "",
-      "gitRemoteUrl": "https://github.com/Mai0313/VibeCodingTracker",
+      "gitRemoteUrl": "",
       "readFileDetails": [
         {
           "characterCount": 10443,


### PR DESCRIPTION
`finalize_record` in the Gemini parser ended with a fallback that could never
fire: it passed `state.folder_path`, which nothing in `gemini.rs` ever assigns,
so `get_git_remote_url` returned an empty string immediately and the branch left
`git_remote` exactly as it found it.

Of the two options in #167, this takes the second and drops the branch. Making it
do what the old doc claimed (`std::env::current_dir()`) would stamp the *scanning*
process's repository onto every Gemini session whatever workspace that session
actually ran in, so a batch `vct usage` run from inside one repo would credit every
Gemini session to it. An empty `gitRemoteUrl` is the honest answer until the log
format carries a workspace path.

- `src/core/src/session/gemini.rs` — remove the branch, its comment, the now-unneeded
  `mut` on the `state` parameter and the orphaned `get_git_remote_url` import. What
  `finalize_record` does with the workspace moves into its own doc comment.
- `tests/fixtures/sessions/gemini.expected.json` — `gitRemoteUrl` becomes `""`, the
  value the parser emits. Hand-edited rather than regenerated through `scripts/test.sh`,
  which would also rewrite the machine-specific `insightsVersion` / `machineId` / `user`.
- `src/core/tests/parser.rs` — `gitRemoteUrl` and `folderPath` leave the Gemini ignore
  list. Both are now deterministically empty for every Gemini session on every machine,
  so the golden asserts them and a regression is visible; the other three parsers keep
  their exclusion because their lookup really is machine-specific.

Closes #167

Opened-by: Claude Opus 5
