### PR TITLE
chore(core): remove nine dead or never-read items in the parsing and models layer

### DIFF
--- a/src/core/src/models/aggregate.rs
+++ b/src/core/src/models/aggregate.rs
@@ -6,8 +6,6 @@
 //! importing the other, and the display layer re-exports this type instead of
 //! defining a parallel container.
 
-use crate::models::Provider;
-
 /// Per-provider totals organized by AI provider.
 ///
 /// Keeps each provider's running totals alongside an `overall` "All Providers"
@@ -50,46 +48,6 @@ impl<S: Default> Default for ProviderTotals<S> {
             grok: S::default(),
             deepseek: S::default(),
             overall: S::default(),
-        }
-    }
-}
-
-impl<S> ProviderTotals<S> {
-    /// Borrows the stats bucket for `provider`.
-    ///
-    /// [`Provider::Unknown`] maps to the `overall` bucket, since there is no
-    /// dedicated slot for unclassified providers.
-    pub fn get_stats(&self, provider: Provider) -> &S {
-        match provider {
-            Provider::ClaudeCode => &self.claude,
-            Provider::Codex => &self.codex,
-            Provider::Copilot => &self.copilot,
-            Provider::Gemini => &self.gemini,
-            Provider::OpenCode => &self.opencode,
-            Provider::Cursor => &self.cursor,
-            Provider::Hermes => &self.hermes,
-            Provider::Grok => &self.grok,
-            Provider::DeepSeek => &self.deepseek,
-            Provider::Unknown => &self.overall,
-        }
-    }
-
-    /// Mutably borrows the stats bucket for `provider`.
-    ///
-    /// [`Provider::Unknown`] maps to the `overall` bucket, since there is no
-    /// dedicated slot for unclassified providers.
-    pub fn get_stats_mut(&mut self, provider: Provider) -> &mut S {
-        match provider {
-            Provider::ClaudeCode => &mut self.claude,
-            Provider::Codex => &mut self.codex,
-            Provider::Copilot => &mut self.copilot,
-            Provider::Gemini => &mut self.gemini,
-            Provider::OpenCode => &mut self.opencode,
-            Provider::Cursor => &mut self.cursor,
-            Provider::Hermes => &mut self.hermes,
-            Provider::Grok => &mut self.grok,
-            Provider::DeepSeek => &mut self.deepseek,
-            Provider::Unknown => &mut self.overall,
         }
     }
 }

--- a/src/core/src/models/copilot.rs
+++ b/src/core/src/models/copilot.rs
@@ -47,12 +47,6 @@ pub struct CopilotSessionStartData {
     /// Session identifier.
     #[serde(default)]
     pub session_id: String,
-    /// Copilot CLI version that produced the session.
-    #[serde(default)]
-    pub copilot_version: String,
-    /// ISO-8601 session start time.
-    #[serde(default)]
-    pub start_time: String,
     /// Workspace context, when the session ran inside a project.
     #[serde(default)]
     pub context: Option<CopilotSessionContext>,
@@ -78,25 +72,10 @@ pub struct CopilotSessionContext {
     /// run inside a git repo.
     #[serde(default)]
     pub repository: String,
-    /// E.g. `"github"`.
-    #[serde(default)]
-    pub host_type: String,
     /// E.g. `"github.com"`; used together with `repository` to reconstruct
     /// the remote URL.
     #[serde(default)]
     pub repository_host: String,
-}
-
-/// `session.model_change` payload — each session may switch between models at
-/// any point, so the analyzer attributes the streamed `assistant.message`
-/// output tokens to the most recent one. That fallback only applies to
-/// sessions that never reach `session.shutdown`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CopilotModelChangeData {
-    /// Model the session switched to.
-    #[serde(default)]
-    pub new_model: String,
 }
 
 /// `session.shutdown` payload — authoritative per-model token usage.
@@ -111,9 +90,6 @@ pub struct CopilotShutdownData {
     /// Per-model token metrics, keyed by model name.
     #[serde(default)]
     pub model_metrics: BTreeMap<String, CopilotModelMetric>,
-    /// Model that was active when the session shut down.
-    #[serde(default)]
-    pub current_model: String,
 }
 
 /// Per-model block inside [`CopilotShutdownData::model_metrics`].

--- a/src/core/src/models/filter.rs
+++ b/src/core/src/models/filter.rs
@@ -54,15 +54,6 @@ impl TimeRange {
     }
 }
 
-/// Collapses the period flags into a single [`TimeRange`].
-///
-/// Falls back to [`TimeRange::All`] when none is set. The flags are mutually
-/// exclusive at the CLI layer (shared `period` group), so at most one is ever
-/// true here.
-pub fn resolve_time_range(daily: bool, weekly: bool, monthly: bool) -> TimeRange {
-    resolve_time_range_with_default(daily, weekly, monthly, false, TimeRange::All)
-}
-
 /// Collapses the period flags into a [`TimeRange`], falling back to `default`
 /// when the caller passed none of them.
 ///

--- a/src/core/src/models/provider.rs
+++ b/src/core/src/models/provider.rs
@@ -1,26 +1,27 @@
-//! The [`Provider`] discriminator and its model-name detection.
+//! The [`Provider`] discriminator and its display name.
 
 use std::fmt;
 
 /// Supported AI coding assistant providers.
 ///
-/// Used both to tag a parsed session with its source assistant and to route
-/// per-provider usage aggregation. [`Provider::Unknown`] is the fallback when a
-/// model name matches none of the known prefixes.
+/// Routes the per-provider usage and analysis roll-ups and labels their display
+/// rows. The assistant a session was parsed *from* is
+/// [`ExtensionType`](crate::models::ExtensionType), which has no `Unknown`;
+/// [`Provider::Unknown`] here is the fallback for a row that belongs to no
+/// known provider.
 ///
 /// # Examples
 ///
 /// ```
 /// use vct_core::models::Provider;
 ///
-/// assert_eq!(Provider::from_model_name("claude-sonnet-4"), Provider::ClaudeCode);
 /// assert_eq!(Provider::ClaudeCode.display_name(), "Claude");
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Provider {
     /// Anthropic Claude Code.
     ClaudeCode,
-    /// OpenAI Codex CLI (also matches raw `gpt-*` / `o1` / `o3` model names).
+    /// OpenAI Codex CLI.
     Codex,
     /// GitHub Copilot CLI.
     Copilot,
@@ -36,86 +37,11 @@ pub enum Provider {
     Grok,
     /// DeepSeek Harness (`dsh`).
     DeepSeek,
-    /// Model name matched no known provider prefix.
+    /// No known provider.
     Unknown,
 }
 
 impl Provider {
-    /// Detects the AI provider from a model name using byte-level prefix matching.
-    ///
-    /// Recognizes the `claude`, `copilot`, `gemini`, and `grok` prefixes, and
-    /// treats `gpt*` / `o1*` / `o3*` model names as [`Provider::Codex`].
-    /// Matching is case-sensitive (lowercase) and operates directly on the
-    /// UTF-8 bytes, so it stays `const` and allocation-free. Returns
-    /// [`Provider::Unknown`] when no prefix matches.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use vct_core::models::Provider;
-    ///
-    /// assert_eq!(Provider::from_model_name("gpt-4-turbo"), Provider::Codex);
-    /// assert_eq!(Provider::from_model_name("o3-mini"), Provider::Codex);
-    /// assert_eq!(Provider::from_model_name("gemini-2.0-flash"), Provider::Gemini);
-    /// assert_eq!(Provider::from_model_name("mystery-model"), Provider::Unknown);
-    /// ```
-    pub const fn from_model_name(model: &str) -> Self {
-        let bytes = model.as_bytes();
-
-        if bytes.len() >= 6
-            && bytes[0] == b'c'
-            && bytes[1] == b'l'
-            && bytes[2] == b'a'
-            && bytes[3] == b'u'
-            && bytes[4] == b'd'
-            && bytes[5] == b'e'
-        {
-            return Self::ClaudeCode;
-        }
-
-        if bytes.len() >= 7
-            && bytes[0] == b'c'
-            && bytes[1] == b'o'
-            && bytes[2] == b'p'
-            && bytes[3] == b'i'
-            && bytes[4] == b'l'
-            && bytes[5] == b'o'
-            && bytes[6] == b't'
-        {
-            return Self::Copilot;
-        }
-
-        if bytes.len() >= 6
-            && bytes[0] == b'g'
-            && bytes[1] == b'e'
-            && bytes[2] == b'm'
-            && bytes[3] == b'i'
-            && bytes[4] == b'n'
-            && bytes[5] == b'i'
-        {
-            return Self::Gemini;
-        }
-
-        if bytes.len() >= 4
-            && bytes[0] == b'g'
-            && bytes[1] == b'r'
-            && bytes[2] == b'o'
-            && bytes[3] == b'k'
-        {
-            return Self::Grok;
-        }
-
-        if bytes.len() >= 3 && bytes[0] == b'g' && bytes[1] == b'p' && bytes[2] == b't' {
-            return Self::Codex;
-        }
-
-        if bytes.len() >= 2 && bytes[0] == b'o' && (bytes[1] == b'1' || bytes[1] == b'3') {
-            return Self::Codex;
-        }
-
-        Self::Unknown
-    }
-
     /// Returns the human-readable display name of the provider.
     ///
     /// This is the same string produced by the [`std::fmt::Display`] impl.
@@ -144,37 +70,6 @@ impl fmt::Display for Provider {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_provider_detection() {
-        assert_eq!(
-            Provider::from_model_name("claude-sonnet-4"),
-            Provider::ClaudeCode
-        );
-        assert_eq!(
-            Provider::from_model_name("claude-3-opus"),
-            Provider::ClaudeCode
-        );
-        assert_eq!(Provider::from_model_name("gpt-4-turbo"), Provider::Codex);
-        assert_eq!(Provider::from_model_name("gpt-3.5"), Provider::Codex);
-        assert_eq!(Provider::from_model_name("o1-preview"), Provider::Codex);
-        assert_eq!(Provider::from_model_name("o3-mini"), Provider::Codex);
-        assert_eq!(Provider::from_model_name("copilot"), Provider::Copilot);
-        assert_eq!(
-            Provider::from_model_name("copilot-gpt-4"),
-            Provider::Copilot
-        );
-        assert_eq!(Provider::from_model_name("gemini-pro"), Provider::Gemini);
-        assert_eq!(
-            Provider::from_model_name("gemini-2.0-flash"),
-            Provider::Gemini
-        );
-        assert_eq!(Provider::from_model_name("grok-4.5"), Provider::Grok);
-        assert_eq!(
-            Provider::from_model_name("unknown-model"),
-            Provider::Unknown
-        );
-    }
 
     #[test]
     fn test_provider_display() {

--- a/src/core/src/models/quota.rs
+++ b/src/core/src/models/quota.rs
@@ -333,9 +333,6 @@ pub struct WhamCredits {
     /// Approximate `[low, high]` local (CLI) messages the credits still buy.
     #[serde(default)]
     pub approx_local_messages: Option<Vec<i64>>,
-    /// Approximate `[low, high]` cloud-task messages the credits still buy.
-    #[serde(default)]
-    pub approx_cloud_messages: Option<Vec<i64>>,
 }
 
 /// Deserializes a JSON string or number into `Option<String>`.

--- a/src/core/src/session/claude.rs
+++ b/src/core/src/session/claude.rs
@@ -248,7 +248,7 @@ where
 
         if let Some(tur) = &log.tool_use_result {
             let correlated =
-                first_tool_result(log.message.as_ref()).and_then(|(tool_use_id, _, is_error)| {
+                first_tool_result(log.message.as_ref()).and_then(|(tool_use_id, is_error)| {
                     pending_tool_uses
                         .remove(tool_use_id)
                         .map(|pending| (pending, is_error))
@@ -360,17 +360,17 @@ fn is_tracked_file_tool(name: &str) -> bool {
     matches!(name, "Read" | "Write" | "Edit")
 }
 
-fn first_tool_result(message: Option<&ClaudeMessage>) -> Option<(&str, &str, bool)> {
+fn first_tool_result(message: Option<&ClaudeMessage>) -> Option<(&str, bool)> {
     message?.content.iter().find_map(|item| {
         let ClaudeContentItem::ToolResult {
             tool_use_id,
-            content,
             is_error,
+            ..
         } = item
         else {
             return None;
         };
-        Some((tool_use_id.as_str(), content.as_str(), *is_error))
+        Some((tool_use_id.as_str(), *is_error))
     })
 }
 

--- a/src/core/src/session/copilot.rs
+++ b/src/core/src/session/copilot.rs
@@ -142,6 +142,9 @@ where
                 }
             }
             "session.model_change" => {
+                // A session may switch models at any point, so the streamed
+                // `assistant.message` tokens below are attributed to whichever
+                // model was current when they arrived.
                 let new_model = event
                     .data
                     .get("newModel")

--- a/src/core/src/session/cursor.rs
+++ b/src/core/src/session/cursor.rs
@@ -975,10 +975,8 @@ fn collect_read_results(blobs: &[Vec<u8>]) -> HashMap<String, CursorReadResult> 
         let role = msg.get("role").and_then(Value::as_str);
         // Assistant messages are also stored as standalone content-addressed
         // JSON blobs and referenced from binary DAG nodes. Pass 2 reads the
-        // dated node, so this undated payload copy is expected and ignored.
-        if role == Some("assistant") {
-            continue;
-        }
+        // dated node, so this undated payload copy is expected and skipped
+        // here along with every other non-tool role.
         if role != Some("tool") {
             continue;
         }

--- a/src/core/src/session/parser.rs
+++ b/src/core/src/session/parser.rs
@@ -11,7 +11,7 @@ use crate::session::detector::{RecordClassifier, detect_extension_type};
 use crate::session::diagnostics::{ParseDiagnostics, ParsedAnalysis};
 use crate::session::dsh::{has_zstd_magic, parse_dsh_session};
 use crate::session::gemini::parse_gemini_events_with_diagnostics;
-use crate::session::grok::{is_grok_signals, parse_grok_session};
+use crate::session::grok::parse_grok_session;
 use crate::session::state::ParseMode;
 use crate::utils::{get_current_user, get_machine_id, read_json, read_jsonl};
 use anyhow::{Context, Result, bail};
@@ -1057,11 +1057,11 @@ fn raw_record_kind(provider: ExtensionType, value: &Value) -> (bool, bool) {
             (recognized, relevant)
         }
         ExtensionType::Gemini => (false, false),
-        ExtensionType::Grok => (is_grok_signals(value), is_grok_signals(value)),
-        // DeepSeek runs its own reader (and the SQLite providers are not files
-        // at all), so no record of theirs ever reaches the typed-stream path
-        // this classifies for.
-        ExtensionType::DeepSeek
+        // Grok and DeepSeek run their own readers (and the SQLite providers are
+        // not files at all), so no record of theirs ever reaches the
+        // typed-stream path this classifies for.
+        ExtensionType::Grok
+        | ExtensionType::DeepSeek
         | ExtensionType::OpenCode
         | ExtensionType::Cursor
         | ExtensionType::Hermes => (false, false),


### PR DESCRIPTION
Resolves all nine items from #193. Every one is removed rather than wired up; two (`first_tool_result` and the Cursor guard) keep the code and only reshape it. No command output changes, the golden fixtures are untouched, and no struct in the set uses `deny_unknown_fields`, so the JSON keys behind the dropped serde fields go on being ignored exactly as before.

## What each item got, and why

- **`CopilotModelChangeData`** — deleted. Its one field is a `#[serde(default)] String`, so a typed read of `session.model_change` can never fail and would add no drift signal on top of what `raw_record_kind`'s Copilot arm and the recognized-type set already record. The sibling arms deserialize because their payloads are nested and can genuinely fail to match; this one has nothing to catch. The raw `event.data.get("newModel")` read is what runs today, is correct, and is covered by tests. The half of the struct's doc that was not already stated beside the code moved onto the handler arm.

- **Four never-read Copilot fields** (`copilot_version`, `start_time`, `host_type`, `current_model`) — deleted. Each was a `String` allocated per event for nothing. The on-disk event shape is pinned by `tests/fixtures/sessions/copilot.jsonl` and documented in `CLAUDE.md`, not by unread struct fields.

- **`first_tool_result`** — now returns `Option<(&str, bool)>`; the middle element was bound to `_` at its one call site. The let-else pattern takes `..` so the `content` binding does not go unused.

- **`raw_record_kind`'s Grok arm** — folded into the inert `(false, false)` group with the comment there extended to name it. Grok's dispatch reaches `parse_grok_session` through every entry point and never this function, and `parse_grok_session` records its own diagnostics. The `is_grok_signals` import goes with the arm; its live callers in `detector.rs` and `grok.rs` are untouched.

- **The redundant `continue` in `collect_read_results`** — dropped; its comment moved onto the surviving `role != Some("tool")` guard, which is where the reader now needs it.

- **`resolve_time_range` (3-arg)** — deleted. `resolve_time_range_with_default` is what the CLI imports and re-exports; the 3-arg form was a forwarding shim with no callers.

- **`WhamCredits::approx_cloud_messages`** — deleted. The captured response fixture and the inline test body keep the JSON key: they mirror what the API really returns, and dropping a field serde already tolerates is not a reason to make a fixture less faithful.

- **`Provider::from_model_name`** — deleted, with the enum's own doc example that called it, its own doctests, and the unit test covering it. This was not a helper waiting to be connected. `PerProviderUsage`'s doc in `models/usage.rs` records that "classify each row by model-name prefix" is the logic that *already shipped a wrong number* — it mis-attributed every Copilot session to Claude Code once Copilot CLI stopped writing the `copilot` sentinel — and that the fix was to bucket by source. The missing `o4` named in the issue is a symptom of that same class, so adding it would fix one name and leave the next. Three doc claims went stale with the function and were reworded: the module doc, the `Codex` variant's "also matches raw `gpt-*` / `o1` / `o3`", and the enum / `Unknown` docs that defined the type by model-name matching.

- **`ProviderTotals::get_stats` / `get_stats_mut`** — both deleted, and the sharp edge with them. `usage/summary.rs` and `analysis/summary.rs` do recompute `overall` from the per-provider fields, so a `get_stats_mut(Provider::Unknown) += x` really would have been discarded. If a keyed accessor is ever wanted, `PerProviderUsage::get` / `get_mut` next door already shows the shape that cannot produce that write: `Option<&S>`, with `Unknown` mapping to `None`.

## Notes

Three of the deletions orphan an import or a binding that only surfaces under `-D warnings`, so each was cleaned up in the same commit: `parser.rs`'s `is_grok_signals`, `aggregate.rs`'s `Provider` import plus the now-empty `impl` block, and the `content` binding in the `first_tool_result` pattern.

Seven of the nine are `pub` in the published `vct-core` crate, reachable through the `models` glob re-export, so this removes public API under what `git-cliff` will read as a minor bump. Nothing in this workspace — core, tui, cli, integration tests or benches — references any of them, and none appears in `vct.schema.json`, which is generated from `config` alone.

Verified with `cargo build --workspace`, `cargo test --workspace` (all suites plus doctests), `make fmt` (clippy at `-D warnings`) and `uvx pre-commit run -a`.

Closes #193

Opened-by: Claude Opus 5
