### PR TITLE
test(session): name three tests for what they assert

### DIFF
--- a/src/core/src/session/claude.rs
+++ b/src/core/src/session/claude.rs
@@ -774,12 +774,13 @@ mod tests {
     }
 
     #[test]
-    fn main_session_string_tool_use_result_does_not_double_count() {
-        // Main session records can have a string-shaped toolUseResult
-        // (rejection messages) alongside a content tool_result block.
-        // Here we simulate `isSidechain == false` and expect zero read
-        // lines: the string `toolUseResult` carries no file content, so the
-        // content block's text must not be counted as one.
+    fn main_session_tool_result_block_is_not_read_as_file_content() {
+        // A main-session user record can carry a content tool_result block
+        // alongside a string-shaped `toolUseResult` (a rejection message),
+        // which deserializes to `None` and so lands in the subagent fallback
+        // branch. The `!log.is_sidechain` gate there is what keeps the
+        // block's text out of the read tally, while the assistant's
+        // `tool_use` still counts one Read call.
         let raw_assistant = serde_json::json!({
             "type": "assistant",
             "timestamp": "2025-01-01T00:00:00Z",
@@ -813,7 +814,7 @@ mod tests {
         let record = &analysis.records[0];
         assert_eq!(
             record.total_read_lines, 0,
-            "main-session string toolUseResult must not trigger fallback"
+            "main-session tool_result block must not be dispatched as a file read"
         );
         assert_eq!(record.tool_call_counts.read, 1, "tool_use bump only");
     }

--- a/src/core/src/session/codex.rs
+++ b/src/core/src/session/codex.rs
@@ -1093,7 +1093,10 @@ mod tests {
     }
 
     #[test]
-    fn resumed_usage_subtracts_the_pre_context_replay_baseline() {
+    fn resumed_usage_bills_only_post_baseline_deltas() {
+        // A resumed session replays its prior context before the first
+        // `turn_context`: that opening snapshot only advances the parse loop's
+        // baseline, and every later event is billed its own delta.
         let logs: Vec<CodexLog> = [
             serde_json::json!({
                 "timestamp": "2026-07-12T00:00:00Z",

--- a/src/core/src/session/cursor.rs
+++ b/src/core/src/session/cursor.rs
@@ -835,22 +835,6 @@ fn load_node_blobs(conn: &Connection) -> Result<Vec<Vec<u8>>> {
     Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
 }
 
-/// Returns `(embedded message JSON bytes, timestamp_ms)` for a binary DAG node.
-///
-/// Binary nodes start with `field 1` (`0x0A`), carry the message in `field 4`
-/// and the epoch-ms timestamp in `field 26`; the role is not checked here.
-/// Non-node blobs (JSON messages) return `None`, as do nodes missing the
-/// timestamp — an undateable turn is skipped rather than mis-bucketed to the
-/// epoch (1970).
-#[cfg(test)]
-fn assistant_node(data: &[u8]) -> Option<(&[u8], i64)> {
-    if data.first() != Some(&0x0A) {
-        return None;
-    }
-    let node = walk_node(data);
-    Some((node.msg?, node.ts?))
-}
-
 /// The `role` of a message JSON blob, when it parses and carries one.
 fn message_role(bytes: &[u8]) -> Option<String> {
     serde_json::from_slice::<Value>(bytes)
@@ -1306,15 +1290,15 @@ mod tests {
     }
 
     #[test]
-    fn assistant_node_extracts_message_and_ts() {
+    fn node_fields_extract_message_and_ts() {
         let node = make_node(
             r#"{"role":"assistant","content":[]}"#,
             1_700_000_000_000,
             None,
         );
-        let (msg, ts) = assistant_node(&node).unwrap();
-        assert_eq!(ts, 1_700_000_000_000);
-        let parsed: Value = serde_json::from_slice(msg).unwrap();
+        let nf = walk_node(&node);
+        assert_eq!(nf.ts, Some(1_700_000_000_000));
+        let parsed: Value = serde_json::from_slice(nf.msg.unwrap()).unwrap();
         assert_eq!(parsed["role"], "assistant");
     }
 
@@ -1326,9 +1310,33 @@ mod tests {
     }
 
     #[test]
-    fn json_blob_is_not_an_assistant_node() {
-        let blob = br#"{"role":"assistant","content":[]}"#.to_vec();
-        assert!(assistant_node(&blob).is_none());
+    fn json_blob_is_not_read_as_an_assistant_turn() {
+        // Assistant turns are binary DAG nodes; a JSON blob is a tool-result
+        // payload even when its own `role` says assistant. Neither reader may
+        // pick one up as a turn, or the same tool calls would be billed twice
+        // once a real node references them.
+        let json_blob = r#"{"role":"assistant","content":[
+            {"type":"tool-call","toolName":"Write","toolCallId":"a","args":{"path":"/r/x.rs","contents":"l1\nl2"}}
+        ]}"#;
+        let (_dir, path) = make_store_db(&[], &[json_blob]);
+        let conv_models = FastHashMap::default();
+
+        let store = read_store_analysis(
+            &path,
+            &conv_models,
+            TimeRange::All,
+            ParseMode::Full,
+            "u",
+            "m",
+        )
+        .unwrap();
+        assert!(store.rows.is_empty());
+        assert_eq!(store.normalized_messages, 0);
+        assert_eq!(store.failed_payloads, 0);
+
+        let read = read_store_context(&path, &conv_models, "conversation").unwrap();
+        assert!(read.turns.is_empty());
+        assert_eq!(read.expected_records, 0);
     }
 
     #[test]


### PR DESCRIPTION
Closes #194.

Three tests named coverage they did not have. The assertions were correct in all three and are kept; what changes is the names, the comments, and — for Cursor — what the test is pointed at.

### `src/core/src/session/codex.rs`

`resumed_usage_subtracts_the_pre_context_replay_baseline` named a mechanism deleted in `b861d02`. Renamed to `resumed_usage_bills_only_post_baseline_deltas`, with a comment naming the mechanism that does exist: the pre-`turn_context` snapshot only advances the parse loop's baseline, and every later event is billed its own delta. It now reads as the same design as its sibling `pre_context_usage_is_not_guessed_from_a_later_model` rather than a competing one.

### `src/core/src/session/claude.rs`

`main_session_string_tool_use_result_does_not_double_count` named something structurally impossible. Renamed to `main_session_tool_result_block_is_not_read_as_file_content`, which is the `!log.is_sidechain` gate it really guards: the read tally stays 0 while `tool_call_counts.read` still bumps to 1.

No replacement double-count test is added. The two result paths are `if` / `else if`, so exactly one runs per record and the same result cannot be counted twice. A test for it would pin a property no edit inside either branch can break, which is the failure mode #165 is about.

### `src/core/src/session/cursor.rs`

`assistant_node` was `#[cfg(test)]`-only with no production caller, and its first-byte check was a *copy* of the checks in `read_store_analysis` / `read_store_context` rather than the check itself — so both of its tests asserted something about a test fixture, not about vct. It is deleted and both tests point at production instead:

- `node_fields_extract_message_and_ts` calls the production `walk_node` directly, the way the neighbouring `node_context_gauge_decodes` already did.
- `json_blob_is_not_read_as_an_assistant_turn` drives `read_store_analysis` and `read_store_context` over a store whose only blob is an assistant-role JSON payload carrying a `Write` tool call. Both must come back empty, so a JSON payload can never have its tool calls billed as a turn's. Verified load-bearing by mutation: folding JSON blobs into the message path turns it red. The nearest existing fixture (`read_store_analysis_over_real_db_counts_tools_and_ignores_non_assistant`) also holds an assistant-role JSON blob, but with empty content, so it bills nothing either way.

What the test does *not* pin is the leading-`0x0A` check in isolation: a `{` is not a decodable protobuf tag, so `walk_node` rejects the blob anyway and removing the byte guard leaves the test green. That guard is a fast path and `load_node_blobs`'s SQL `X'0A'` filter is a memory optimisation; neither changes an outcome, and pinning them would take a synthetic blob Cursor never writes.

One correction to the issue as filed. "Nothing anywhere distinguishes an assistant node from a non-assistant one" does not hold for production: `read_store_analysis_over_real_db_counts_tools_and_ignores_non_assistant` and `read_store_context_recovers_gauge_per_assistant_turn_only` each feed a `role: "user"` node and assert it is dropped, and both production paths do check the role. `assistant_node` simply was not the code doing it, so the gap was confined to the test-only helper. Teaching that helper a role check would have added a rule no caller enforces; removing it and pointing the tests at the readers that do enforce one closes the gap for real.

No production behaviour changes. `make fmt`, `cargo test --workspace` and `uvx pre-commit run -a` are clean.

---

Opened-by: Claude Opus 5
