### PR TITLE
chore(core): fix dead, unguarded and silently-failing paths in the service layer

### DIFF
--- a/src/core/src/cache/file_cache.rs
+++ b/src/core/src/cache/file_cache.rs
@@ -1,9 +1,8 @@
 use crate::constants::capacity;
 use crate::models::{
     CodeAnalysis, CodeAnalysisApplyDiffDetail, CodeAnalysisReadDetail, CodeAnalysisRecord,
-    CodeAnalysisRunCommandDetail, CodeAnalysisWriteDetail, ExtensionType,
+    CodeAnalysisRunCommandDetail, CodeAnalysisWriteDetail,
 };
-use crate::session::ParseMode;
 use anyhow::Result;
 use lru::LruCache;
 use std::fs;
@@ -66,9 +65,10 @@ impl FileParseCache {
     /// Retrieves cached analysis or parses the file if needed, auto-detecting
     /// the provider from file contents.
     ///
-    /// Prefer [`Self::get_or_parse_as`] whenever the caller already knows which
-    /// provider the file belongs to (e.g. walking a specific session
-    /// directory). Content detection is only safe for ad-hoc single-file paths.
+    /// Detection is content-based, so this suits an ad-hoc single-file path. A
+    /// caller walking one provider's session directory already knows the
+    /// provider and should parse through
+    /// [`crate::session::parse_session_file_typed_as`] instead.
     ///
     /// # Errors
     ///
@@ -76,35 +76,7 @@ impl FileParseCache {
     /// session file fails (malformed data, unreadable contents, etc.). A
     /// poisoned cache lock does not error — it simply forces a reparse.
     pub fn get_or_parse<P: AsRef<Path>>(&self, path: P) -> Result<Arc<CodeAnalysis>> {
-        self.get_or_parse_inner(path.as_ref(), None)
-    }
-
-    /// Same as [`Self::get_or_parse`] but the caller specifies which provider
-    /// the file belongs to — the parser skips content-based detection, so
-    /// metadata sentinels at the top of a Claude session (`permission-mode`,
-    /// `file-history-snapshot`) cannot cause the file to be mis-filed under a
-    /// different provider.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the file's metadata cannot be read or if parsing the
-    /// session file as `provider` fails.
-    pub fn get_or_parse_as<P: AsRef<Path>>(
-        &self,
-        path: P,
-        provider: ExtensionType,
-    ) -> Result<Arc<CodeAnalysis>> {
-        self.get_or_parse_inner(path.as_ref(), Some(provider))
-    }
-
-    /// Shared cache lookup + parse path behind [`Self::get_or_parse`] and
-    /// [`Self::get_or_parse_as`]; `provider` of `None` triggers content-based
-    /// auto-detection.
-    fn get_or_parse_inner(
-        &self,
-        path: &Path,
-        provider: Option<ExtensionType>,
-    ) -> Result<Arc<CodeAnalysis>> {
+        let path = path.as_ref();
         let path_buf = path.to_path_buf();
 
         let primary = file_stamp(path)?;
@@ -113,8 +85,7 @@ impl FileParseCache {
             if let Ok(cache_read) = self.cache.read() {
                 // peek() rather than get(), so a hit needs no write lock.
                 if let Some(cached) = cache_read.peek(&path_buf) {
-                    let is_grok = provider == Some(ExtensionType::Grok)
-                        || cached.analysis.extension_name == "Grok";
+                    let is_grok = cached.analysis.extension_name == "Grok";
                     let fingerprint = FileFingerprint {
                         primary,
                         grok_dependencies: is_grok.then(|| grok_dependency_stamps(path)),
@@ -137,26 +108,22 @@ impl FileParseCache {
         }
 
         log::debug!("LRU cache miss for {}, parsing...", path.display());
-        let possible_grok_dependencies = (provider.is_none()
-            || provider == Some(ExtensionType::Grok))
-        .then(|| grok_dependency_stamps(path));
-        let analysis = match provider {
-            Some(p) => crate::session::parse_session_file_typed_as(path, p, ParseMode::Full)?,
-            None => crate::session::parse_session_file_typed(path)?,
-        };
+        // Sampled before the parse: a stamp taken after it could be newer than
+        // what was actually parsed, and the entry would never go stale.
+        let possible_grok_dependencies = grok_dependency_stamps(path);
+        let analysis = crate::session::parse_session_file_typed(path)?;
         let arc_analysis = Arc::new(analysis);
         let size_bytes = estimate_analysis_bytes(arc_analysis.as_ref());
 
         // At capacity the LRU evicts its oldest entry to make room.
         if let Ok(mut cache_write) = self.cache.write() {
-            let is_grok =
-                provider == Some(ExtensionType::Grok) || arc_analysis.extension_name == "Grok";
+            let is_grok = arc_analysis.extension_name == "Grok";
             cache_write.put(
                 path_buf,
                 CachedFile {
                     fingerprint: FileFingerprint {
                         primary,
-                        grok_dependencies: is_grok.then_some(possible_grok_dependencies).flatten(),
+                        grok_dependencies: is_grok.then_some(possible_grok_dependencies),
                     },
                     analysis: Arc::clone(&arc_analysis),
                     size_bytes,

--- a/src/core/src/logging/mod.rs
+++ b/src/core/src/logging/mod.rs
@@ -116,9 +116,10 @@ impl Log for FileLogger {
     }
 
     fn flush(&self) {
-        if let Ok(mut guard) = self.open.lock()
-            && let Some(open) = guard.as_mut()
-        {
+        // Same contract as `append`: a poisoned mutex still holds a valid file
+        // handle, so recover instead of turning flush into a permanent no-op.
+        let mut guard = self.open.lock().unwrap_or_else(|p| p.into_inner());
+        if let Some(open) = guard.as_mut() {
             let _ = open.file.flush();
         }
     }

--- a/src/core/src/pricing/cache.rs
+++ b/src/core/src/pricing/cache.rs
@@ -397,15 +397,18 @@ pub(crate) fn pricing_cache_date() -> String {
 
 /// Removes outdated pricing cache files in `dir`, keeping only today's cache.
 ///
-/// Best-effort: an unreadable directory or a failed delete is ignored rather
-/// than propagated, since a stale cache file is harmless and rotates out daily.
+/// Best-effort: an unreadable directory or a failed delete is logged rather
+/// than propagated, since a stale cache file is harmless. A delete that keeps
+/// failing does not rotate out on its own, though, so it is worth a warning.
 pub fn cleanup_old_cache_in(dir: &Path) {
     let today = pricing_cache_date();
 
     for (filename, path) in list_pricing_cache_files_in(dir) {
         if !filename.contains(&today) {
-            let _ = fs::remove_file(&path);
-            log::debug!("Removed old cache file: {:?}", path);
+            match fs::remove_file(&path) {
+                Ok(()) => log::debug!("Removed old cache file: {}", path.display()),
+                Err(e) => log::warn!("Failed to remove old cache file {}: {e}", path.display()),
+            }
         }
     }
 }

--- a/src/core/src/pricing/matching.rs
+++ b/src/core/src/pricing/matching.rs
@@ -39,7 +39,9 @@ pub struct ModelPricingMap {
     raw: HashMap<Rc<str>, ModelPricing>,
     // Precomputed normalized keys for fast matching
     normalized_index: HashMap<String, Vec<Rc<str>>>,
-    // Precomputed lowercase keys for substring/fuzzy matching
+    // Precomputed lowercase keys for substring/fuzzy matching. Order is
+    // unobservable: both consumers scan the whole vector and tie-break on the
+    // key itself, so no arrangement of it can change a lookup.
     lowercase_keys: Vec<(String, Rc<str>)>, // (lowercase_key, original_key as Rc)
     // Lookup results belong to this map. A process-global result cache is
     // incorrect because model names can map to different prices in each map.
@@ -97,7 +99,6 @@ impl ModelPricingMap {
             rc_raw.insert(rc_key, pricing);
         }
 
-        lowercase_keys.sort_by(|a, b| a.0.cmp(&b.0));
         for candidates in normalized_index.values_mut() {
             candidates.sort_by(|a, b| a.as_ref().cmp(b.as_ref()));
         }

--- a/src/core/src/pricing/matching.rs
+++ b/src/core/src/pricing/matching.rs
@@ -587,13 +587,13 @@ mod tests {
         clear_pricing_cache();
 
         let mut raw = HashMap::new();
-        raw.insert("gpt-4-0613".to_string(), create_test_pricing());
+        raw.insert("claude-3-opus-20240229".to_string(), create_test_pricing());
 
         let map = ModelPricingMap::new(raw);
 
-        // `0613` is four digits, so nothing normalizes away: despite this
-        // test's name the price comes from the substring stage.
-        let result = map.get("gpt-4");
+        // The key's 8-digit date suffix normalizes away, so the query and the
+        // key share a normalized form and never reach the looser stages.
+        let result = map.get("claude-3-opus");
         assert!(result.pricing.input_cost_per_token > 0.0);
     }
 
@@ -602,13 +602,13 @@ mod tests {
         clear_pricing_cache();
 
         let mut raw = HashMap::new();
-        raw.insert("claude-3-opus-20240229".to_string(), create_test_pricing());
+        raw.insert("gpt-4-0613".to_string(), create_test_pricing());
 
         let map = ModelPricingMap::new(raw);
 
-        // The key's 8-digit date normalizes away, so despite this test's name
-        // the price comes from the normalized stage.
-        let result = map.get("claude-3-opus");
+        // `0613` is four digits, not the eight a date suffix needs, so nothing
+        // normalizes away and the price comes from the substring scan.
+        let result = map.get("gpt-4");
         assert!(result.pricing.input_cost_per_token > 0.0);
     }
 
@@ -627,17 +627,15 @@ mod tests {
 
     #[test]
     fn test_fuzzy_match() {
-        // Test fuzzy matching with similar names
         let mut raw = HashMap::new();
         raw.insert("claude-3-sonnet".to_string(), create_test_pricing());
 
         let map = ModelPricingMap::new(raw);
 
-        // Slightly misspelled should still match (if similarity >= 0.7)
+        // Neither name contains the other, so the substring stage finds nothing
+        // and the typo resolves on Jaro-Winkler alone (~0.98, over the 0.7 gate).
         let result = map.get("claude-3-sonet");
-        // This might or might not match depending on Jaro-Winkler score
-        // Just verify it returns a result
-        assert!(result.pricing.input_cost_per_token >= 0.0);
+        assert!(result.pricing.input_cost_per_token > 0.0);
     }
 
     #[test]

--- a/src/core/src/quota/cache.rs
+++ b/src/core/src/quota/cache.rs
@@ -41,7 +41,7 @@ trait CachedQuota: Serialize + DeserializeOwned {
 }
 
 impl CachedQuota for ClaudeQuotaSnapshot {
-    const SCHEMA_VERSION: u32 = 1;
+    const SCHEMA_VERSION: u32 = 2;
 }
 
 impl CachedQuota for CodexQuotaSnapshot {

--- a/src/core/src/quota/claude.rs
+++ b/src/core/src/quota/claude.rs
@@ -186,12 +186,14 @@ pub fn map_claude_usage(body: &str, now: i64) -> Result<ClaudeQuotaSnapshot> {
                     .unwrap_or(std::cmp::Ordering::Equal),
             )
         });
+    // The label is carried whole: how much of it fits is a panel-layout
+    // question, so the renderer that owns the column width decides it.
     let scoped_label = scoped
         .and_then(|l| l.scope.as_ref())
         .and_then(|s| s.model.as_ref())
         .and_then(|m| m.display_name.as_deref())
         .filter(|name| !name.is_empty())
-        .map(|name| name.chars().take(6).collect::<String>());
+        .map(str::to_owned);
     let scoped_weekly = scoped
         .filter(|_| scoped_label.is_some())
         .map(|l| QuotaWindow {
@@ -626,6 +628,18 @@ mod tests {
         assert!(snap.limit_reached, "5h at 100% trips the LIMIT flag");
         assert_eq!(snap.balance.as_deref(), Some("$5.00"));
         assert_eq!(snap.scoped_label.as_deref(), Some("Opus"));
+    }
+
+    #[test]
+    fn scoped_label_is_carried_whole() {
+        // Anthropic sends a full display name. Shortening it is the panel's
+        // call, so the mapper must not spend it here.
+        let body = r#"{
+          "limits": [ { "kind": "weekly_scoped", "percent": 30, "is_active": true,
+                        "scope": { "model": { "display_name": "Claude Opus 4.5" } } } ]
+        }"#;
+        let snap = map_claude_usage(body, 1).unwrap();
+        assert_eq!(snap.scoped_label.as_deref(), Some("Claude Opus 4.5"));
     }
 
     #[test]

--- a/src/core/src/quota/claude.rs
+++ b/src/core/src/quota/claude.rs
@@ -312,11 +312,10 @@ fn refresh_claude(
         body["scope"] = json!(scopes.join(" "));
     }
 
-    let urls = token_urls;
     let mut parsed: Option<ClaudeRefreshResponse> = None;
     let mut last_err: Option<anyhow::Error> = None;
-    for (i, url) in urls.iter().enumerate() {
-        let has_next = i + 1 < urls.len();
+    for (i, url) in token_urls.iter().enumerate() {
+        let has_next = i + 1 < token_urls.len();
         let req = client
             .post(url)
             .header(reqwest::header::USER_AGENT, claude_ua())

--- a/src/core/src/quota/mod.rs
+++ b/src/core/src/quota/mod.rs
@@ -459,6 +459,93 @@ mod tests {
         }
     }
 
+    /// A failing details endpoint is best-effort: the usage snapshot survives
+    /// with the count `wham/usage` itself reported.
+    #[test]
+    fn fetch_with_refresh_keeps_usage_when_details_fail() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET).path("/wham");
+            then.status(200)
+                .body(r#"{"plan_type":"plus","rate_limit_reset_credits":{"available_count":2}}"#);
+        });
+        server.mock(|when, then| {
+            when.method(GET).path("/reset-credits");
+            then.status(500).body("boom");
+        });
+
+        let dir = tempfile::tempdir().unwrap();
+        let auth = dir.path().join("auth.json");
+        std::fs::write(
+            &auth,
+            r#"{"tokens":{"access_token":"tok","refresh_token":"rt","account_id":"acct"}}"#,
+        )
+        .unwrap();
+
+        let client = crate::quota::http::build_client().unwrap();
+        let mut state = CodexState::default();
+        let result = state.fetch_with_refresh(
+            &client,
+            &auth,
+            1_000_000,
+            &server.url("/wham"),
+            &server.url("/reset-credits"),
+            &server.url("/token"),
+        );
+
+        match result {
+            CodexFetch::Ok(snap) => {
+                assert_eq!(snap.reset_credits_available, Some(2));
+                assert!(snap.reset_credit_expirations.is_none());
+            }
+            _ => panic!("a details failure must not fail the usage snapshot"),
+        }
+    }
+
+    /// A details response that omits `available_count` still contributes its
+    /// expirations, and the count `wham/usage` reported is what survives.
+    #[test]
+    fn fetch_with_refresh_keeps_the_usage_count_when_details_omit_it() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET).path("/wham");
+            then.status(200)
+                .body(r#"{"plan_type":"plus","rate_limit_reset_credits":{"available_count":2}}"#);
+        });
+        server.mock(|when, then| {
+            when.method(GET).path("/reset-credits");
+            then.status(200)
+                .body(r#"{"credits":[{"status":"available","expires_at":null}]}"#);
+        });
+
+        let dir = tempfile::tempdir().unwrap();
+        let auth = dir.path().join("auth.json");
+        std::fs::write(
+            &auth,
+            r#"{"tokens":{"access_token":"tok","refresh_token":"rt","account_id":"acct"}}"#,
+        )
+        .unwrap();
+
+        let client = crate::quota::http::build_client().unwrap();
+        let mut state = CodexState::default();
+        let result = state.fetch_with_refresh(
+            &client,
+            &auth,
+            1_000_000,
+            &server.url("/wham"),
+            &server.url("/reset-credits"),
+            &server.url("/token"),
+        );
+
+        match result {
+            CodexFetch::Ok(snap) => {
+                assert_eq!(snap.reset_credits_available, Some(2), "from wham/usage");
+                assert_eq!(snap.reset_credit_expirations, Some(vec![None]));
+            }
+            _ => panic!("a details response missing fields must still map"),
+        }
+    }
+
     /// When refresh itself fails (token endpoint 400), the loop reports
     /// `NeedsLogin` rather than looping or succeeding.
     #[test]

--- a/src/core/src/quota/provider.rs
+++ b/src/core/src/quota/provider.rs
@@ -126,6 +126,10 @@ pub enum QuotaOutcome<T> {
 /// Spawns a detached background worker that refreshes `shared` (and the on-disk
 /// cache via `save`) every `refresh_secs` until `shutdown` is set.
 ///
+/// `refresh_secs` is clamped to at least one second here rather than trusted:
+/// a `0` cadence leaves no sleep at all, so the worker would hammer `resolve`
+/// (and the provider's API) in a tight loop.
+///
 /// The worker is panic-isolated and holds the mutex only for the assignment, so
 /// it can never poison the lock. It is not joined on quit — `shutdown` is set as
 /// a courtesy and the OS reclaims the thread on process exit.
@@ -142,6 +146,8 @@ where
     R: FnMut() -> QuotaOutcome<T> + Send + 'static,
     S: Fn(&T) + Send + 'static,
 {
+    // Sleep in 200ms slices so shutdown stays responsive.
+    let ticks = refresh_secs.max(1).saturating_mul(5);
     std::thread::spawn(move || {
         loop {
             if shutdown.load(Ordering::Relaxed) {
@@ -169,8 +175,7 @@ where
                 Ok(QuotaOutcome::Transient) => {}
                 Err(_) => log::warn!("{label} quota worker panicked; keeping last snapshot"),
             }
-            // Sleep in 200ms slices so shutdown stays responsive.
-            for _ in 0..(refresh_secs * 5) {
+            for _ in 0..ticks {
                 if shutdown.load(Ordering::Relaxed) {
                     break;
                 }

--- a/src/core/src/quota/wham.rs
+++ b/src/core/src/quota/wham.rs
@@ -286,37 +286,6 @@ pub fn call_wham(
     }
 }
 
-/// Calls `wham/usage`, then enriches a successful snapshot with earned reset
-/// credit details. The details request is best-effort: any HTTP or parse error
-/// keeps the count `wham/usage` already reported.
-pub fn call_wham_with_reset_credits(
-    client: &reqwest::blocking::Client,
-    token: &str,
-    account_id: Option<&str>,
-    now: i64,
-    wham_url: &str,
-    reset_credits_url: &str,
-) -> WhamResult {
-    let mut snap = match call_wham(client, token, account_id, now, wham_url) {
-        WhamResult::Ok(snap) => snap,
-        WhamResult::Unauthorized => return WhamResult::Unauthorized,
-        WhamResult::Transient => return WhamResult::Transient,
-    };
-
-    match call_reset_credit_details(client, token, account_id, reset_credits_url) {
-        ResetCreditsResult::Ok {
-            available_count,
-            expirations,
-        } => {
-            snap.reset_credits_available = available_count.or(snap.reset_credits_available);
-            snap.reset_credit_expirations = Some(expirations);
-        }
-        ResetCreditsResult::Unauthorized | ResetCreditsResult::Transient => {}
-    }
-
-    WhamResult::Ok(snap)
-}
-
 /// Calls and maps the earned reset-credit details endpoint.
 pub fn call_reset_credit_details(
     client: &reqwest::blocking::Client,

--- a/src/core/src/update/mod.rs
+++ b/src/core/src/update/mod.rs
@@ -462,8 +462,14 @@ fn acquire_update_lock_at(current_exe: &Path) -> Result<lock::UpdateLock> {
 /// never block the requested command.
 pub fn maybe_auto_update(enabled: bool) -> AutoUpdateOutcome {
     let offline = crate::utils::network_disabled();
-    let Ok(current_exe) = env::current_exe() else {
-        return AutoUpdateOutcome::Failed;
+    let current_exe = match env::current_exe() {
+        Ok(path) => path,
+        Err(error) => {
+            log::warn!(
+                "startup auto-update failed: cannot resolve the running executable: {error}"
+            );
+            return AutoUpdateOutcome::Failed;
+        }
     };
     let managed = ownership::is_release_managed(&current_exe);
     if !auto_update_allowed(enabled, offline, managed) {

--- a/src/core/src/update/mod.rs
+++ b/src/core/src/update/mod.rs
@@ -589,12 +589,6 @@ pub fn update_interactive(force: bool) -> Result<()> {
     }
 }
 
-// Re-export functions for testing
-#[doc(hidden)]
-pub use archive::{extract_targz, extract_zip};
-#[doc(hidden)]
-pub use platform::get_asset_pattern;
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/core/tests/http_mock.rs
+++ b/src/core/tests/http_mock.rs
@@ -10,8 +10,7 @@ use httpmock::prelude::*;
 use serde_json::json;
 use vct_core::quota::http::build_client;
 use vct_core::quota::wham::{
-    ResetCreditsResult, WhamResult, call_reset_credit_details, call_wham,
-    call_wham_with_reset_credits, refresh_codex,
+    ResetCreditsResult, WhamResult, call_reset_credit_details, call_wham, refresh_codex,
 };
 use vct_test_support::fixture_str;
 
@@ -72,14 +71,8 @@ fn call_wham_500_is_transient() {
 }
 
 #[test]
-fn call_wham_with_reset_credits_maps_details() {
+fn call_reset_credit_details_maps_available_credits() {
     let server = MockServer::start();
-    let usage = server.mock(|when, then| {
-        when.method(GET).path("/wham");
-        then.status(200)
-            .header("content-type", "application/json")
-            .body(fixture_str("quota/wham_usage_response.json"));
-    });
     let details = server.mock(|when, then| {
         when.method(GET)
             .path("/reset-credits")
@@ -94,91 +87,21 @@ fn call_wham_with_reset_credits_maps_details() {
     });
     let client = build_client().unwrap();
 
-    let result = call_wham_with_reset_credits(
-        &client,
-        "tok",
-        Some("acct"),
-        1_000_000,
-        &server.url("/wham"),
-        &server.url("/reset-credits"),
-    );
+    let result =
+        call_reset_credit_details(&client, "tok", Some("acct"), &server.url("/reset-credits"));
 
-    usage.assert();
     details.assert();
     match result {
-        WhamResult::Ok(snap) => {
-            assert_eq!(snap.reset_credits_available, Some(5));
-            let expirations = snap.reset_credit_expirations.unwrap();
+        ResetCreditsResult::Ok {
+            available_count,
+            expirations,
+        } => {
+            assert_eq!(available_count, Some(5));
             assert_eq!(expirations.len(), 3);
             assert!(expirations[0].unwrap() < expirations[1].unwrap());
             assert_eq!(expirations[2], None);
         }
-        _ => panic!("expected WhamResult::Ok"),
-    }
-}
-
-#[test]
-fn reset_credit_details_failure_preserves_usage_summary() {
-    let server = MockServer::start();
-    server.mock(|when, then| {
-        when.method(GET).path("/wham");
-        then.status(200)
-            .body(fixture_str("quota/wham_usage_response.json"));
-    });
-    server.mock(|when, then| {
-        when.method(GET).path("/reset-credits");
-        then.status(500).body("boom");
-    });
-    let client = build_client().unwrap();
-
-    let result = call_wham_with_reset_credits(
-        &client,
-        "tok",
-        Some("acct"),
-        1_000_000,
-        &server.url("/wham"),
-        &server.url("/reset-credits"),
-    );
-
-    match result {
-        WhamResult::Ok(snap) => {
-            assert_eq!(snap.reset_credits_available, Some(2));
-            assert!(snap.reset_credit_expirations.is_none());
-        }
-        _ => panic!("details failure must not fail the usage snapshot"),
-    }
-}
-
-#[test]
-fn reset_credit_details_without_a_count_keeps_the_usage_summary_count() {
-    let server = MockServer::start();
-    server.mock(|when, then| {
-        when.method(GET).path("/wham");
-        then.status(200)
-            .body(fixture_str("quota/wham_usage_response.json"));
-    });
-    server.mock(|when, then| {
-        when.method(GET).path("/reset-credits");
-        then.status(200)
-            .body(r#"{"credits":[{"status":"available","expires_at":null}]}"#);
-    });
-    let client = build_client().unwrap();
-
-    let result = call_wham_with_reset_credits(
-        &client,
-        "tok",
-        Some("acct"),
-        1_000_000,
-        &server.url("/wham"),
-        &server.url("/reset-credits"),
-    );
-
-    match result {
-        WhamResult::Ok(snap) => {
-            assert_eq!(snap.reset_credits_available, Some(2), "from wham/usage");
-            assert_eq!(snap.reset_credit_expirations, Some(vec![None]));
-        }
-        _ => panic!("a details response missing fields must still map"),
+        _ => panic!("expected ResetCreditsResult::Ok"),
     }
 }
 

--- a/src/tui/src/display/usage/interactive.rs
+++ b/src/tui/src/display/usage/interactive.rs
@@ -121,6 +121,11 @@ const SHARE_COL_MAX_W: u16 = 24;
 /// How many providers can show a quota card (Claude / Codex / Copilot / Cursor
 /// / Grok). The grid never reads this — it only bounds the render dispatch.
 const MAX_QUOTA_PANELS: usize = 5;
+/// Widest a provider-supplied gauge label may be (Claude's per-model weekly
+/// row). It sits in the same column as `5h` / `7d`, so anything past this is
+/// width the bars lose; `label_width`'s own floor is 5, making 6 the first
+/// width that costs anything at all.
+const SCOPED_LABEL_W: u16 = 6;
 
 /// Which provider quota panels have credentials on this machine.
 #[derive(Clone, Copy, Default)]
@@ -2231,11 +2236,15 @@ fn label_width(labels: &[&str]) -> usize {
 /// Builds the Claude card: plan, 5h / 7d / per-model gauges, then balance.
 fn claude_card(claude: &ClaudeQuotaSnapshot, now: i64, width: u16) -> QuotaCard {
     let inner = card_inner_w(width);
+    // The scoped row's label shares the gauge label column with `5h` / `7d`, so
+    // every character past `SCOPED_LABEL_W` would come straight off the bars.
+    // Anthropic sends a full display name ("Claude Opus 4.5"), hence the cut.
     let scoped = claude
         .scoped_label
         .as_deref()
-        .filter(|_| claude.scoped_weekly.is_some());
-    let label_w = label_width(&["5h", "7d", scoped.unwrap_or("")]);
+        .filter(|_| claude.scoped_weekly.is_some())
+        .map(|label| fit_text(label, SCOPED_LABEL_W));
+    let label_w = label_width(&["5h", "7d", scoped.as_deref().unwrap_or("")]);
 
     // The plan/age line is unconditional: the age is the only sign that a
     // retained snapshot is stale, and a provider without a plan label (Grok
@@ -2277,7 +2286,7 @@ fn claude_card(claude: &ClaudeQuotaSnapshot, now: i64, width: u16) -> QuotaCard 
     }
     // The per-model weekly cap (Fable today) is volatile on Anthropic's side, so
     // it is only drawn when both the window and its model label are present.
-    if let (Some(w), Some(label)) = (&claude.scoped_weekly, scoped) {
+    if let (Some(w), Some(label)) = (&claude.scoped_weekly, scoped.as_deref()) {
         lines.push(gauge_line(
             label,
             label_w,
@@ -3217,6 +3226,22 @@ mod tests {
         let rendered = render_min_card(&claude_card(&claude, 0, CARD_GRID.min_w));
         assert!(rendered.contains(CLAUDE_LOGIN_HINT), "got:\n{rendered}");
         assert!(rendered.contains("+"), "and it says something was hidden");
+    }
+
+    #[test]
+    fn claude_card_shortens_a_long_scoped_label() {
+        // The scoped label is a provider-supplied model name sharing the gauge
+        // label column with 5h / 7d, so the card cuts it rather than letting it
+        // push every bar to the right. The cut is marked, not silent.
+        let claude = ClaudeQuotaSnapshot {
+            five_hour: Some(QuotaWindow::default()),
+            scoped_weekly: Some(QuotaWindow::default()),
+            scoped_label: Some("Claude Opus 4.5".into()),
+            ..Default::default()
+        };
+        let rendered = render_min_card(&claude_card(&claude, 0, CARD_GRID.min_w));
+        assert!(rendered.contains("Claud…"), "got:\n{rendered}");
+        assert!(!rendered.contains("Opus"), "the tail is gone:\n{rendered}");
     }
 
     #[test]


### PR DESCRIPTION
Closes #182.

Twelve independent fixes to paths in the service layer that were dead, unguarded, or quietly weaker than they looked. None was user-visible on its own; each commit stands alone.

**Unreachable-today but unguarded public API**

- `spawn_quota_worker` clamps its own sleep to `refresh_secs.max(1).saturating_mul(5)` ticks and states the precondition. Every in-tree caller comes through `UsageConfig::quota_refresh_secs()`, which already clamps, but the function is `pub` in a published crate and took the raw `u64`: a `0` left no sleep at all and spun the worker on `resolve`.
- `call_wham_with_reset_credits` is gone. It duplicated the enrichment that `CodexState::fetch_with_refresh` → `call_wham` + `finish_with_reset_credits` performs, minus that path's details-401 refresh-and-retry, and only the test suite reached it. Its coverage moves rather than disappears: the successful-details HTTP check now drives `call_reset_credit_details` (keeping the header-identity assertions), and the two snapshot-level cases become inline `CodexState` tests on the shipped path — "the details request fails, so the count `wham/usage` reported survives" (which nothing covered before) and #209's "the details response omits `available_count`", which had been written against the wrapper.

**Dead**

- The three `#[doc(hidden)] pub use` re-exports in `update/mod.rs` (`extract_targz`, `extract_zip`, `get_asset_pattern`). Nothing outside the module used them, and its own tests already reach `platform::get_asset_pattern` by its private path.
- `FileParseCache::get_or_parse_as`, which had no callers anywhere. That leaves `get_or_parse_inner` with an always-`None` provider, so it folds back into `get_or_parse` (dropping the `ExtensionType` / `ParseMode` imports with it). The Grok dependency stamps stay sampled before the parse, and the fingerprint is byte-identical.
- The `lowercase_keys` sort in `ModelPricingMap::new`. Both consumers scan the whole vector and tie-break on the key, which is unique, so no arrangement of it can change a lookup.
- `let urls = token_urls;` in `refresh_claude`.

**Failures that left no trace**

- `FileLogger::flush` recovers from a poisoned mutex like `append` does, instead of becoming a permanent silent no-op on the same lock.
- `maybe_auto_update` logs the `env::current_exe()` failure. Every other failure path there logs, and the READMEs promise the reason is in the diagnostic log.
- `cleanup_old_cache_in` logs what the delete actually did instead of asserting a removal that may not have happened. It stays best-effort.

**Tests that did not test what they said**

- `test_fuzzy_match` asserted `input_cost_per_token >= 0.0`, which no pricing value can fail. The lookup it drives is stable (`jaro_winkler("claude-3-sonet", "claude-3-sonnet")` ≈ 0.98, and neither name contains the other so the substring stage really is skipped), so it now asserts `> 0.0`.
- `test_normalized_match` and `test_substring_match` had each other's fixtures. Their bodies are swapped so each name covers the stage it exercises, and the comments #174 left in place are rewritten.

**Display shaping in a core mapper**

- `map_claude_usage` no longer truncates the scoped-window model label to 6 characters. How much of a provider-supplied label fits is a panel-layout question, and it now lives in `claude_card` next to the label-column width it competes with, applied through the display layer's own `fit_text`.

Two things worth flagging on that last one:

- It is a visible change. `fit_text` marks the cut, so a `display_name` of "Claude Opus 4.5" renders as `Claud…` rather than `Claude`, which read as a whole word and hid that anything had been dropped. Six is kept as the width because `label_width`'s floor is 5, so it is the first width that costs the gauges anything.
- `ClaudeQuotaSnapshot::SCHEMA_VERSION` bumps to 2 per the rule in `quota/cache.rs`: a build that derives a stored field differently must not paint the previous build's value. It is belt-and-braces here — a v1 file holds an already-short label that would re-truncate to itself — but the rule is mechanical and the cost is one discarded seed snapshot.

Two guards ship with the move so it cannot drift back: a core test that a long `display_name` survives the mapper whole, and a TUI test that the card cuts it.

`cargo test --workspace`, `make fmt` and `uvx pre-commit run -a` are all clean. No README or CLAUDE.md update is owed: no CLI behavior or flag changed, and nothing in either documents the removed items or the old 6-char cut.

Opened-by: Claude Opus 5
