### PR TITLE
fix(scripts): verify TLS certificates in the installers

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -4,7 +4,37 @@ $Repo = "Mai0313/VibeCodingTracker"
 $BinaryName = "vibe_coding_tracker"
 
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
-[System.Net.ServicePointManager]::ServerCertificateValidationCallback = { $true }
+
+# The request already reports the underlying reason; this only says what to do about it.
+$TlsFailureHint = @(
+    "If the error above is a trust or certificate problem, this machine does not trust the",
+    "server's issuer. Import the missing root (or your proxy's CA) into the Windows",
+    "certificate store and retry. This installer never skips certificate verification."
+) -join "`r`n"
+
+function Invoke-Download {
+    param(
+        [Parameter(Mandatory = $true)][string]$Uri,
+        [string]$OutFile
+    )
+
+    $params = @{ Uri = $Uri; UseBasicParsing = $true }
+    if ($OutFile) {
+        $params.OutFile = $OutFile
+    }
+
+    try {
+        return Invoke-WebRequest @params
+    }
+    catch {
+        # The outer message is just "see inner exception"; the certificate error is nested.
+        $reason = @()
+        for ($e = $_.Exception; $e; $e = $e.InnerException) {
+            $reason += $e.Message
+        }
+        throw "Download failed: $Uri`r`n$($reason -join "`r`n")`r`n$TlsFailureHint"
+    }
+}
 
 function Get-Architecture {
     switch ($env:PROCESSOR_ARCHITECTURE) {
@@ -18,7 +48,7 @@ function Get-Architecture {
 }
 
 function Get-LatestVersion {
-    $response = Invoke-WebRequest -Uri "https://api.github.com/repos/$Repo/releases/latest" -UseBasicParsing
+    $response = Invoke-Download -Uri "https://api.github.com/repos/$Repo/releases/latest"
     $tag = ($response.Content | ConvertFrom-Json).tag_name
     if (-not $tag) {
         Write-Error "Failed to determine latest release."
@@ -45,7 +75,7 @@ function Install-Binary {
 
     try {
         $archive = Join-Path $tempDir $filename
-        Invoke-WebRequest -Uri $url -OutFile $archive -UseBasicParsing
+        Invoke-Download -Uri $url -OutFile $archive
 
         Expand-Archive -Path $archive -DestinationPath $tempDir -Force
         $binary = Get-ChildItem -Path $tempDir -Filter "$BinaryName.exe" -Recurse | Select-Object -First 1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -28,8 +28,20 @@ detect_platform() {
     printf "%s-%s" "$os" "$arch"
 }
 
+# curl already prints the underlying reason; this only says what to do about it.
+download_failed() {
+    echo "Download failed: $1" >&2
+    echo "If the error above is a certificate problem, this machine does not trust the" >&2
+    echo "server's issuer. Update your CA certificates, or point CURL_CA_BUNDLE at your" >&2
+    echo "proxy's CA, and retry. This installer never skips certificate verification." >&2
+    exit 1
+}
+
 get_latest_version() {
-    curl -fsSLk "https://api.github.com/repos/${REPO}/releases/latest" |
+    local url="https://api.github.com/repos/${REPO}/releases/latest"
+    local response
+    response="$(curl -fsSL "$url")" || download_failed "$url"
+    printf "%s" "$response" |
         grep -o '"tag_name": "[^"]*"' |
         cut -d'"' -f4
 }
@@ -61,7 +73,7 @@ install_binary() {
     trap 'rm -rf "$temp_dir"' EXIT
 
     local archive="${temp_dir}/${filename}"
-    curl -fsSLk -o "$archive" "$url"
+    curl -fsSL -o "$archive" "$url" || download_failed "$url"
     tar -xzf "$archive" -C "$temp_dir"
 
     local binary


### PR DESCRIPTION
Both installers turned off TLS certificate verification before downloading the binary the user is
about to run, so anyone able to intercept the connection could substitute their own archive and the
script would install it without complaint.

`git log -S` shows neither `-k` nor the PowerShell callback was a workaround for anything: both
landed in the commit that first added the scripts. So there is nothing to preserve, and the fix is
to stop disabling verification and make the resulting failure actionable.

## Changes

- `scripts/install.sh` — drop `k` from both `curl -fsSLk` calls (release lookup and archive
  download) and route both through one failure path that prints the URL plus a hint naming the CA
  store and `CURL_CA_BUNDLE`. `curl -S` already prints the underlying TLS reason; the hint says what
  to do about it.
- `scripts/install.ps1` — remove the process-wide
  `[System.Net.ServicePointManager]::ServerCertificateValidationCallback = { $true }` and route both
  `Invoke-WebRequest` calls through one `Invoke-Download` helper that rethrows with the URL and the
  same hint. The outer .NET message is only "The SSL connection could not be established, see inner
  exception", so the helper walks the inner exceptions to surface the real reason
  (`RemoteCertificateChainErrors`). `SecurityProtocol = Tls12` stays; it is unrelated to
  verification.

No README change: the successful install path is unchanged, and none of the three READMEs quote
these scripts' flags. `rg` finds no other `--insecure` / `-k` / `danger_accept_invalid_certs` /
`-SkipCertificateCheck` in the repo, and the Rust self-updater uses stock reqwest.

## Verification

- `uvx pre-commit run --all-files` (ShellCheck covers `install.sh`) — clean.
- `install.sh` end to end against a throwaway `HOME`: resolves `v2.6.0`, installs, and the installed
  binary runs.
- `install.sh` against a local self-signed HTTPS server: curl reports the certificate problem, the
  hint follows, and the script exits 1 without installing.
- `install.ps1` parsed with `Parser::ParseFile` (clean) and `Invoke-Download` exercised under
  PowerShell 7.4.6 against both the real GitHub API and the self-signed server; the failing case
  leaves no partial output file.

Closes #163

Opened-by: Claude Opus 5
