### PR TITLE
fix(quota): tolerate dropped fields in the wham reset-credits response

### DIFF
--- a/src/core/src/models/quota.rs
+++ b/src/core/src/models/quota.rs
@@ -408,23 +408,26 @@ pub struct WhamResetCredits {
 #[derive(Debug, Clone, Deserialize)]
 pub struct WhamResetCreditsDetails {
     /// Per-credit details. The backend may cap this list.
+    #[serde(default)]
     pub credits: Vec<WhamResetCreditDetails>,
-    /// Authoritative number of available reset credits.
-    pub available_count: i64,
+    /// Authoritative number of available reset credits, when reported. Absent
+    /// means "unknown", not zero: the caller keeps the count wham/usage gave it.
+    #[serde(default)]
+    pub available_count: Option<i64>,
 }
 
 /// One earned rate-limit reset credit.
 #[derive(Debug, Clone, Deserialize)]
 pub struct WhamResetCreditDetails {
-    /// Stable backend identifier.
+    /// Stable backend identifier, only ever quoted back in an error message.
+    #[serde(default)]
     pub id: String,
-    /// Limit family reset by this credit.
-    pub reset_type: String,
-    /// Lifecycle state, e.g. `available` / `redeeming` / `redeemed`.
+    /// Lifecycle state, e.g. `available` / `redeeming` / `redeemed`. An entry
+    /// that omits it is not readable as available, so it is skipped.
+    #[serde(default)]
     pub status: String,
-    /// RFC3339 grant time.
-    pub granted_at: String,
     /// RFC3339 expiry time, or `None` when the credit does not expire.
+    #[serde(default)]
     pub expires_at: Option<String>,
 }
 

--- a/src/core/src/quota/mod.rs
+++ b/src/core/src/quota/mod.rs
@@ -272,7 +272,7 @@ impl CodexState {
                 expirations,
             } => {
                 self.reset_credits_cooldown.clear();
-                snap.reset_credits_available = Some(available_count);
+                snap.reset_credits_available = available_count.or(snap.reset_credits_available);
                 snap.reset_credit_expirations = Some(expirations);
             }
             ResetCreditsResult::Transient => {}
@@ -306,7 +306,8 @@ impl CodexState {
                         expirations,
                     } => {
                         self.reset_credits_cooldown.clear();
-                        snap.reset_credits_available = Some(available_count);
+                        snap.reset_credits_available =
+                            available_count.or(snap.reset_credits_available);
                         snap.reset_credit_expirations = Some(expirations);
                     }
                     ResetCreditsResult::Unauthorized => {

--- a/src/core/src/quota/wham.rs
+++ b/src/core/src/quota/wham.rs
@@ -169,16 +169,18 @@ pub fn map_wham_response(body: &str, now: i64) -> Result<CodexQuotaSnapshot> {
 /// times for credits whose status is `available`.
 ///
 /// The expiry list may be shorter than the count because the backend can cap
-/// detail rows. `None` entries sort last and mean the credit never expires.
+/// detail rows. `None` entries sort last and mean the credit never expires. A
+/// `None` count means the response did not report one, leaving whatever
+/// wham/usage already said standing.
 ///
 /// # Errors
 ///
 /// Returns an error when the response shape or an available credit's RFC3339
 /// expiry is malformed.
-pub fn map_reset_credits_response(body: &str) -> Result<(i64, Vec<Option<i64>>)> {
+pub fn map_reset_credits_response(body: &str) -> Result<(Option<i64>, Vec<Option<i64>>)> {
     let resp: WhamResetCreditsDetails = serde_json::from_str(body)
         .context("Failed to parse wham/rate-limit-reset-credits response")?;
-    let available_count = resp.available_count.max(0);
+    let available_count = resp.available_count.map(|count| count.max(0));
 
     let mut expirations = Vec::new();
     for credit in resp.credits.into_iter().filter(|c| c.status == "available") {
@@ -234,9 +236,10 @@ pub enum WhamResult {
 
 /// Outcome of the optional reset-credit details request.
 pub enum ResetCreditsResult {
-    /// Authoritative count plus sorted available-credit expirations.
+    /// Authoritative count plus sorted available-credit expirations. A `None`
+    /// count means the response omitted it; keep the one wham/usage reported.
     Ok {
-        available_count: i64,
+        available_count: Option<i64>,
         expirations: Vec<Option<i64>>,
     },
     /// 401: the caller may refresh the token and retry once.
@@ -305,7 +308,7 @@ pub fn call_wham_with_reset_credits(
             available_count,
             expirations,
         } => {
-            snap.reset_credits_available = Some(available_count);
+            snap.reset_credits_available = available_count.or(snap.reset_credits_available);
             snap.reset_credit_expirations = Some(expirations);
         }
         ResetCreditsResult::Unauthorized | ResetCreditsResult::Transient => {}
@@ -537,7 +540,7 @@ mod tests {
     fn maps_available_reset_credit_expirations_in_order() {
         let (count, expirations) = map_reset_credits_response(RESET_CREDITS_SAMPLE).unwrap();
 
-        assert_eq!(count, 5, "top-level count stays authoritative");
+        assert_eq!(count, Some(5), "top-level count stays authoritative");
         assert_eq!(expirations.len(), 3, "redeemed credit is excluded");
         assert!(expirations[0].unwrap() < expirations[1].unwrap());
         assert_eq!(expirations[2], None, "non-expiring credit sorts last");
@@ -555,6 +558,40 @@ mod tests {
         }"#;
 
         assert!(map_reset_credits_response(body).is_err());
+    }
+
+    #[test]
+    fn maps_reset_credits_response_with_dropped_fields() {
+        let body = r#"{
+          "credits": [
+            { "status": "available", "expires_at": "2026-08-01T00:00:00Z" },
+            { "status": "available" },
+            { "expires_at": "2026-07-01T00:00:00Z" }
+          ],
+          "available_count": 3
+        }"#;
+
+        let (count, expirations) = map_reset_credits_response(body).unwrap();
+
+        assert_eq!(count, Some(3));
+        assert_eq!(
+            expirations,
+            vec![Some(1785542400), None],
+            "an entry with no status is not readable as available"
+        );
+    }
+
+    #[test]
+    fn missing_reset_credit_count_leaves_the_usage_count_standing() {
+        let (count, expirations) =
+            map_reset_credits_response(r#"{"credits":[{"status":"redeemed"}]}"#).unwrap();
+
+        assert_eq!(count, None, "absent count means unknown, not zero");
+        assert!(expirations.is_empty());
+
+        let (count, expirations) = map_reset_credits_response("{}").unwrap();
+        assert_eq!(count, None);
+        assert!(expirations.is_empty());
     }
 
     #[test]

--- a/src/core/tests/http_mock.rs
+++ b/src/core/tests/http_mock.rs
@@ -150,6 +150,39 @@ fn reset_credit_details_failure_preserves_usage_summary() {
 }
 
 #[test]
+fn reset_credit_details_without_a_count_keeps_the_usage_summary_count() {
+    let server = MockServer::start();
+    server.mock(|when, then| {
+        when.method(GET).path("/wham");
+        then.status(200)
+            .body(fixture_str("quota/wham_usage_response.json"));
+    });
+    server.mock(|when, then| {
+        when.method(GET).path("/reset-credits");
+        then.status(200)
+            .body(r#"{"credits":[{"status":"available","expires_at":null}]}"#);
+    });
+    let client = build_client().unwrap();
+
+    let result = call_wham_with_reset_credits(
+        &client,
+        "tok",
+        Some("acct"),
+        1_000_000,
+        &server.url("/wham"),
+        &server.url("/reset-credits"),
+    );
+
+    match result {
+        WhamResult::Ok(snap) => {
+            assert_eq!(snap.reset_credits_available, Some(2), "from wham/usage");
+            assert_eq!(snap.reset_credit_expirations, Some(vec![None]));
+        }
+        _ => panic!("a details response missing fields must still map"),
+    }
+}
+
+#[test]
 fn reset_credit_details_401_is_unauthorized() {
     let server = MockServer::start();
     server.mock(|when, then| {


### PR DESCRIPTION
`WhamResetCreditDetails` and its container were the only two structs in the wham model family with no serde leniency, so a single key the backend stops emitting fails the whole `wham/rate-limit-reset-credits` parse and the Codex quota card loses every credit expiry. Two of the five fields it insisted on were never read at all.

Closes #192

## What changed

- **`models/quota.rs`** — `#[serde(default)]` on every field of `WhamResetCreditsDetails` and `WhamResetCreditDetails`, matching `WhamCredits` and the rest of the family. `reset_type` and `granted_at` are gone: nothing reads them, and every other struct here models only the subset the code reads, so keeping them as always-defaulted `String`s would just leave two dead fields behind. `expires_at` needed nothing, since serde already maps a missing `Option` field to `None` — which is why it was the one field of the five that never contributed to this bug.
- **`available_count` became `Option<i64>`** rather than a defaulted `0`. Defaulting it would have been *worse* than the hard error it replaces: the panel would report "0 reset credits" and hide the expiry line, while the parse failure at least preserved the count `wham/usage` had already given it. `None` now says exactly that, and the three assignment sites fall back with `available_count.or(snap.reset_credits_available)`.
- An entry that drops `status` is skipped rather than counted, so a partial list can never fabricate a "reset never expires" line.

## Deliberately unchanged

A malformed RFC3339 `expires_at` on an available credit still fails the details parse. That is a wrong value rather than a dropped field, and it is the only signal the panel has that the timestamp cannot be trusted.

No doc changes: `docs/quota.md` describes the endpoint's real shape, and the CLAUDE.md line about the count staying authoritative over a capped list is still true.

## Testing

`cargo test --workspace`, `make fmt`, `uvx pre-commit run -a`. Three new tests: a credit list carrying nothing but `expires_at` still maps, a details response with no `available_count` leaves the summary's count standing (end to end through `call_wham_with_reset_credits`), and an entry with no `status` is skipped instead of failing the response.

---

Opened-by: Claude Opus 5
