### PR TITLE
fix(opencode): join session in the all-time analysis candidate count

### DIFF
--- a/src/core/src/session/opencode.rs
+++ b/src/core/src/session/opencode.rs
@@ -186,6 +186,10 @@ struct CollectedAnalysis {
 }
 
 /// Counts rows that should be understood by the current analysis reader.
+///
+/// Every branch selects exactly what its collector counterpart selects: a row
+/// counted here but unreachable there is reported as schema drift, and a
+/// database made up entirely of such rows fails the whole scan.
 fn count_analysis_candidates(conn: &Connection, time_range: TimeRange) -> Result<usize> {
     let cutoff_ms = cutoff_millis(time_range);
     let (sql, parameterized) = if table_exists(conn, "message")? {
@@ -203,6 +207,7 @@ fn count_analysis_candidates(conn: &Connection, time_range: TimeRange) -> Result
             ),
             None => (
                 "SELECT COUNT(*) FROM message \
+                 JOIN session ON session.id = message.session_id \
                  WHERE json_extract(message.data, '$.role') = 'assistant'",
                 false,
             ),
@@ -1458,6 +1463,58 @@ mod tests {
                 .to_string()
                 .contains("none of 1 OpenCode analysis records")
         );
+    }
+
+    #[test]
+    fn analysis_candidate_count_skips_messages_without_a_session() {
+        let (_dir, db_path) = make_db();
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute(
+            "INSERT INTO session (id, directory, time_updated) VALUES ('s1', '/repo', 1780757089000)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES ('m1', 's1', ?1)",
+            [assistant_message("model", 1, 2, 0, 0, 0, 0.5)],
+        )
+        .unwrap();
+        // The collectors join `session`, so an assistant row whose session is
+        // gone can never be collected and must not be counted as expected.
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES ('m2', 'gone', ?1)",
+            [assistant_message("model", 3, 4, 0, 0, 0, 0.5)],
+        )
+        .unwrap();
+        drop(conn);
+
+        let result =
+            read_opencode_analysis_with_diagnostics(&db_path, TimeRange::All, ParseMode::Full)
+                .unwrap();
+        assert_eq!(result.expected_records, 1);
+        assert_eq!(result.parsed_records, 1);
+        assert_eq!(result.rows.len(), 1);
+    }
+
+    #[test]
+    fn analysis_accepts_a_database_whose_assistant_rows_are_all_orphaned() {
+        let (_dir, db_path) = make_db();
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute(
+            "INSERT INTO message (id, session_id, data) VALUES ('m1', 'gone', ?1)",
+            [assistant_message("model", 1, 2, 0, 0, 0, 0.5)],
+        )
+        .unwrap();
+        drop(conn);
+
+        let result =
+            read_opencode_analysis_with_diagnostics(&db_path, TimeRange::All, ParseMode::Full)
+                .unwrap();
+        assert_eq!(result.expected_records, 0);
+        assert_eq!(result.parsed_records, 0);
+
+        let rows = read_opencode_analysis(&db_path, TimeRange::All, ParseMode::Full).unwrap();
+        assert!(rows.is_empty());
     }
 
     #[test]

--- a/src/core/tests/analysis.rs
+++ b/src/core/tests/analysis.rs
@@ -1400,6 +1400,34 @@ fn collection_diagnostics_reject_unknown_opencode_assistant_schema() {
 }
 
 #[test]
+fn collection_diagnostics_accept_opencode_messages_without_a_session() {
+    let home = TempHome::new();
+    std::fs::create_dir_all(home.paths.opencode_db.parent().unwrap()).unwrap();
+    let conn = Connection::open(&home.paths.opencode_db).unwrap();
+    conn.execute_batch(
+        "CREATE TABLE session (id TEXT PRIMARY KEY, directory TEXT, time_updated INTEGER); \
+         CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, data TEXT); \
+         CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, data TEXT); \
+         INSERT INTO message VALUES ('m1', 'gone', \
+             '{\"role\":\"assistant\",\"modelID\":\"model\",\"tokens\":{\"input\":1}}');",
+    )
+    .unwrap();
+    drop(conn);
+
+    let dataset = collect_analysis_sessions_from_paths_with(
+        &home.paths,
+        TimeRange::All,
+        providers_only(ExtensionType::OpenCode),
+        ParseMode::Full,
+    )
+    .unwrap();
+    assert!(dataset.is_empty());
+    assert_eq!(dataset.diagnostics.candidates, 1);
+    assert_eq!(dataset.diagnostics.parsed, 1);
+    assert!(dataset.diagnostics.failures.is_empty());
+}
+
+#[test]
 fn streaming_aggregation_retains_partial_failure_diagnostics() {
     let home = TempHome::new();
     home.put_claude_session(


### PR DESCRIPTION
Closes #184.

`count_analysis_candidates` in `src/core/src/session/opencode.rs` has two SQL branches for the
`message` schema. The cutoff branch joins `session`; the no-cutoff branch did not. Both real
collectors (`collect_message_analysis`, `collect_message_usage`) carry
`JOIN session ON session.id = message.session_id` in **both** of their branches, so an assistant
`message` row whose `session_id` has no matching `session` row was counted into `expected_records`
and could never appear in the collected rows.

`cutoff_millis` returns `None` for `TimeRange::All`, which is also the default, so this is the
branch `vct analysis --all` and any run under the default `default_time_range` takes.

## What changed

- The no-cutoff `message` branch now carries the same join as its cutoff sibling, so both branches
  select exactly the row set the collectors do. The legacy `session`-table branches already matched
  `collect_session_analysis` and are untouched.
- The function's doc comment now states the invariant the two branches have to hold.

## Why it matters

Downstream, `read_opencode_analysis` and both aggregator paths in `src/core/src/analysis/aggregator.rs`
derive their diagnostics from `expected - parsed`:

- a positive difference logged a schema-drift warning naming records that were never drift;
- `expected > 0 && parsed == 0` returned a hard error, so a database whose assistant `message` rows
  are all orphaned failed the whole scan with "none of N OpenCode analysis records used a recognized
  schema".

An orphaned row belongs to a deleted session, so it carries no `directory` or `time_updated` and the
collectors could not build a row from it either way. It is now dropped quietly rather than reported
as drift, which is what the counter agreeing with the collectors means.

## Tests

Three regression tests, each failing before the fix:

- `analysis_candidate_count_skips_messages_without_a_session` — one joinable assistant message plus
  one orphaned one under `TimeRange::All`: `expected_records` counts only the joinable row and equals
  `parsed_records` (was `2` vs `1`).
- `analysis_accepts_a_database_whose_assistant_rows_are_all_orphaned` — an all-orphaned database
  reports zero expected records and returns `Ok` with no rows (was the hard error above).
- `collection_diagnostics_accept_opencode_messages_without_a_session` in `src/core/tests/analysis.rs`
  — the same database at the aggregator level is a successful, empty scan rather than an all-failed
  one, which is where the user-visible symptom came from.

`make fmt`, `cargo test --workspace` and `uvx pre-commit run -a` are clean.

## Out of scope, noticed while here

Two neighbouring count/collect divergences of the same class, neither introduced nor fixed here:

- `cutoff_millis` builds its bound with `Local.with_ymd_and_hms(.., 0, 0, 0).earliest()`, which is
  `None` in a zone whose DST jump lands on local midnight. `--daily` / `--weekly` / `--monthly` then
  fall into the no-cutoff branch, which applies no date predicate at all while the collector still
  drops old rows in Rust. Affects the legacy branch and both usage collectors too.
- In the cutoff branch, the counter resolves the timestamp in SQL while the collector resolves it
  through `serde_json` `as_i64()`, so a `time.completed` written as a float or a string is kept by
  one and dropped by the other.

---

Opened-by: Claude Opus 5
