### PR TITLE
refactor(tui): drop unreachable helpers and settle the quota overlay's card layout

### DIFF
--- a/src/test-support/src/lib.rs
+++ b/src/test-support/src/lib.rs
@@ -6,7 +6,6 @@
 //! files into a fake home and call the `*_from_paths` aggregation entry points
 //! directly. No `HOME`/`XDG_*`/`VCT_OFFLINE` is ever touched, so every test runs
 //! in parallel and behaves identically locally and in CI.
-#![allow(dead_code)]
 
 use std::path::{Path, PathBuf};
 use tempfile::TempDir;

--- a/src/tui/src/display/common/table.rs
+++ b/src/tui/src/display/common/table.rs
@@ -67,20 +67,6 @@ pub fn init_process_metrics(sys: &mut System, pid: sysinfo::Pid) {
     refresh_process_metrics(sys, pid);
 }
 
-/// Builds the bordered, centered title paragraph for the top of a TUI view.
-pub fn create_title(title_text: &str, color: RatatuiColor) -> Paragraph<'_> {
-    Paragraph::new(vec![Line::from(vec![Span::styled(
-        title_text,
-        Style::default().fg(color).bold(),
-    )])])
-    .block(
-        Block::default()
-            .borders(Borders::ALL)
-            .border_style(Style::default().fg(color)),
-    )
-    .centered()
-}
-
 /// Separator drawn between summary-bar segments.
 const SUMMARY_SEP: &str = "  |  ";
 

--- a/src/tui/src/display/common/tui.rs
+++ b/src/tui/src/display/common/tui.rs
@@ -229,6 +229,14 @@ impl<T: Send + 'static> RefreshWorker<T> {
                 }
                 match command {
                     RefreshCommand::Run => {
+                        // Catching the panic keeps the worker answering the next
+                        // request; letting it unwind out of the loop drops the
+                        // result channel, and a disconnected worker never
+                        // refreshes again. It only fires on an unwinding
+                        // profile — dev, and the test profile that pins the
+                        // retry below. The release and dist profiles set
+                        // `panic = "abort"`, where the process is gone before
+                        // this is reached.
                         let result =
                             std::panic::catch_unwind(std::panic::AssertUnwindSafe(&mut loader))
                                 .map_err(|_| {

--- a/src/tui/src/display/common/tui.rs
+++ b/src/tui/src/display/common/tui.rs
@@ -641,45 +641,6 @@ pub enum InputAction {
     Continue,
 }
 
-/// Tracks when the next periodic data refresh is due, plus a one-shot force flag.
-pub struct RefreshState {
-    last_refresh: Instant,
-    force_refresh: bool,
-    refresh_interval: Duration,
-}
-
-impl RefreshState {
-    /// Creates a refresh state with the given interval in seconds, primed to refresh immediately.
-    ///
-    /// `last_refresh` is backdated by one interval and `force_refresh` is set,
-    /// so the first [`should_refresh`](Self::should_refresh) returns `true` and
-    /// the initial load is not delayed by one interval.
-    pub fn new(refresh_secs: u64) -> Self {
-        let refresh_interval = Duration::from_secs(refresh_secs);
-        Self {
-            last_refresh: Instant::now() - refresh_interval,
-            force_refresh: true,
-            refresh_interval,
-        }
-    }
-
-    /// Returns whether a refresh is due (forced, or the interval has elapsed).
-    pub fn should_refresh(&self) -> bool {
-        self.force_refresh || self.last_refresh.elapsed() >= self.refresh_interval
-    }
-
-    /// Records that a refresh just happened, resetting the timer and clearing the force flag.
-    pub fn mark_refreshed(&mut self) {
-        self.last_refresh = Instant::now();
-        self.force_refresh = false;
-    }
-
-    /// Forces the next [`should_refresh`](Self::should_refresh) to return `true`.
-    pub fn force(&mut self) {
-        self.force_refresh = true;
-    }
-}
-
 /// Tracks per-row changes to drive temporary highlighting of recently-updated rows.
 ///
 /// To bound memory it stores a hash of each row's data rather than a clone, and

--- a/src/tui/src/display/usage/interactive.rs
+++ b/src/tui/src/display/usage/interactive.rs
@@ -1682,17 +1682,21 @@ fn render_quota_overlay(f: &mut Frame, area: Rect, quota: &QuotaView, now: i64) 
         width: outer.width.saturating_sub(2),
         height: outer.height.saturating_sub(2),
     };
-    // Lay the cells out first: a card's lines are built for the width they will
-    // be drawn at, never for the spec's maximum, or the fitting every line
-    // builder does would be against a cell the card never gets.
+    // Settle how many cards get drawn before laying any out, so the width a
+    // card is built for and the cell it is drawn into come from the same
+    // layout. A card's lines are built for the width they will be drawn at,
+    // never for the spec's maximum, or the fitting every line builder does
+    // would be against a cell the card never gets. `collect_cards` pushes one
+    // card per present provider, so the count the grid needs is known before
+    // the first card exists.
     let present = quota.present.count();
-    let cells = grid_cells(&OVERLAY_GRID, inner, present);
+    let rows_that_fit = usize::from(inner.height / OVERLAY_GRID.height);
+    let (cols, _) = quota_grid(&OVERLAY_GRID, inner.width, present);
+    let fits = present.min(cols.saturating_mul(rows_that_fit));
+    let hidden = present - fits;
+    let cells = grid_cells(&OVERLAY_GRID, inner, fits);
     let card_w = cells.first().map_or(OVERLAY_GRID.min_w, |cell| cell.width);
     let cards = collect_cards(quota, now, card_w);
-    let rows_that_fit = usize::from(inner.height / OVERLAY_GRID.height);
-    let (cols, _) = quota_grid(&OVERLAY_GRID, inner.width, cards.len());
-    let fits = cards.len().min(cols.saturating_mul(rows_that_fit));
-    let hidden = cards.len() - fits;
 
     let mut block = Block::default()
         .borders(Borders::ALL)
@@ -1724,10 +1728,7 @@ fn render_quota_overlay(f: &mut Frame, area: Rect, quota: &QuotaView, now: i64) 
         return;
     }
 
-    for (cell, card) in grid_cells(&OVERLAY_GRID, inner, fits)
-        .into_iter()
-        .zip(&cards)
-    {
+    for (cell, card) in cells.into_iter().zip(&cards) {
         render_quota_card(f, cell, card);
     }
 }


### PR DESCRIPTION
Closes #166

Five items, one commit each.

### `create_title` and `RefreshState` are dropped

Neither has a caller anywhere in the workspace, in a test, in a bench, or in a doc example. Both views build their title through `TableChrome.title` and drive refreshes through `RefreshWorker`, so keeping either as embedder API would mean publishing an interface nobody reaches — and in `RefreshState`'s case, carrying the `new(0)` trap the issue describes in code nothing runs. Both are `pub` in `vct-tui`, so this is technically a public-API removal; `vct-tui` is published so `cargo install vct-cli` resolves, not as a UI toolkit anyone builds against.

### The quota overlay derives its card width from one layout

Reordered so `fits` is settled from `quota.present.count()` before any cell is laid out, and the single resulting `cells` vector supplies both `card_w` and the render targets. The second `grid_cells` call is gone.

**The reported symptom is not reachable, and this commit changes no output.** `grid_cells` takes its width from `quota_grid`'s column count alone. With `base = max(inner.width / 34, 1)`, `P = present`, `R = rows_that_fit` and `F = min(P, cols_P * R)`:

- `P <= base` gives `cols_P = P`, and for `R >= 1`, `F = P`, so `cols_F = cols_P`.
- `P > base` gives `cols_P = base` and `F >= base`, so `cols_F = min(base, F) = base = cols_P`.

The only divergent case is `R == 0`, where `fits == 0`, `grid_cells` returns nothing and no card is drawn at all. So the two layouts already agreed on every reachable input. What the reorder buys is that the agreement now holds by construction instead of by that argument, which is the rule the file states about itself and the one `overlay_cards_are_built_for_the_cell_they_are_drawn_in` already pins.

### `RefreshWorker`'s `catch_unwind` stays, with a comment saying what it covers

It is live under any unwinding profile, which includes the dev profile and the test profile `loader_panic_is_reported_once_and_worker_can_retry` runs under, and inert under `[profile.release]` / `[profile.dist]`, where the panic aborts before it is reached. Deleting it would leave a debug-build loader panic dropping the result channel, and a disconnected worker never refreshes again for the rest of the session — so the retry path earns its keep where it runs. What was wrong was the code reading as unconditional, which is what the comment fixes.

### `#![allow(dead_code)]` is dropped from `vct-test-support`

Verified with `cargo rustc -p vct-test-support --lib -- --force-warn dead_code`: zero warnings. Every private helper in the crate is used inside it, and the public ones never trip the lint.

### Verification

`make fmt`, `cargo test --workspace` (all suites green), `uvx pre-commit run -a`. Nothing here is user-visible, so no README or `vct.schema.json` change.

---
Opened-by: Claude Opus 5
