### PR TITLE
test: cover DeepSeek Harness in the every-provider test lists

### DIFF
--- a/src/cli/tests/cli.rs
+++ b/src/cli/tests/cli.rs
@@ -118,6 +118,7 @@ fn analysis_file_json_matches_typed_parser_for_every_file_provider() {
         "sessions/copilot.jsonl",
         "sessions/gemini.jsonl",
         "sessions/grok/signals.json",
+        "sessions/dsh/session.jsonl.zstd",
     ] {
         let path = fixture(fixture_name);
         let expected = serde_json::to_value(parse_session_file_typed(&path).unwrap()).unwrap();
@@ -493,6 +494,7 @@ fn single_file_summary_projection_is_parse_mode_invariant() {
         "sessions/copilot.jsonl",
         "sessions/gemini.jsonl",
         "sessions/grok/signals.json",
+        "sessions/dsh/session.jsonl.zstd",
     ] {
         let path = fixture(fixture_name);
         let full = parse_session_file_typed_with_mode(&path, ParseMode::Full).unwrap();

--- a/src/core/src/models/provider.rs
+++ b/src/core/src/models/provider.rs
@@ -186,6 +186,7 @@ mod tests {
         assert_eq!(Provider::Cursor.display_name(), "Cursor");
         assert_eq!(Provider::Hermes.display_name(), "Hermes");
         assert_eq!(Provider::Grok.display_name(), "Grok");
+        assert_eq!(Provider::DeepSeek.display_name(), "DeepSeek");
         assert_eq!(Provider::Unknown.display_name(), "Unknown");
     }
 }

--- a/src/core/tests/analysis.rs
+++ b/src/core/tests/analysis.rs
@@ -13,14 +13,14 @@ use std::path::Path;
 use tempfile::TempDir;
 use vct_core::TimeRange;
 use vct_core::analysis::aggregator::{
-    AnalysisData, aggregate_sessions_by_model_from_paths,
+    AnalysisData, PerProviderAnalysisRows, aggregate_sessions_by_model_from_paths,
     aggregate_sessions_by_model_from_paths_with_cache,
     aggregate_sessions_by_model_from_paths_with_diagnostics,
     aggregate_sessions_by_model_from_paths_with_providers,
     collect_analysis_sessions_from_paths_with, project_code_analysis,
 };
 use vct_core::config::ProvidersConfig;
-use vct_core::models::ExtensionType;
+use vct_core::models::{ExtensionType, ProviderActiveDays};
 use vct_core::session::parser::{
     parse_session_file_to_value, parse_session_file_typed, parse_session_file_typed_as,
     parse_session_file_with_diagnostics,
@@ -101,69 +101,72 @@ fn seed_opencode_tie_breaker_db(path: &Path) {
     tx.commit().unwrap();
 }
 
+/// Compares every per-provider bucket of two analysis results.
+///
+/// Each bucket is reached by destructuring rather than by naming fields one at
+/// a time: a provider added to one of these structs then fails to compile here,
+/// instead of silently going uncompared.
 fn assert_analysis_data_eq(actual: &AnalysisData, expected: &AnalysisData) {
     assert_eq!(
         serde_json::to_value(&actual.rows).unwrap(),
         serde_json::to_value(&expected.rows).unwrap()
     );
-    assert_eq!(
-        serde_json::to_value(&actual.per_provider.claude).unwrap(),
-        serde_json::to_value(&expected.per_provider.claude).unwrap()
-    );
-    assert_eq!(
-        serde_json::to_value(&actual.per_provider.codex).unwrap(),
-        serde_json::to_value(&expected.per_provider.codex).unwrap()
-    );
-    assert_eq!(
-        serde_json::to_value(&actual.per_provider.copilot).unwrap(),
-        serde_json::to_value(&expected.per_provider.copilot).unwrap()
-    );
-    assert_eq!(
-        serde_json::to_value(&actual.per_provider.gemini).unwrap(),
-        serde_json::to_value(&expected.per_provider.gemini).unwrap()
-    );
-    assert_eq!(
-        serde_json::to_value(&actual.per_provider.grok).unwrap(),
-        serde_json::to_value(&expected.per_provider.grok).unwrap()
-    );
-    assert_eq!(
-        serde_json::to_value(&actual.per_provider.deepseek).unwrap(),
-        serde_json::to_value(&expected.per_provider.deepseek).unwrap()
-    );
-    assert_eq!(
-        serde_json::to_value(&actual.per_provider.opencode).unwrap(),
-        serde_json::to_value(&expected.per_provider.opencode).unwrap()
-    );
-    assert_eq!(
-        serde_json::to_value(&actual.per_provider.cursor).unwrap(),
-        serde_json::to_value(&expected.per_provider.cursor).unwrap()
-    );
-    assert_eq!(
-        (
-            actual.provider_days.claude,
-            actual.provider_days.codex,
-            actual.provider_days.copilot,
-            actual.provider_days.gemini,
-            actual.provider_days.grok,
-            actual.provider_days.deepseek,
-            actual.provider_days.opencode,
-            actual.provider_days.cursor,
-            actual.provider_days.hermes,
-            actual.provider_days.total,
-        ),
-        (
-            expected.provider_days.claude,
-            expected.provider_days.codex,
-            expected.provider_days.copilot,
-            expected.provider_days.gemini,
-            expected.provider_days.grok,
-            expected.provider_days.deepseek,
-            expected.provider_days.opencode,
-            expected.provider_days.cursor,
-            expected.provider_days.hermes,
-            expected.provider_days.total,
-        )
-    );
+
+    let PerProviderAnalysisRows {
+        claude,
+        codex,
+        copilot,
+        gemini,
+        grok,
+        deepseek,
+        opencode,
+        cursor,
+    } = &actual.per_provider;
+    let other = &expected.per_provider;
+    for (provider, actual_rows, expected_rows) in [
+        ("Claude", claude, &other.claude),
+        ("Codex", codex, &other.codex),
+        ("Copilot", copilot, &other.copilot),
+        ("Gemini", gemini, &other.gemini),
+        ("Grok", grok, &other.grok),
+        ("DeepSeek", deepseek, &other.deepseek),
+        ("OpenCode", opencode, &other.opencode),
+        ("Cursor", cursor, &other.cursor),
+    ] {
+        assert_eq!(
+            serde_json::to_value(actual_rows).unwrap(),
+            serde_json::to_value(expected_rows).unwrap(),
+            "{provider} rows differ"
+        );
+    }
+
+    let ProviderActiveDays {
+        claude,
+        codex,
+        copilot,
+        gemini,
+        opencode,
+        cursor,
+        hermes,
+        grok,
+        deepseek,
+        total,
+    } = &actual.provider_days;
+    let other = &expected.provider_days;
+    for (provider, actual_days, expected_days) in [
+        ("Claude", claude, &other.claude),
+        ("Codex", codex, &other.codex),
+        ("Copilot", copilot, &other.copilot),
+        ("Gemini", gemini, &other.gemini),
+        ("Grok", grok, &other.grok),
+        ("DeepSeek", deepseek, &other.deepseek),
+        ("OpenCode", opencode, &other.opencode),
+        ("Cursor", cursor, &other.cursor),
+        ("Hermes", hermes, &other.hermes),
+        ("All providers", total, &other.total),
+    ] {
+        assert_eq!(actual_days, expected_days, "{provider} active days differ");
+    }
 }
 
 #[test]
@@ -506,6 +509,7 @@ fn cached_analysis_matches_uncached_and_reuses_unchanged_sources() {
         &fixture_str("sessions/gemini.jsonl"),
     );
     home.put_grok_fixture_session("workspace", "grok-session");
+    home.put_dsh_fixture_session("dsh-project", "dsh-session");
     seed_opencode_tie_breaker_db(&home.paths.opencode_db);
     home.put_cursor_session(
         "cursor-project",
@@ -530,32 +534,47 @@ fn cached_analysis_matches_uncached_and_reuses_unchanged_sources() {
         &mut cache,
     )
     .unwrap();
-    assert_eq!(cache.stats().parsed_sources, 7);
-    assert_eq!(cold.diagnostics.candidates, 7);
-    assert_eq!(cold.diagnostics.parsed, 7);
+    assert_eq!(cache.stats().parsed_sources, 8);
+    assert_eq!(cold.diagnostics.candidates, 8);
+    assert_eq!(cold.diagnostics.parsed, 8);
     assert!(cold.diagnostics.failures.is_empty());
     assert_eq!(cold.diagnostics, uncached.diagnostics);
     assert_analysis_data_eq(&cold.data, &uncached.data);
+    // Destructured so that a provider added later cannot be left unseeded: the
+    // new field has to be named here, and naming it without using it below is
+    // an unused-variable warning, which CI denies.
+    let PerProviderAnalysisRows {
+        claude,
+        codex,
+        copilot,
+        gemini,
+        grok,
+        deepseek,
+        opencode,
+        cursor,
+    } = &cold.data.per_provider;
     for (provider, rows) in [
-        ("Claude", &cold.data.per_provider.claude),
-        ("Codex", &cold.data.per_provider.codex),
-        ("Copilot", &cold.data.per_provider.copilot),
-        ("Gemini", &cold.data.per_provider.gemini),
-        ("Grok", &cold.data.per_provider.grok),
-        ("OpenCode", &cold.data.per_provider.opencode),
-        ("Cursor", &cold.data.per_provider.cursor),
+        ("Claude", claude),
+        ("Codex", codex),
+        ("Copilot", copilot),
+        ("Gemini", gemini),
+        ("Grok", grok),
+        ("DeepSeek", deepseek),
+        ("OpenCode", opencode),
+        ("Cursor", cursor),
     ] {
         assert!(!rows.is_empty(), "{provider} fixture must contribute a row");
     }
     for rows in [
         &cold.data.rows,
-        &cold.data.per_provider.claude,
-        &cold.data.per_provider.codex,
-        &cold.data.per_provider.copilot,
-        &cold.data.per_provider.gemini,
-        &cold.data.per_provider.grok,
-        &cold.data.per_provider.opencode,
-        &cold.data.per_provider.cursor,
+        claude,
+        codex,
+        copilot,
+        gemini,
+        grok,
+        deepseek,
+        opencode,
+        cursor,
     ] {
         assert!(
             rows.windows(2).all(|pair| pair[0].model <= pair[1].model),

--- a/src/core/tests/analysis.rs
+++ b/src/core/tests/analysis.rs
@@ -101,14 +101,19 @@ fn seed_opencode_tie_breaker_db(path: &Path) {
     tx.commit().unwrap();
 }
 
-/// Compares every per-provider bucket of two analysis results.
+/// Compares every bucket of two analysis results.
 ///
-/// Each bucket is reached by destructuring rather than by naming fields one at
-/// a time: a provider added to one of these structs then fails to compile here,
-/// instead of silently going uncompared.
+/// Every struct here is destructured rather than having its fields named one at
+/// a time: a bucket added to any of them then fails to compile, instead of
+/// silently going uncompared.
 fn assert_analysis_data_eq(actual: &AnalysisData, expected: &AnalysisData) {
+    let AnalysisData {
+        rows,
+        per_provider,
+        provider_days,
+    } = actual;
     assert_eq!(
-        serde_json::to_value(&actual.rows).unwrap(),
+        serde_json::to_value(rows).unwrap(),
         serde_json::to_value(&expected.rows).unwrap()
     );
 
@@ -121,7 +126,7 @@ fn assert_analysis_data_eq(actual: &AnalysisData, expected: &AnalysisData) {
         deepseek,
         opencode,
         cursor,
-    } = &actual.per_provider;
+    } = per_provider;
     let other = &expected.per_provider;
     for (provider, actual_rows, expected_rows) in [
         ("Claude", claude, &other.claude),
@@ -151,7 +156,7 @@ fn assert_analysis_data_eq(actual: &AnalysisData, expected: &AnalysisData) {
         grok,
         deepseek,
         total,
-    } = &actual.provider_days;
+    } = provider_days;
     let other = &expected.provider_days;
     for (provider, actual_days, expected_days) in [
         ("Claude", claude, &other.claude),

--- a/src/core/tests/usage.rs
+++ b/src/core/tests/usage.rs
@@ -10,10 +10,10 @@ use rusqlite::{Connection, params};
 use std::os::unix::fs::PermissionsExt;
 use vct_core::TimeRange;
 use vct_core::config::ProvidersConfig;
-use vct_core::models::ExtensionType;
+use vct_core::models::{ExtensionType, PerProviderUsage, ProviderActiveDays};
 use vct_core::summary_cache::SummaryScanCache;
 use vct_core::usage::aggregator::{
-    UsageData, aggregate_usage_from_paths, aggregate_usage_from_paths_with_cache,
+    StoredCosts, UsageData, aggregate_usage_from_paths, aggregate_usage_from_paths_with_cache,
     aggregate_usage_from_paths_with_diagnostics, aggregate_usage_from_paths_with_providers,
 };
 use vct_test_support::{TempHome, append_cursor_json_blob, fixture_str};
@@ -167,43 +167,84 @@ fn seed_hermes_usage_db(path: &std::path::Path) {
         .unwrap();
 }
 
+/// Compares every per-provider bucket of two usage results.
+///
+/// Each bucket is reached by destructuring rather than by naming fields one at
+/// a time: a provider added to one of these structs then fails to compile here,
+/// instead of silently going uncompared the way DeepSeek Harness did.
 fn assert_usage_data_eq(actual: &UsageData, expected: &UsageData) {
     assert_eq!(actual.models, expected.models);
-    assert_eq!(actual.per_provider.claude, expected.per_provider.claude);
-    assert_eq!(actual.per_provider.codex, expected.per_provider.codex);
-    assert_eq!(actual.per_provider.copilot, expected.per_provider.copilot);
-    assert_eq!(actual.per_provider.gemini, expected.per_provider.gemini);
-    assert_eq!(actual.per_provider.grok, expected.per_provider.grok);
-    assert_eq!(actual.per_provider.opencode, expected.per_provider.opencode);
-    assert_eq!(actual.per_provider.cursor, expected.per_provider.cursor);
-    assert_eq!(actual.per_provider.hermes, expected.per_provider.hermes);
-    assert_eq!(
-        (
-            actual.provider_days.claude,
-            actual.provider_days.codex,
-            actual.provider_days.copilot,
-            actual.provider_days.gemini,
-            actual.provider_days.grok,
-            actual.provider_days.opencode,
-            actual.provider_days.cursor,
-            actual.provider_days.hermes,
-            actual.provider_days.total,
-        ),
-        (
-            expected.provider_days.claude,
-            expected.provider_days.codex,
-            expected.provider_days.copilot,
-            expected.provider_days.gemini,
-            expected.provider_days.grok,
-            expected.provider_days.opencode,
-            expected.provider_days.cursor,
-            expected.provider_days.hermes,
-            expected.provider_days.total,
-        )
-    );
-    assert_eq!(actual.stored_costs.opencode, expected.stored_costs.opencode);
-    assert_eq!(actual.stored_costs.cursor, expected.stored_costs.cursor);
-    assert_eq!(actual.stored_costs.hermes, expected.stored_costs.hermes);
+
+    let PerProviderUsage {
+        claude,
+        codex,
+        copilot,
+        gemini,
+        opencode,
+        cursor,
+        hermes,
+        grok,
+        deepseek,
+    } = &actual.per_provider;
+    let other = &expected.per_provider;
+    for (provider, actual_usage, expected_usage) in [
+        ("Claude", claude, &other.claude),
+        ("Codex", codex, &other.codex),
+        ("Copilot", copilot, &other.copilot),
+        ("Gemini", gemini, &other.gemini),
+        ("OpenCode", opencode, &other.opencode),
+        ("Cursor", cursor, &other.cursor),
+        ("Hermes", hermes, &other.hermes),
+        ("Grok", grok, &other.grok),
+        ("DeepSeek", deepseek, &other.deepseek),
+    ] {
+        assert_eq!(actual_usage, expected_usage, "{provider} usage differs");
+    }
+
+    let ProviderActiveDays {
+        claude,
+        codex,
+        copilot,
+        gemini,
+        opencode,
+        cursor,
+        hermes,
+        grok,
+        deepseek,
+        total,
+    } = &actual.provider_days;
+    let other = &expected.provider_days;
+    for (provider, actual_days, expected_days) in [
+        ("Claude", claude, &other.claude),
+        ("Codex", codex, &other.codex),
+        ("Copilot", copilot, &other.copilot),
+        ("Gemini", gemini, &other.gemini),
+        ("OpenCode", opencode, &other.opencode),
+        ("Cursor", cursor, &other.cursor),
+        ("Hermes", hermes, &other.hermes),
+        ("Grok", grok, &other.grok),
+        ("DeepSeek", deepseek, &other.deepseek),
+        ("All providers", total, &other.total),
+    ] {
+        assert_eq!(actual_days, expected_days, "{provider} active days differ");
+    }
+
+    let StoredCosts {
+        opencode,
+        cursor,
+        hermes,
+    } = &actual.stored_costs;
+    let other = &expected.stored_costs;
+    for (provider, actual_costs, expected_costs) in [
+        ("OpenCode", opencode, &other.opencode),
+        ("Cursor", cursor, &other.cursor),
+        ("Hermes", hermes, &other.hermes),
+    ] {
+        assert_eq!(
+            actual_costs, expected_costs,
+            "{provider} stored costs differ"
+        );
+    }
 }
 
 #[test]
@@ -246,6 +287,7 @@ fn cached_usage_matches_uncached_for_every_provider_source() {
         1_234,
     );
     seed_hermes_usage_db(&home.paths.hermes_db);
+    home.put_dsh_fixture_session("dsh-project", "dsh-session");
 
     let providers = ProvidersConfig::default();
     let uncached =
@@ -255,20 +297,35 @@ fn cached_usage_matches_uncached_for_every_provider_source() {
         aggregate_usage_from_paths_with_cache(&home.paths, TimeRange::All, providers, &mut cache)
             .unwrap();
 
-    assert_eq!(cold.diagnostics.candidates, 8);
-    assert_eq!(cold.diagnostics.parsed, 8);
+    assert_eq!(cold.diagnostics.candidates, 9);
+    assert_eq!(cold.diagnostics.parsed, 9);
     assert!(cold.diagnostics.failures.is_empty());
-    assert_eq!(cache.stats().parsed_sources, 8);
+    assert_eq!(cache.stats().parsed_sources, 9);
     assert_usage_data_eq(&cold.data, &uncached);
+    // Destructured so that a provider added later cannot be left unseeded: the
+    // new field has to be named here, and naming it without using it below is
+    // an unused-variable warning, which CI denies.
+    let PerProviderUsage {
+        claude,
+        codex,
+        copilot,
+        gemini,
+        opencode,
+        cursor,
+        hermes,
+        grok,
+        deepseek,
+    } = &cold.data.per_provider;
     for (provider, usage) in [
-        ("Claude", &cold.data.per_provider.claude),
-        ("Codex", &cold.data.per_provider.codex),
-        ("Copilot", &cold.data.per_provider.copilot),
-        ("Gemini", &cold.data.per_provider.gemini),
-        ("Grok", &cold.data.per_provider.grok),
-        ("OpenCode", &cold.data.per_provider.opencode),
-        ("Cursor", &cold.data.per_provider.cursor),
-        ("Hermes", &cold.data.per_provider.hermes),
+        ("Claude", claude),
+        ("Codex", codex),
+        ("Copilot", copilot),
+        ("Gemini", gemini),
+        ("Grok", grok),
+        ("DeepSeek", deepseek),
+        ("OpenCode", opencode),
+        ("Cursor", cursor),
+        ("Hermes", hermes),
     ] {
         assert!(
             !usage.is_empty(),

--- a/src/core/tests/usage.rs
+++ b/src/core/tests/usage.rs
@@ -167,13 +167,19 @@ fn seed_hermes_usage_db(path: &std::path::Path) {
         .unwrap();
 }
 
-/// Compares every per-provider bucket of two usage results.
+/// Compares every bucket of two usage results.
 ///
-/// Each bucket is reached by destructuring rather than by naming fields one at
-/// a time: a provider added to one of these structs then fails to compile here,
-/// instead of silently going uncompared the way DeepSeek Harness did.
+/// Every struct here is destructured rather than having its fields named one at
+/// a time: a bucket added to any of them then fails to compile, instead of
+/// silently going uncompared the way DeepSeek Harness did.
 fn assert_usage_data_eq(actual: &UsageData, expected: &UsageData) {
-    assert_eq!(actual.models, expected.models);
+    let UsageData {
+        models,
+        per_provider,
+        provider_days,
+        stored_costs,
+    } = actual;
+    assert_eq!(models, &expected.models);
 
     let PerProviderUsage {
         claude,
@@ -185,7 +191,7 @@ fn assert_usage_data_eq(actual: &UsageData, expected: &UsageData) {
         hermes,
         grok,
         deepseek,
-    } = &actual.per_provider;
+    } = per_provider;
     let other = &expected.per_provider;
     for (provider, actual_usage, expected_usage) in [
         ("Claude", claude, &other.claude),
@@ -212,7 +218,7 @@ fn assert_usage_data_eq(actual: &UsageData, expected: &UsageData) {
         grok,
         deepseek,
         total,
-    } = &actual.provider_days;
+    } = provider_days;
     let other = &expected.provider_days;
     for (provider, actual_days, expected_days) in [
         ("Claude", claude, &other.claude),
@@ -233,7 +239,7 @@ fn assert_usage_data_eq(actual: &UsageData, expected: &UsageData) {
         opencode,
         cursor,
         hermes,
-    } = &actual.stored_costs;
+    } = stored_costs;
     let other = &expected.stored_costs;
     for (provider, actual_costs, expected_costs) in [
         ("OpenCode", opencode, &other.opencode),


### PR DESCRIPTION
Closes #164

DeepSeek Harness was missing from four hand-maintained "every provider" test
lists, so those tests covered one provider fewer than their names claimed while
staying green. This adds it, and where the list is backed by a struct it makes
the completeness check the compiler's job rather than a reviewer's.

## What changed

- **`src/core/tests/usage.rs` / `src/core/tests/analysis.rs` — the equivalence
  helpers.** `assert_usage_data_eq` and `assert_analysis_data_eq` now reach each
  bucket by destructuring: `UsageData` / `AnalysisData` on the outside, then
  `PerProviderUsage` / `PerProviderAnalysisRows` / `ProviderActiveDays` /
  `StoredCosts`, instead of naming fields one at a time. A field added to any of
  them stops these helpers compiling: an unmentioned field is `error[E0027]`,
  and a mentioned-but-unused binding is an unused variable, which CI denies
  (`cargo clippy --all-targets -- -D warnings`). This is also what restores the
  missing `per_provider.deepseek` and `provider_days.deepseek` comparisons on
  the usage side.

- **The two cache-equivalence tests.** `cached_usage_matches_uncached_for_every_provider_source`
  and `cached_analysis_matches_uncached_and_reuses_unchanged_sources` now seed a
  DSH session through the existing `TempHome::put_dsh_fixture_session` (counts
  8 -> 9 and 7 -> 8), and their "fixture must contribute" loops run off the same
  destructure, so a provider added later cannot be left unseeded either.

- **`src/cli/tests/cli.rs`.** `sessions/dsh/session.jsonl.zstd` joins the two
  "every file provider" fixture lists. These are fixture path strings with no
  struct behind them, so there is nothing here for the compiler to check; the
  entry is simply added.

- **`src/core/src/models/provider.rs`.** `test_provider_display` asserts
  `Provider::DeepSeek`. A `match` over `Provider` inside the test would fail to
  compile on a new variant, but only by re-stating `display_name`'s own arms in
  the assertion, and the variant list it iterates would stay hand-written
  either way, so the plain assertion is kept.

The only non-test file touched is that inline `#[cfg(test)]` module; no
production behaviour changes.

## Verification

`cargo test --workspace` is green (all 16 test binaries), as are `make fmt`
(rustfmt + clippy `-D warnings`) and `uvx pre-commit run -a`.

The compile-time guard was checked rather than assumed: adding a throwaway
field to `PerProviderUsage` fails the build at both new destructure sites
(`error[E0027]: pattern does not mention field`), and the probe was then
reverted.

## Deliberately left out

Two more provider lists carry the same omission and are not touched here:
`src/tui/benches/benchmarks.rs` (a missing benchmark, not missing coverage) and
`test_file_cache_multiple_files` in `src/core/tests/cache.rs`, whose list is a
handful of session files for an LRU test rather than an every-provider claim.

Planned-by: Claude Opus 5
Opened-by: Claude Opus 5
