### PR TITLE
fix(quota): a failed Grok settings fetch leaves the previous account's plan label on the panel

### DIFF
--- a/src/core/src/quota/cache.rs
+++ b/src/core/src/quota/cache.rs
@@ -57,7 +57,7 @@ impl CachedQuota for CursorQuotaSnapshot {
 }
 
 impl CachedQuota for GrokQuotaSnapshot {
-    const SCHEMA_VERSION: u32 = 1;
+    const SCHEMA_VERSION: u32 = 2;
 }
 
 /// The on-disk envelope: the writing build's schema version + the snapshot.

--- a/src/core/src/quota/grok.rs
+++ b/src/core/src/quota/grok.rs
@@ -589,6 +589,7 @@ impl GrokState {
                     &token,
                     user_id.as_deref(),
                     file_mtime(&path),
+                    GROK_SETTINGS_URL,
                 ))
             }
             FetchResult::Unauthorized => {
@@ -614,6 +615,7 @@ impl GrokState {
                                     &fresh,
                                     user_id.as_deref(),
                                     file_mtime(&path),
+                                    GROK_SETTINGS_URL,
                                 ))
                             }
                             // A transient retry error keeps the freshly
@@ -649,13 +651,18 @@ impl GrokState {
         token: &str,
         user_id: Option<&str>,
         cred_mtime: Option<SystemTime>,
+        settings_url: &str,
     ) -> GrokQuotaSnapshot {
         if self
             .plan
             .as_ref()
             .is_none_or(|cached| cached.mtime != cred_mtime)
         {
-            match fetch_grok_plan(client, token, user_id, GROK_SETTINGS_URL) {
+            // Drop the stale label first: it belongs to whoever wrote the
+            // previous `auth.json`, so a failed fetch must leave the Plan line
+            // off rather than paint the previous account's tier.
+            self.plan = None;
+            match fetch_grok_plan(client, token, user_id, settings_url) {
                 Ok(label) => {
                     self.plan = Some(CachedPlan {
                         label,
@@ -1087,6 +1094,59 @@ mod tests {
         );
         // A failed fetch is an error so the worker retries it later.
         assert!(fetch_grok_plan(&client, "tok", None, &server.url("/down")).is_err());
+    }
+
+    #[test]
+    fn a_relogin_drops_the_plan_label_even_when_the_refetch_fails() {
+        let server = MockServer::start();
+        let settings = server.mock(|when, then| {
+            when.method(GET).path("/settings");
+            then.status(200)
+                .body(r#"{"subscription_tier_display":"SuperGrok"}"#);
+        });
+        server.mock(|when, then| {
+            when.method(GET).path("/down");
+            then.status(503);
+        });
+        let client = build_client().unwrap();
+        let mut state = GrokState::default();
+        let first_login = Some(SystemTime::UNIX_EPOCH);
+        let second_login = Some(SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1));
+        let snap = || map_grok_billing(CREDITS, 1_000_000).unwrap();
+
+        let labelled = state.with_plan(
+            &client,
+            snap(),
+            "tok",
+            None,
+            first_login,
+            &server.url("/settings"),
+        );
+        assert_eq!(labelled.plan_type.as_deref(), Some("SuperGrok"));
+
+        // Same login: the label is reused rather than re-fetched.
+        let cached = state.with_plan(
+            &client,
+            snap(),
+            "tok",
+            None,
+            first_login,
+            &server.url("/settings"),
+        );
+        assert_eq!(cached.plan_type.as_deref(), Some("SuperGrok"));
+        assert_eq!(settings.calls(), 1, "the label is cached per login");
+
+        // A re-login with the settings endpoint down: the panel omits the Plan
+        // line instead of painting the previous account's tier.
+        let after_relogin = state.with_plan(
+            &client,
+            snap(),
+            "tok",
+            None,
+            second_login,
+            &server.url("/down"),
+        );
+        assert_eq!(after_relogin.plan_type, None);
     }
 
     #[test]


### PR DESCRIPTION
`GrokState::with_plan` cached the plan label against `auth.json`'s mtime and, on a mismatch, re-fetched it while leaving the old entry in place. A failed `/v1/settings` call therefore painted the **previous** account's subscription tier onto the panel, and kept repainting it on every tick for as long as the fetch kept failing.

Dropping the cached label at the point the mismatch is detected — before the fetch — makes a failure omit the Plan line instead, which is what the panel already does elsewhere with data it cannot get. A success overwrites it exactly as before, so the only behaviour that changes is the failure path. `CachedPlan::mtime`'s doc already described this ("a re-login rewrites the file and drops the label so the new account's plan is read fresh") and is now true as written.

`with_plan` hardcoded `GROK_SETTINGS_URL`, so it could not be driven against an `httpmock` server. It now takes a `settings_url` parameter — the shape `fetch_grok_billing` already uses for `GROK_BILLING_URL` — and the two `resolve` call sites pass the constant. That is what makes the regression test hermetic; it fails on the old code with the stale `SuperGrok` label still attached.

No CLI behaviour or flags change, so the READMEs are untouched, and the CLAUDE.md paragraph on Grok's Plan line already describes the fixed behaviour.

`GrokQuotaSnapshot::SCHEMA_VERSION` goes to 2 in the same change, per the rule in `cache.rs`. The old build persisted the wrong-account label into `~/.vct/grok_usage.json` whenever billing succeeded and settings did not, and a transient failure keeps a seeded snapshot indefinitely, so without the bump an upgrade that cannot reach the settings endpoint would keep painting exactly the label this fixes.

Closes #179

---

Opened-by: Claude Opus 5
