### PR TITLE
test: point hollow tests at the code they name

### DIFF
--- a/src/cli/tests/cli.rs
+++ b/src/cli/tests/cli.rs
@@ -282,15 +282,33 @@ fn usage_output_flag_is_rejected() {
 }
 
 #[test]
-fn test_analysis_validates_file_extension() {
+fn analysis_detects_provider_by_content_not_extension() {
     let home = TempHome::new();
     let temp_dir = tempfile::TempDir::new().unwrap();
-    let wrong_ext = temp_dir.path().join("test.txt");
-    std::fs::write(&wrong_ext, "test content").unwrap();
 
-    // Nothing is asserted: the extension is not validated, so the file's
-    // content alone decides whether the run succeeds.
-    let _ = child_cmd(&home).arg("analysis").arg(&wrong_ext).output();
+    // A Claude session under a `.txt` name: detection reads the records, so the
+    // provider still resolves and the run succeeds.
+    let wrong_ext = temp_dir.path().join("session.txt");
+    std::fs::copy(fixture("sessions/claude_code.jsonl"), &wrong_ext).unwrap();
+    child_cmd(&home)
+        .arg("analysis")
+        .arg(&wrong_ext)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            r#""extensionName": "Claude-Code""#,
+        ));
+
+    // And the mirror case: a `.jsonl` name buys nothing when the content does
+    // not even parse.
+    let right_ext = temp_dir.path().join("session.jsonl");
+    std::fs::write(&right_ext, "test content\n").unwrap();
+    child_cmd(&home)
+        .arg("analysis")
+        .arg(&right_ext)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Failed to parse JSON from file"));
 }
 
 #[test]
@@ -579,6 +597,13 @@ fn usage_json_smoke_prices_seeded_session() {
         "proj",
         "session.jsonl",
         &vct_test_support::fixture_str("sessions/claude_code.jsonl"),
+    );
+    // Codex is the provider whose usage stays nested internally, so the
+    // flat-shape loop below only means anything with one of its sessions in the
+    // scan.
+    home.put_codex_session(
+        "2026/06/06/rollout-2026-06-06T10-00-00-019e4b75-8a4e-7801-a9ed-9723e77e0497.jsonl",
+        &vct_test_support::fixture_str("sessions/codex.jsonl"),
     );
     home.seed_pricing_cache(&pricing_seed());
 

--- a/src/core/tests/analysis.rs
+++ b/src/core/tests/analysis.rs
@@ -1497,41 +1497,73 @@ fn test_analysis_with_invalid_json() {
 }
 
 #[test]
-fn test_analysis_aggregation_logic() {
+fn analysis_rows_sum_repeated_sessions_for_one_model() {
     use vct_core::analysis::aggregator::AggregatedAnalysisRow;
 
-    let rows = [
-        AggregatedAnalysisRow {
-            model: "claude-sonnet-4".to_string(),
-            edit_lines: 50,
-            read_lines: 100,
-            write_lines: 25,
-            bash_count: 5,
-            edit_count: 10,
-            read_count: 15,
-            todo_write_count: 2,
-            write_count: 3,
-        },
-        AggregatedAnalysisRow {
-            model: "claude-sonnet-4".to_string(),
-            edit_lines: 50,
-            read_lines: 100,
-            write_lines: 25,
-            bash_count: 5,
-            edit_count: 10,
-            read_count: 15,
-            todo_write_count: 3,
-            write_count: 5,
-        },
-    ];
+    /// Every counter of a row. Destructured rather than read field by field, so
+    /// a counter added later is a compile error here instead of a field the
+    /// doubling assertion silently skips.
+    fn counters(row: &AggregatedAnalysisRow) -> [usize; 8] {
+        let AggregatedAnalysisRow {
+            model: _,
+            edit_lines,
+            read_lines,
+            write_lines,
+            bash_count,
+            edit_count,
+            read_count,
+            todo_write_count,
+            write_count,
+        } = *row;
+        [
+            edit_lines,
+            read_lines,
+            write_lines,
+            bash_count,
+            edit_count,
+            read_count,
+            todo_write_count,
+            write_count,
+        ]
+    }
 
-    let total_edit_lines: usize = rows.iter().map(|r| r.edit_lines).sum();
-    let total_read_lines: usize = rows.iter().map(|r| r.read_lines).sum();
-    let total_write_lines: usize = rows.iter().map(|r| r.write_lines).sum();
+    let session = fixture_str("sessions/claude_code.jsonl");
+    const MODEL: &str = "claude-sonnet-4-20250514";
 
-    assert_eq!(total_edit_lines, 100);
-    assert_eq!(total_read_lines, 200);
-    assert_eq!(total_write_lines, 50);
+    let one = TempHome::new();
+    one.put_claude_session("proj", "session.jsonl", &session);
+    let single = aggregate_sessions_by_model_from_paths(&one.paths, TimeRange::All)
+        .expect("aggregate one session");
+    let single_row = single
+        .rows
+        .iter()
+        .find(|row| row.model == MODEL)
+        .expect("a row for the fixture's model");
+    assert!(
+        counters(single_row).iter().all(|count| *count > 0),
+        "the fixture must exercise every counter for the doubling to mean anything, got: {:?}",
+        counters(single_row)
+    );
+
+    // The same session recorded twice: the aggregator folds both into one row
+    // per model, so every counter doubles.
+    let two = TempHome::new();
+    two.put_claude_session("proj", "session.jsonl", &session);
+    two.put_claude_session("proj", "second.jsonl", &session);
+    let doubled = aggregate_sessions_by_model_from_paths(&two.paths, TimeRange::All)
+        .expect("aggregate two sessions");
+    assert_eq!(
+        doubled.rows.len(),
+        single.rows.len(),
+        "the second session must not open a second row"
+    );
+    let doubled_row = doubled
+        .rows
+        .iter()
+        .find(|row| row.model == MODEL)
+        .expect("a row for the fixture's model");
+
+    assert_eq!(counters(doubled_row), counters(single_row).map(|c| c * 2));
 }
 
 /// Writes a Claude session whose first line is a metadata sentinel carrying no

--- a/src/core/tests/usage.rs
+++ b/src/core/tests/usage.rs
@@ -3,7 +3,8 @@
 // These drive `aggregate_usage_from_paths` against a `TempHome` (fixture session files
 // under a temp directory) so the real aggregation runs hermetically: no
 // process-global env is mutated, no machine files are read, and no external API
-// is reached. The remaining tests are pure in-memory cost / JSON math.
+// is reached. The lone exception is the cost-math case, which prices a token
+// bucket directly and needs no sources at all.
 
 use rusqlite::{Connection, params};
 #[cfg(unix)]
@@ -966,35 +967,6 @@ fn disabled_provider_is_dropped_from_usage_rollup() {
 }
 
 #[test]
-fn test_usage_data_serialization() {
-    use serde_json::json;
-    use vct_core::models::usage::UsageResult;
-
-    let mut usage = UsageResult::default();
-    usage.insert(
-        "claude-sonnet-4".to_string(),
-        json!({
-            "input_tokens": 1000,
-            "output_tokens": 500,
-            "cache_read_input_tokens": 2000,
-            "cache_creation_input_tokens": 1000,
-            "cost_usd": 0.05,
-            "matched_model": "claude-sonnet-4"
-        }),
-    );
-
-    let json = serde_json::to_string(&usage).unwrap();
-    assert!(
-        json.contains("claude-sonnet-4"),
-        "Should contain model name"
-    );
-
-    let deserialized: UsageResult = serde_json::from_str(&json).unwrap();
-    assert_eq!(deserialized.len(), usage.len());
-    assert!(deserialized.contains_key("claude-sonnet-4"));
-}
-
-#[test]
 fn test_usage_calculation_cost_accuracy() {
     use vct_core::pricing::{ModelPricing, calculate_cost};
 
@@ -1026,97 +998,111 @@ fn test_usage_calculation_cost_accuracy() {
 }
 
 #[test]
-fn test_usage_with_multiple_models() {
+fn usage_json_rows_flatten_the_codex_nested_shape() {
     use serde_json::json;
-    use vct_core::models::usage::UsageResult;
+    use std::collections::HashMap;
+    use vct_core::pricing::{ModelPricing, ModelPricingMap, clear_pricing_cache};
+    use vct_core::usage::price_usage_data;
 
-    let mut usage = UsageResult::default();
-    usage.insert(
-        "claude-sonnet-4".to_string(),
-        json!({
-            "input_tokens": 1000,
-            "output_tokens": 500,
-            "cache_read_input_tokens": 0,
-            "cache_creation_input_tokens": 0,
-            "cost_usd": 0.05
-        }),
+    clear_pricing_cache();
+    let home = TempHome::new();
+    home.put_codex_session(
+        &format!("2026/06/06/{CODEX_ROLLOUT}"),
+        &fixture_str("sessions/codex.jsonl"),
     );
-    usage.insert(
-        "gpt-4-turbo".to_string(),
-        json!({
-            "input_tokens": 2000,
-            "output_tokens": 1000,
-            "cache_read_input_tokens": 0,
-            "cache_creation_input_tokens": 0,
-            "cost_usd": 0.10
-        }),
-    );
+    let data = aggregate_usage_from_paths(&home.paths, TimeRange::All).expect("aggregate codex");
 
-    assert_eq!(usage.len(), 2, "Should have two models");
-
-    let total_cost: f64 = usage.values().filter_map(|v| v["cost_usd"].as_f64()).sum();
+    // Codex keeps its own nested shape in the aggregate, which is exactly why
+    // the payload builder has to flatten it.
+    let raw = data
+        .models
+        .get("aide-gpt-5")
+        .expect("the Codex fixture's model");
     assert!(
-        (total_cost - 0.15).abs() < 0.001,
-        "Total cost should be sum of individual costs"
-    );
-}
-
-#[test]
-fn test_usage_json_output_format() {
-    use serde_json::{Value, json};
-    use vct_core::models::usage::UsageResult;
-
-    let mut usage = UsageResult::default();
-    usage.insert(
-        "claude-sonnet-4".to_string(),
-        json!({
-            "input_tokens": 1000,
-            "output_tokens": 500,
-            "cache_read_input_tokens": 2000,
-            "cache_creation_input_tokens": 1000,
-            "cost_usd": 0.05123456789,
-            "matched_model": "claude-sonnet-4"
-        }),
+        raw.get("total_token_usage").is_some(),
+        "the aggregate should still carry Codex's nested shape, got: {raw}"
     );
 
-    let json = serde_json::to_string_pretty(&usage).unwrap();
-    let parsed: Value = serde_json::from_str(&json).unwrap();
-
-    assert!(parsed.is_object(), "Root should be an object");
-
-    let model_value = &parsed["claude-sonnet-4"];
-    assert!(
-        model_value["input_tokens"].is_number(),
-        "input_tokens should be number"
+    let mut prices = HashMap::new();
+    prices.insert(
+        "aide-gpt-5".to_string(),
+        ModelPricing {
+            input_cost_per_token: 1e-6,
+            ..Default::default()
+        },
     );
-    assert!(
-        model_value["output_tokens"].is_number(),
-        "output_tokens should be number"
-    );
-    assert!(
-        model_value["cost_usd"].is_number(),
-        "cost_usd should be number"
-    );
-}
+    let rows = price_usage_data(&data, &ModelPricingMap::new(prices));
+    let row = rows
+        .iter()
+        .find(|row| row.model == "aide-gpt-5")
+        .expect("a priced row for the Codex model");
 
-#[test]
-fn test_usage_handles_missing_cache_tokens() {
-    use serde_json::json;
-
-    let usage_value = json!({
-        "model": "test-model",
-        "input_tokens": 1000,
-        "output_tokens": 500,
-        "cache_read_input_tokens": 0,
-        "cache_creation_input_tokens": 0,
-        "cost_usd": 0.05
-    });
-
-    assert_eq!(usage_value["input_tokens"].as_i64().unwrap(), 1000);
-    assert_eq!(usage_value["cache_read_input_tokens"].as_i64().unwrap(), 0);
+    // The fixture's final snapshot reports `input 270530 (136832 cached) /
+    // output 12551 (9536 reasoning) / total 283081`. Flattening splits those
+    // into disjoint buckets so each token is billed exactly once, and nothing
+    // of the nested shape survives.
     assert_eq!(
-        usage_value["cache_creation_input_tokens"].as_i64().unwrap(),
-        0
+        row.usage,
+        json!({
+            "input_tokens": 270_530 - 136_832,
+            "cache_read_input_tokens": 136_832,
+            "output_tokens": 12_551 - 9_536,
+            "reasoning_output_tokens": 9_536,
+            "cache_creation_input_tokens": 0,
+            "total_tokens": 283_081,
+        })
+    );
+
+    // Only input carries a rate here, so the cost is billed off the flattened
+    // bucket rather than Codex's raw prompt size.
+    assert!(
+        (row.cost_usd - 0.133_698).abs() < 1e-9,
+        "got {}",
+        row.cost_usd
+    );
+}
+
+#[test]
+fn usage_json_reports_absent_cache_buckets_as_zero() {
+    use std::collections::HashMap;
+    use vct_core::pricing::{ModelPricingMap, clear_pricing_cache};
+    use vct_core::usage::price_usage_data;
+
+    clear_pricing_cache();
+    let home = TempHome::new();
+    home.put_gemini_session(
+        "proj-hash",
+        "chat.jsonl",
+        &fixture_str("sessions/gemini.jsonl"),
+    );
+    let data = aggregate_usage_from_paths(&home.paths, TimeRange::All).expect("aggregate gemini");
+
+    // The fixture's Pro model never writes to the cache, so its record carries
+    // no cache-write bucket at all.
+    let raw = data
+        .models
+        .get("gemini-3.1-pro-preview")
+        .expect("the Gemini fixture's Pro model");
+    assert!(
+        raw.get("cache_creation_input_tokens").is_none(),
+        "the aggregate should leave the absent bucket absent, got: {raw}"
+    );
+
+    let rows = price_usage_data(&data, &ModelPricingMap::new(HashMap::new()));
+    let row = rows
+        .iter()
+        .find(|row| row.model == "gemini-3.1-pro-preview")
+        .expect("a priced row for the Gemini Pro model");
+
+    assert_eq!(
+        row.usage["cache_creation_input_tokens"].as_i64(),
+        Some(0),
+        "an absent bucket must serialize as 0, not disappear from the row"
+    );
+    assert_eq!(row.usage["cache_read_input_tokens"].as_i64(), Some(0));
+    assert!(
+        row.usage["input_tokens"].as_i64().unwrap() > 0,
+        "and the buckets the record does carry survive"
     );
 }
 


### PR DESCRIPTION
Closes #165

Five tests named coverage the repo did not have: they built literals, summed them in the test body, and asserted properties of `serde_json`. Each is now either deleted as redundant or pointed at the code its name promises. Test-only change; no production code moved.

## `src/cli/tests/cli.rs`

`test_analysis_validates_file_extension` discarded the child's `Result`, so a spawn failure, a non-zero exit and a panic all looked like success — and there is no extension validation to test, since detection is content-based. It becomes `analysis_detects_provider_by_content_not_extension`, which asserts both halves of that contract: a Claude session under a `.txt` name parses and reports `"extensionName": "Claude-Code"`, while a `.jsonl` name buys nothing for content that does not parse.

While there: `usage_json_smoke_prices_seeded_session` already carried the assertion "nested Codex shape must not leak into usage --json", but its `TempHome` only held a Claude session, so that loop never saw a Codex row. Seeding one makes the existing end-to-end assertion real.

## `src/core/tests/usage.rs`

- `test_usage_data_serialization` and `test_usage_with_multiple_models` are deleted. The first round-tripped a `FastHashMap<String, Value>` type alias through serde; the second summed two hand-written literals. `merges_multiple_providers_from_paths` already aggregates two providers from real fixtures.
- `test_usage_json_output_format` becomes `usage_json_rows_flatten_the_codex_nested_shape`: it scans the Codex fixture, confirms the aggregate still carries the nested `total_token_usage`, then asserts the priced `usage --json` row by exact equality against the buckets the fixture's snapshot implies. That pins both normalizations Codex needs — cached reads out of input, reasoning out of output — so neither can start double-billing unnoticed.
- `test_usage_handles_missing_cache_tokens` becomes `usage_json_reports_absent_cache_buckets_as_zero`, over the Gemini fixture's Pro model, whose record carries no cache-write key at all: the row must report a numeric `0` rather than dropping the key.

## `src/core/tests/analysis.rs`

`test_analysis_aggregation_logic` wrote the aggregation it claimed to test. It becomes `analysis_rows_sum_repeated_sessions_for_one_model`: the same session recorded twice must fold into one row with every counter doubled. The counters are read by destructuring, so a counter added later is a compile error rather than a field the assertion skips.

## Verification

`cargo test --workspace`, `make fmt` and `uvx pre-commit run -a` are clean. Every new test was also checked against the code it names by breaking that code and confirming the test goes red: the analysis fold overwriting instead of accumulating, `price_usage_data` skipping normalization, the flat writer dropping zero-valued buckets, the detector losing its Claude marker, and the Codex branch skipping either subtraction.

Opened-by: Claude Opus 5
