### PR TITLE
fix(session): parsing-layer correctness and diagnostics gaps

### DIFF
--- a/src/core/src/analysis/aggregator.rs
+++ b/src/core/src/analysis/aggregator.rs
@@ -605,7 +605,7 @@ fn scan_opencode_analysis(
             );
         }
         Err(error) => {
-            let failure = error.to_string();
+            let failure = format!("{error:#}");
             record_failure(diagnostics, provider, source, failure.clone());
             if is_cacheable_sqlite_failure(&error) {
                 cache.insert(
@@ -644,7 +644,7 @@ fn scan_cursor_analysis(
         match load_conversation_model_snapshot(tracking_db) {
             Ok(snapshot) => (snapshot.models, snapshot.fingerprint, true),
             Err(error) => {
-                record_failure(diagnostics, provider, tracking_db, error.to_string());
+                record_failure(diagnostics, provider, tracking_db, format!("{error:#}"));
                 (FastHashMap::default(), None, false)
             }
         };
@@ -722,7 +722,7 @@ fn scan_cursor_analysis(
                 }
             }
             Err(error) => {
-                let failure = error.to_string();
+                let failure = format!("{error:#}");
                 record_failure(diagnostics, provider, &store, failure.clone());
                 if tracking_ok && is_cacheable_sqlite_failure(&error) {
                     cache.insert(

--- a/src/core/src/session/codex.rs
+++ b/src/core/src/session/codex.rs
@@ -420,16 +420,39 @@ fn output_reports_argument_error(output: Option<&str>) -> bool {
 /// Without stripping, sed/cat read-detail extraction over-counts the file
 /// by 5 lines (the prefix). Legacy `shell` outputs do not include the
 /// header, so the search returns the original slice unchanged when no
-/// `\nOutput:\n` marker is found.
+/// `\nOutput:\n` marker is found — or when what precedes the marker is not a
+/// header, which is how a `cat` of a file whose body contains a line reading
+/// `Output:` keeps everything above it.
 fn strip_exec_command_metadata_prefix(output: &str) -> &str {
     const MARKER: &str = "\nOutput:\n";
-    if let Some(idx) = output.find(MARKER) {
-        &output[idx + MARKER.len()..]
-    } else if let Some(rest) = output.strip_prefix("Output:\n") {
-        rest
-    } else {
-        output
+    if let Some(idx) = output.find(MARKER)
+        && is_exec_metadata_header(&output[..idx])
+    {
+        return &output[idx + MARKER.len()..];
     }
+    output.strip_prefix("Output:\n").unwrap_or(output)
+}
+
+/// Whether everything ahead of the `Output:` marker is Codex's own header.
+///
+/// The header vocabulary is a closed set on purpose: an open rule such as
+/// "looks like `Key: value`" matches the YAML and log dumps a `cat` most often
+/// produces, which is the content this guard exists to protect. A header line
+/// this build has never seen therefore stops the strip rather than truncating,
+/// which over-counts a read by the header's length instead of losing its body.
+fn is_exec_metadata_header(prefix: &str) -> bool {
+    const HEADER_LINES: [&str; 5] = [
+        "Chunk ID:",
+        "Original token count:",
+        "Process exited with code",
+        "Script completed",
+        "Wall time:",
+    ];
+
+    !prefix.is_empty()
+        && prefix
+            .lines()
+            .all(|line| HEADER_LINES.iter().any(|known| line.starts_with(known)))
 }
 
 /// Decodes a shell output into a `CodexShellOutput`, falling back to the
@@ -1397,6 +1420,20 @@ mod tests {
         // existing fixture-based tests keep matching.
         let raw = "line one\nline two\n";
         assert_eq!(strip_exec_command_metadata_prefix(raw), raw);
+    }
+
+    #[test]
+    fn a_body_line_reading_output_is_not_a_metadata_header() {
+        // `cat` of a file that documents its own output; nothing above the
+        // `Output:` line may be discarded.
+        let raw = "fn main() {}\nUsage: demo\nOutput:\nthe answer\n";
+        assert_eq!(strip_exec_command_metadata_prefix(raw), raw);
+    }
+
+    #[test]
+    fn custom_exec_header_variant_is_still_stripped() {
+        let raw = "Script completed\nWall time: 0.1 seconds\nOutput:\nthe content";
+        assert_eq!(strip_exec_command_metadata_prefix(raw), "the content");
     }
 
     #[test]

--- a/src/core/src/session/copilot.rs
+++ b/src/core/src/session/copilot.rs
@@ -220,7 +220,25 @@ where
                             },
                         );
                     }
-                    Ok(_) | Err(_) => diagnostics.record_relevant(false),
+                    Ok(data) => {
+                        diagnostics.record_relevant(false);
+                        // The verdict for this call is already taken. Holding
+                        // the id keeps its completion pairing, so the same
+                        // drift is not counted a second time as an orphan.
+                        if !data.tool_call_id.is_empty() {
+                            pending_tools.insert(
+                                data.tool_call_id,
+                                PendingTool {
+                                    tool_name: String::new(),
+                                    arguments: Value::Null,
+                                    timestamp: ts,
+                                    tracked: false,
+                                    arguments_supported: false,
+                                },
+                            );
+                        }
+                    }
+                    Err(_) => diagnostics.record_relevant(false),
                 }
             }
             "tool.execution_complete" => {
@@ -234,6 +252,14 @@ where
                     continue;
                 };
                 let Some(pending) = pending_tools.remove(tool_call_id) else {
+                    // Without the start event there is no tool name, so there
+                    // is no `tracked` flag to gate on. Only a completion that
+                    // reported success could have carried a file operation —
+                    // a failed one is skipped even when it does pair — so that
+                    // is the orphan counted as a record left unnormalized.
+                    if event.data.get("success").and_then(Value::as_bool) == Some(true) {
+                        diagnostics.record_relevant(false);
+                    }
                     continue;
                 };
                 let Some(success) = event.data.get("success").and_then(Value::as_bool) else {
@@ -1065,6 +1091,46 @@ mod tests {
         assert!(!failed.diagnostics.is_complete_failure());
         assert_eq!(failed.diagnostics.partial_failure_count(), 0);
         assert_eq!(failed.analysis.records[0].tool_call_counts.read, 0);
+    }
+
+    #[test]
+    fn an_orphaned_successful_completion_is_not_dropped_silently() {
+        let complete = |success: bool| {
+            event(
+                "tool.execution_complete",
+                json!({
+                    "toolCallId": "never-started",
+                    "success": success,
+                    "result": { "content": "one\ntwo" }
+                }),
+            )
+        };
+
+        let orphan =
+            parse_copilot_events_with_diagnostics(vec![complete(true)], ParseMode::Full).unwrap();
+        assert_eq!(orphan.diagnostics.failed_relevant_records, 1);
+
+        // A failed tool produces no metric even when it does pair, so its
+        // orphan lost nothing and must not read as a gap.
+        let failed =
+            parse_copilot_events_with_diagnostics(vec![complete(false)], ParseMode::Full).unwrap();
+        assert_eq!(failed.diagnostics.failed_relevant_records, 0);
+        assert_eq!(failed.diagnostics.partial_failure_count(), 0);
+
+        // A start whose schema drifted already recorded the failure, so its
+        // completion must not record a second one for the same call.
+        let drifted = parse_copilot_events_with_diagnostics(
+            vec![
+                event(
+                    "tool.execution_start",
+                    json!({ "toolCallId": "never-started", "renamedTool": "show_file" }),
+                ),
+                complete(true),
+            ],
+            ParseMode::Full,
+        )
+        .unwrap();
+        assert_eq!(drifted.diagnostics.failed_relevant_records, 1);
     }
 
     #[test]

--- a/src/core/src/session/cursor.rs
+++ b/src/core/src/session/cursor.rs
@@ -800,20 +800,32 @@ fn resolve_store_model(
         .unwrap_or_else(|| "unknown".to_string())
 }
 
-/// Reads `lastUsedModel` from the store's `meta` row.
+/// Reads `lastUsedModel` from the store's `meta` table.
 ///
 /// The `meta.value` is a hex-encoded JSON string; decode then read the field.
 /// Tolerates a plain-JSON value too, in case a future build stops hex-encoding.
+/// `meta` is keyed `(key PRIMARY KEY, value)` and current stores hold one row
+/// keyed `0`, but that name is cursor-agent's to change, so every row is
+/// decoded and the first one carrying the field wins rather than whichever row
+/// SQLite happens to return first.
 fn store_meta_model(conn: &Connection) -> Option<String> {
-    let value: String = conn
-        .query_row("SELECT value FROM meta LIMIT 1", [], |r| r.get(0))
-        .ok()?;
-    let bytes = decode_hex(&value).unwrap_or_else(|| value.clone().into_bytes());
-    let json: Value = serde_json::from_slice(&bytes).ok()?;
-    json.get("lastUsedModel")
-        .and_then(|m| m.as_str())
-        .filter(|s| !s.is_empty())
-        .map(|s| s.to_string())
+    let mut stmt = conn.prepare("SELECT value FROM meta ORDER BY key").ok()?;
+    // A row whose `value` is NULL or not text is skipped, not fatal: failing
+    // the whole read on one would lose the lookup for exactly the multi-row
+    // store this scan exists to handle.
+    let values = stmt
+        .query_map([], |r| r.get::<_, String>(0))
+        .ok()?
+        .filter_map(rusqlite::Result::ok)
+        .collect::<Vec<_>>();
+    values.into_iter().find_map(|value| {
+        let bytes = decode_hex(&value).unwrap_or_else(|| value.into_bytes());
+        let json: Value = serde_json::from_slice(&bytes).ok()?;
+        json.get("lastUsedModel")
+            .and_then(|m| m.as_str())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+    })
 }
 
 /// Loads every blob's raw bytes from a store.
@@ -1477,6 +1489,30 @@ mod tests {
             .unwrap();
         }
         drop(conn);
+    }
+
+    #[test]
+    fn store_meta_model_does_not_depend_on_which_row_comes_first() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("store.db");
+        write_store_db(&path, &[], &[]);
+        let conn = Connection::open(&path).unwrap();
+        let hex: String = r#"{"agentId":"a","lastUsedModel":"gpt-5.6-sol"}"#
+            .bytes()
+            .map(|byte| format!("{byte:02x}"))
+            .collect();
+        conn.execute(
+            "INSERT INTO meta (key, value) VALUES ('0', ?1)",
+            [r#"{"other":true}"#],
+        )
+        .unwrap();
+        // A row that is not readable as text must not abort the scan.
+        conn.execute("INSERT INTO meta (key, value) VALUES ('1', NULL)", [])
+            .unwrap();
+        conn.execute("INSERT INTO meta (key, value) VALUES ('z', ?1)", [&hex])
+            .unwrap();
+
+        assert_eq!(store_meta_model(&conn).as_deref(), Some("gpt-5.6-sol"));
     }
 
     #[test]

--- a/src/core/src/session/dsh.rs
+++ b/src/core/src/session/dsh.rs
@@ -353,6 +353,10 @@ impl<'a> DshParser<'a> {
     }
 
     /// Holds one step's usage sample, flushing the previous step's.
+    ///
+    /// The sample's verdict is left to [`Self::flush_usage`]: a report that the
+    /// next one supersedes describes the same billing event, so counting both
+    /// would report two records where the log has one.
     fn apply_usage(&mut self, data: &Value, usage: Option<&Value>, model: String) {
         // An assistant message carries no `usage` when the adapter reported
         // none; that is a routing fact, not a schema failure.
@@ -363,8 +367,6 @@ impl<'a> DshParser<'a> {
             self.diagnostics.record_relevant(false);
             return;
         };
-        self.diagnostics.record_relevant(true);
-
         let sample = UsageSample {
             turn: data.get("turn").and_then(Value::as_i64).unwrap_or(0),
             step: data.get("step").and_then(Value::as_i64).unwrap_or(0),
@@ -378,10 +380,18 @@ impl<'a> DshParser<'a> {
         self.pending_usage = Some(sample);
     }
 
+    /// Folds the held sample into the per-model totals and records its verdict.
+    ///
+    /// Every step reports its usage twice, so the verdict belongs to the
+    /// survivor of the last-wins slot rather than to each report. A sample
+    /// whose route never resolved (usage before the first `request/context`)
+    /// cannot be attributed to a model, so it is a relevant record the parser
+    /// could not normalize rather than a silent zero.
     fn flush_usage(&mut self) {
         let Some(sample) = self.pending_usage.take() else {
             return;
         };
+        self.diagnostics.record_relevant(!sample.model.is_empty());
         if sample.model.is_empty() {
             return;
         }
@@ -418,15 +428,19 @@ impl<'a> DshParser<'a> {
     /// `tool/call`, which is what carries the operation's own arguments. A
     /// result reporting `error` leaves no metric behind.
     fn apply_tool_result(&mut self, object: &Map<String, Value>, data: &Value) {
-        let call_seq = object
+        // The envelope can list several source events, so every entry is
+        // searched rather than index 0 alone: reading one position mispairs the
+        // result and leaks the real call. A call whose own record was lost with
+        // a torn frame cannot be identified, and the result payload alone does
+        // not say which tool produced it.
+        let Some(call) = object
             .get("sourceEventSeqs")
             .and_then(Value::as_array)
-            .and_then(|seqs| seqs.first())
-            .and_then(Value::as_i64);
-        // A call whose own record was lost with a torn frame cannot be
-        // identified, and the result payload alone does not say which tool
-        // produced it.
-        let Some(call) = call_seq.and_then(|seq| self.pending_calls.remove(&seq)) else {
+            .into_iter()
+            .flatten()
+            .filter_map(Value::as_i64)
+            .find_map(|seq| self.pending_calls.remove(&seq))
+        else {
             return;
         };
         if data.get("error").is_some_and(|error| !error.is_null()) {
@@ -696,6 +710,104 @@ mod tests {
         let parsed = parse(&path);
         assert_eq!(parsed.diagnostics.unrecognized_records, 1);
         assert_eq!(parsed.diagnostics.recognized_records, 2);
+    }
+
+    #[test]
+    fn one_step_reported_twice_is_one_relevant_record() {
+        let dir = TempDir::new().unwrap();
+        let route = json!({"type": "request/context", "seq": 1, "time": 2, "data": {"model": "m"}})
+            .to_string();
+        let chunk = json!({
+            "type": "assistant/chunk",
+            "seq": 2,
+            "time": 3,
+            "data": {
+                "turn": 1,
+                "step": 1,
+                "chunk": {"type": "usage", "usage": {"inputTokens": 1, "outputTokens": 2}},
+            },
+        })
+        .to_string();
+        let path = write_frames(
+            &dir,
+            "session.jsonl.zstd",
+            &[
+                vec![HEADER.to_string()],
+                vec![route, chunk, usage_event(3, 1, 1, "m", 2)],
+            ],
+        );
+
+        let parsed = parse(&path);
+        // The early chunk and the assembled message describe the same step, so
+        // the pair bills once and is counted once.
+        assert_eq!(
+            parsed.analysis.records[0].conversation_usage["m"]["output_tokens"],
+            2
+        );
+        assert_eq!(parsed.diagnostics.relevant_records, 1);
+        assert_eq!(parsed.diagnostics.normalized_records, 1);
+    }
+
+    #[test]
+    fn usage_with_no_route_is_a_failed_record_not_a_silent_drop() {
+        let dir = TempDir::new().unwrap();
+        // A usage chunk takes its model from the last `request/context`, so one
+        // arriving before the first route has nothing to attribute it to.
+        let chunk = json!({
+            "type": "assistant/chunk",
+            "seq": 1,
+            "time": 2,
+            "data": {
+                "turn": 1,
+                "step": 1,
+                "chunk": {"type": "usage", "usage": {"inputTokens": 5, "outputTokens": 7}},
+            },
+        })
+        .to_string();
+        let path = write_frames(
+            &dir,
+            "session.jsonl.zstd",
+            &[vec![HEADER.to_string()], vec![chunk]],
+        );
+
+        let parsed = parse(&path);
+        assert!(parsed.analysis.records[0].conversation_usage.is_empty());
+        assert_eq!(parsed.diagnostics.relevant_records, 1);
+        assert_eq!(parsed.diagnostics.failed_relevant_records, 1);
+    }
+
+    #[test]
+    fn a_result_pairs_on_any_source_event_seq() {
+        let dir = TempDir::new().unwrap();
+        let call = json!({
+            "type": "tool/call",
+            "seq": 4,
+            "time": 5,
+            "data": {
+                "name": "write",
+                "arguments": r#"{"file_path":"/repo/new.rs","content":"one\ntwo\n"}"#,
+            },
+        })
+        .to_string();
+        // The call seq sits past index 0; reading only the first entry loses the
+        // operation and leaves the call pending.
+        let result = json!({
+            "type": "tool/result",
+            "seq": 6,
+            "time": 7,
+            "sourceEventSeqs": [3, 4],
+            "data": {"meta": {}},
+        })
+        .to_string();
+        let path = write_frames(
+            &dir,
+            "session.jsonl.zstd",
+            &[vec![HEADER.to_string()], vec![call, result]],
+        );
+
+        let record = &parse(&path).analysis.records[0];
+        assert_eq!(record.tool_call_counts.write, 1);
+        assert_eq!(record.total_write_lines, 2);
     }
 
     #[test]

--- a/src/core/src/session/gemini.rs
+++ b/src/core/src/session/gemini.rs
@@ -250,8 +250,12 @@ fn gemini_tokens_supported(tokens: &Value) -> bool {
     let Some(tokens) = tokens.as_object() else {
         return false;
     };
+    // Every `GeminiTokens` field defaults, so an empty object deserializes to
+    // all zeros and would pass as a clean scan that billed nothing. It carries
+    // no less drift than an object of only unknown keys, which is already
+    // refused below.
     if tokens.is_empty() {
-        return true;
+        return false;
     }
 
     let mut recognized = false;
@@ -826,6 +830,21 @@ mod tests {
         assert_eq!(
             parsed.analysis.records[0].conversation_usage["gemini-test"]["input_tokens"],
             0
+        );
+    }
+
+    #[test]
+    fn an_empty_token_object_does_not_become_zero_usage() {
+        let mut message = assistant("empty-tokens", "gemini-test", 10, json!([]));
+        message["tokens"] = json!({});
+
+        let parsed =
+            parse_gemini_events_with_diagnostics(session(), vec![message], ParseMode::Full, None)
+                .unwrap();
+        assert!(parsed.diagnostics.is_complete_failure());
+        assert!(
+            parsed.analysis.records[0].conversation_usage.is_empty(),
+            "an empty token object must not become a successful all-zero usage row"
         );
     }
 

--- a/src/core/src/session/grok.rs
+++ b/src/core/src/session/grok.rs
@@ -336,7 +336,10 @@ fn apply_completed_tool(
                 .pointer("/FileContent/content")
                 .and_then(Value::as_str)
                 .unwrap_or_default();
-            if content.is_empty() {
+            // `add_read_detail` counts nothing for a body that trims to no
+            // lines, so a newline-only read has to take the same branch as an
+            // empty one or the invocation vanishes from every counter.
+            if content.trim_end_matches('\n').is_empty() {
                 state.tool_counts.read += 1;
                 state.add_non_text_read_path(path);
             } else {
@@ -574,6 +577,24 @@ mod tests {
         );
         assert_eq!(state.edit_details[0].old_string, "matched one");
         assert_eq!(state.edit_details[1].old_string, "matched two");
+    }
+
+    #[test]
+    fn newline_only_read_still_counts_the_invocation() {
+        let mut state = SessionParseState::new();
+        let call = PendingToolCall {
+            name: "read_file".to_string(),
+            input: json!({"target_file": "/workspace/blank.txt"}),
+        };
+        let output = json!({
+            "type": "Read",
+            "FileContent": {"absolute_path": "/workspace/blank.txt", "content": "\n\n"}
+        });
+
+        assert!(apply_completed_tool(&mut state, &call, 123, &output));
+        assert_eq!(state.tool_counts.read, 1);
+        assert_eq!(state.total_read_lines, 0);
+        assert!(state.unique_files.contains("/workspace/blank.txt"));
     }
 
     #[test]

--- a/src/core/src/session/opencode.rs
+++ b/src/core/src/session/opencode.rs
@@ -116,7 +116,9 @@ pub fn read_opencode_analysis(
     }
     // Records and tool parts are different units: one message can carry many
     // parts, so adding them together reports a part count as a record count.
-    let failed_records = result.expected_records.saturating_sub(result.parsed_records);
+    let failed_records = result
+        .expected_records
+        .saturating_sub(result.parsed_records);
     if failed_records > 0 {
         log::warn!("skipped {failed_records} OpenCode analysis records with unsupported schema");
     }

--- a/src/core/src/session/opencode.rs
+++ b/src/core/src/session/opencode.rs
@@ -949,8 +949,13 @@ fn parse_model_id(raw: &str) -> Option<String> {
             let s = s.trim();
             (!s.is_empty()).then(|| s.to_string())
         }
-        // Not a JSON object or string: treat the column as a plain model name.
-        _ => Some(raw.to_string()),
+        // A bare model name is not valid JSON, so a parse failure is what the
+        // legacy plain-string column looks like.
+        Err(_) => Some(raw.to_string()),
+        // Any other JSON value carries no model name. The SQL guard tests for
+        // SQL `NULL`, not for a column holding the four characters `null`,
+        // which would otherwise be priced and displayed as a model.
+        _ => None,
     }
 }
 
@@ -1366,6 +1371,13 @@ mod tests {
         );
         assert_eq!(parse_model_id(r#"{"providerID":"x"}"#), None);
         assert_eq!(parse_model_id("   "), None);
+        // A column holding a JSON scalar names no model; the SQL guard only
+        // filters SQL `NULL` and the empty string.
+        assert_eq!(parse_model_id("null"), None);
+        assert_eq!(parse_model_id("42"), None);
+        assert_eq!(parse_model_id("[]"), None);
+        // A quoted string is still the legacy plain-name column.
+        assert_eq!(parse_model_id(r#""gpt-5""#).as_deref(), Some("gpt-5"));
     }
 
     #[test]

--- a/src/core/src/session/opencode.rs
+++ b/src/core/src/session/opencode.rs
@@ -114,14 +114,16 @@ pub fn read_opencode_analysis(
             result.expected_records
         ));
     }
-    let failed_records = result
-        .expected_records
-        .saturating_sub(result.parsed_records)
-        + result.failed_tool_parts;
+    // Records and tool parts are different units: one message can carry many
+    // parts, so adding them together reports a part count as a record count.
+    let failed_records = result.expected_records.saturating_sub(result.parsed_records);
     if failed_records > 0 {
+        log::warn!("skipped {failed_records} OpenCode analysis records with unsupported schema");
+    }
+    if result.failed_tool_parts > 0 {
         log::warn!(
-            "skipped {} OpenCode analysis records with unsupported schema",
-            failed_records
+            "skipped {} OpenCode tool parts with unsupported schema",
+            result.failed_tool_parts
         );
     }
     Ok(result

--- a/src/core/src/session/parser.rs
+++ b/src/core/src/session/parser.rs
@@ -346,6 +346,7 @@ fn stream_parse_known(
             let rest = iter_jsonl_typed(
                 &mut stream.reader,
                 provider,
+                stream.lines_read,
                 Rc::clone(&diagnostics),
                 Rc::clone(&warnings),
                 Rc::clone(&io_failure),
@@ -375,6 +376,7 @@ fn stream_parse_known(
             let rest = iter_jsonl_typed(
                 &mut stream.reader,
                 provider,
+                stream.lines_read,
                 Rc::clone(&diagnostics),
                 Rc::clone(&warnings),
                 Rc::clone(&io_failure),
@@ -404,6 +406,7 @@ fn stream_parse_known(
             let rest = iter_jsonl_typed(
                 &mut stream.reader,
                 provider,
+                stream.lines_read,
                 Rc::clone(&diagnostics),
                 Rc::clone(&warnings),
                 Rc::clone(&io_failure),
@@ -441,7 +444,8 @@ fn stream_parse_known_dynamic(
         File::open(path).with_context(|| format!("Failed to open file: {}", path.display()))?;
     let mut reader = BufReader::with_capacity(buffer::FILE_READ_BUFFER, file);
 
-    let first_line = match read_next_non_empty_line(&mut reader)? {
+    let mut lines_read = 0_usize;
+    let first_line = match read_next_non_empty_line(&mut reader, &mut lines_read)? {
         Some(line) => line,
         None => return Ok(None), // empty file — caller returns the empty shape
     };
@@ -460,6 +464,7 @@ fn stream_parse_known_dynamic(
         Rc::new(RefCell::new(ParseWarningSummary::default())),
         path,
         tiers,
+        lines_read,
     )?;
     Ok(Some(finalize(parsed, provider)))
 }
@@ -469,6 +474,9 @@ struct TypedStream<T> {
     reader: BufReader<File>,
     diagnostics: ParseDiagnostics,
     warnings: ParseWarningSummary,
+    /// Physical lines the first record consumed, so the rest of the file keeps
+    /// reporting real line numbers.
+    lines_read: usize,
 }
 
 /// Opens a JSONL source and parses its first record directly into `T`.
@@ -483,8 +491,9 @@ where
         File::open(path).with_context(|| format!("Failed to open file: {}", path.display()))?;
     let mut reader = BufReader::with_capacity(buffer::FILE_READ_BUFFER, file);
     let mut line = Vec::with_capacity(buffer::AVG_JSONL_LINE_SIZE);
+    let mut lines_read = 0_usize;
 
-    if !read_next_non_empty_bytes(&mut reader, &mut line)? {
+    if !read_next_non_empty_bytes(&mut reader, &mut line, &mut lines_read)? {
         return Ok(None);
     }
 
@@ -516,6 +525,7 @@ where
         reader,
         diagnostics,
         warnings,
+        lines_read,
     }))
 }
 
@@ -555,14 +565,15 @@ fn stream_parse_autodetect(path: &Path, mode: ParseMode) -> Result<Option<Parsed
     let mut initial_diagnostics = ParseDiagnostics::default();
     let mut classifier = RecordClassifier::default();
     let warnings = Rc::new(RefCell::new(ParseWarningSummary::default()));
-    let mut line_number = 0_usize;
+    // Physical lines, blank ones included, so the number a malformed record is
+    // reported under is the one an editor shows.
+    let mut lines_read = 0_usize;
 
     loop {
-        let line = match read_next_non_empty_line(&mut reader)? {
+        let line = match read_next_non_empty_line(&mut reader, &mut lines_read)? {
             Some(line) => line,
             None => break,
         };
-        line_number += 1;
 
         match serde_json::from_str::<Value>(line.trim()) {
             Ok(v) => {
@@ -584,7 +595,7 @@ fn stream_parse_autodetect(path: &Path, mode: ParseMode) -> Result<Option<Parsed
                     first_line_was_json = Some(false);
                     break;
                 }
-                warnings.borrow_mut().record_malformed(line_number, &err);
+                warnings.borrow_mut().record_malformed(lines_read, &err);
                 initial_diagnostics.record_malformed();
             }
         }
@@ -608,6 +619,7 @@ fn stream_parse_autodetect(path: &Path, mode: ParseMode) -> Result<Option<Parsed
         warnings,
         path,
         None,
+        lines_read,
     )?;
     Ok(Some(finalize(parsed, ext)))
 }
@@ -615,11 +627,18 @@ fn stream_parse_autodetect(path: &Path, mode: ParseMode) -> Result<Option<Parsed
 /// Reads lines from `reader` until it finds a non-empty one. Returns `Ok(None)`
 /// at EOF.
 ///
+/// `consumed` counts every physical line read, blank ones included, so a caller
+/// that continues the file with another reader can keep reporting the same line
+/// numbers the user sees in an editor.
+///
 /// # Errors
 ///
 /// Returns an error if the underlying `read_line` fails (e.g. an I/O error or
 /// invalid UTF-8 in the stream).
-fn read_next_non_empty_line<R: BufRead>(reader: &mut R) -> Result<Option<String>> {
+fn read_next_non_empty_line<R: BufRead>(
+    reader: &mut R,
+    consumed: &mut usize,
+) -> Result<Option<String>> {
     let mut line = String::new();
     loop {
         line.clear();
@@ -629,6 +648,7 @@ fn read_next_non_empty_line<R: BufRead>(reader: &mut R) -> Result<Option<String>
         if n == 0 {
             return Ok(None);
         }
+        *consumed += 1;
         if !line.trim().is_empty() {
             return Ok(Some(line));
         }
@@ -636,7 +656,13 @@ fn read_next_non_empty_line<R: BufRead>(reader: &mut R) -> Result<Option<String>
 }
 
 /// Reuses `line` while reading through blank lines to the next JSONL record.
-fn read_next_non_empty_bytes<R: BufRead>(reader: &mut R, line: &mut Vec<u8>) -> Result<bool> {
+///
+/// `consumed` counts physical lines exactly as in [`read_next_non_empty_line`].
+fn read_next_non_empty_bytes<R: BufRead>(
+    reader: &mut R,
+    line: &mut Vec<u8>,
+    consumed: &mut usize,
+) -> Result<bool> {
     loop {
         line.clear();
         let count = reader
@@ -645,6 +671,7 @@ fn read_next_non_empty_bytes<R: BufRead>(reader: &mut R, line: &mut Vec<u8>) -> 
         if count == 0 {
             return Ok(false);
         }
+        *consumed += 1;
         if !trim_ascii_whitespace(line).is_empty() {
             return Ok(true);
         }
@@ -679,6 +706,7 @@ fn dispatch_streaming_buffered(
     warnings: Rc<RefCell<ParseWarningSummary>>,
     path: &Path,
     tiers: Option<&TierThresholds>,
+    lines_read: usize,
 ) -> Result<ParsedAnalysis> {
     let extra_diagnostics = Rc::new(RefCell::new(initial_diagnostics));
     let io_failure = Rc::new(RefCell::new(None));
@@ -686,6 +714,7 @@ fn dispatch_streaming_buffered(
         ExtensionType::ClaudeCode => {
             let rest = iter_jsonl_values(
                 &mut reader,
+                lines_read,
                 Rc::clone(&extra_diagnostics),
                 Rc::clone(&warnings),
                 Rc::clone(&io_failure),
@@ -699,6 +728,7 @@ fn dispatch_streaming_buffered(
         ExtensionType::Codex => {
             let rest = iter_jsonl_values(
                 &mut reader,
+                lines_read,
                 Rc::clone(&extra_diagnostics),
                 Rc::clone(&warnings),
                 Rc::clone(&io_failure),
@@ -712,6 +742,7 @@ fn dispatch_streaming_buffered(
         ExtensionType::Copilot => {
             let rest = iter_jsonl_values(
                 &mut reader,
+                lines_read,
                 Rc::clone(&extra_diagnostics),
                 Rc::clone(&warnings),
                 Rc::clone(&io_failure),
@@ -736,6 +767,7 @@ fn dispatch_streaming_buffered(
 
                 let rest_events = iter_jsonl_values(
                     &mut reader,
+                    lines_read,
                     Rc::clone(&extra_diagnostics),
                     Rc::clone(&warnings),
                     Rc::clone(&io_failure),
@@ -784,10 +816,12 @@ fn json_error_category(error: &serde_json::Error) -> &'static str {
 ///
 /// The line buffer is retained across iterations. A raw `Value` is only built
 /// when typed deserialization fails and diagnostics need to classify the
-/// unsupported record.
+/// unsupported record. `lines_read` is how many physical lines the caller
+/// already consumed from `reader`, so reported line numbers stay absolute.
 fn iter_jsonl_typed<'a, T>(
     reader: &'a mut BufReader<File>,
     provider: ExtensionType,
+    lines_read: usize,
     diagnostics: Rc<RefCell<ParseDiagnostics>>,
     warnings: Rc<RefCell<ParseWarningSummary>>,
     io_failure: Rc<RefCell<Option<String>>>,
@@ -796,7 +830,7 @@ where
     T: DeserializeOwned + 'a,
 {
     let mut line = Vec::with_capacity(buffer::AVG_JSONL_LINE_SIZE);
-    let mut line_number = 1_usize;
+    let mut line_number = lines_read;
 
     std::iter::from_fn(move || {
         loop {
@@ -847,8 +881,13 @@ where
 /// through this too, since the classifier has already materialized their
 /// buffered prefix as `Value`s; those three convert each one into their typed
 /// record straight away.
+///
+/// `lines_read` is how many physical lines the caller already consumed from
+/// `reader` — the buffered prefix on the auto-detect path — so reported line
+/// numbers stay absolute instead of restarting at 1.
 fn iter_jsonl_values<'a>(
     reader: &'a mut BufReader<File>,
+    lines_read: usize,
     diagnostics: Rc<RefCell<ParseDiagnostics>>,
     warnings: Rc<RefCell<ParseWarningSummary>>,
     io_failure: Rc<RefCell<Option<String>>>,
@@ -856,7 +895,7 @@ fn iter_jsonl_values<'a>(
     // Reuse one byte buffer via `read_until` instead of allocating a `String`
     // per line (`reader.lines()`).
     let mut line = Vec::with_capacity(buffer::AVG_JSONL_LINE_SIZE);
-    let mut line_number = 0_usize;
+    let mut line_number = lines_read;
 
     std::iter::from_fn(move || {
         loop {
@@ -1206,5 +1245,36 @@ mod tests {
 
         assert_eq!(parsed.analysis.extension_name, "Claude-Code");
         assert_eq!(record_inspections(), 10_001);
+    }
+
+    #[test]
+    fn a_malformed_record_is_reported_under_its_physical_line() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("session.jsonl");
+        // Record, blank, record, malformed: the failure sits on line 4.
+        std::fs::write(&path, "{\"a\":1}\n\n{\"b\":2}\nnot json\n").unwrap();
+
+        let mut reader = BufReader::new(File::open(&path).unwrap());
+        let mut lines_read = 0_usize;
+        // Every streaming entry point consumes the first record before handing
+        // the rest of the file to the iterator.
+        read_next_non_empty_line(&mut reader, &mut lines_read)
+            .unwrap()
+            .unwrap();
+        assert_eq!(lines_read, 1);
+
+        let warnings = Rc::new(RefCell::new(ParseWarningSummary::default()));
+        let rest: Vec<Value> = iter_jsonl_values(
+            &mut reader,
+            lines_read,
+            Rc::new(RefCell::new(ParseDiagnostics::default())),
+            Rc::clone(&warnings),
+            Rc::new(RefCell::new(None)),
+        )
+        .collect();
+
+        assert_eq!(rest.len(), 1);
+        let reason = warnings.borrow().first_reason.clone().unwrap();
+        assert!(reason.starts_with("malformed line 4:"), "{reason}");
     }
 }

--- a/src/core/src/session/sqlite.rs
+++ b/src/core/src/session/sqlite.rs
@@ -53,6 +53,10 @@ pub(crate) fn optional_database_fingerprint(db_path: &Path) -> Result<Option<Dat
 /// remain failures until the source fingerprint changes, so incremental scans
 /// may cache their diagnostics. Open, permission, busy, and I/O failures are
 /// deliberately excluded and retried on every refresh.
+///
+/// The decision reads the flattened chain (`{error:#}`), so a caller rendering
+/// the same failure for the user has to flatten it too — plain `Display` keeps
+/// only the outermost context, which is never the cause this matches on.
 pub(crate) fn is_cacheable_sqlite_failure(error: &anyhow::Error) -> bool {
     let message = format!("{error:#}").to_ascii_lowercase();
     [
@@ -63,7 +67,6 @@ pub(crate) fn is_cacheable_sqlite_failure(error: &anyhow::Error) -> bool {
         "malformed json",
         "file is not a database",
         "database disk image is malformed",
-        "unsupported sqlite schema",
     ]
     .iter()
     .any(|needle| message.contains(needle))
@@ -91,18 +94,21 @@ pub(crate) fn with_readonly_connection<T>(
         return f(&conn);
     }
 
+    // The context names the source database, not the private copy: the copy's
+    // path is deleted by the time anyone reads the message, and it is the
+    // source the user can act on.
     let copy = StableTempCopy::new(db_path, temp_prefix)?;
     let conn = Connection::open_with_flags(&copy.db_path, OpenFlags::SQLITE_OPEN_READ_WRITE)
         .with_context(|| {
             format!(
-                "Failed to open {label} DB copy at {}",
-                copy.db_path.display()
+                "Failed to open a copy of the {label} DB at {}",
+                db_path.display()
             )
         })?;
     probe(&conn, &probe_sql).with_context(|| {
         format!(
-            "Failed to read {label} DB copy at {}",
-            copy.db_path.display()
+            "Failed to read a copy of the {label} DB at {}",
+            db_path.display()
         )
     })?;
     f(&conn)
@@ -242,6 +248,36 @@ mod tests {
             .unwrap();
 
         assert_eq!(value, 42);
+    }
+
+    #[test]
+    fn a_probe_failure_keeps_its_cause_and_names_the_source() {
+        let source_dir = tempfile::tempdir().unwrap();
+        let source_path = source_dir.path().join("source.db");
+        let source = Connection::open(&source_path).unwrap();
+        source
+            .execute_batch("CREATE TABLE other (value INTEGER NOT NULL);")
+            .unwrap();
+        drop(source);
+
+        let error = with_readonly_connection(
+            &source_path,
+            "session",
+            "vct-sqlite-test-",
+            "Example",
+            |_| Ok(()),
+        )
+        .unwrap_err();
+
+        // Plain `Display` stops at the outer context, which is exactly what
+        // the cacheability check never sees.
+        let flattened = format!("{error:#}");
+        assert!(flattened.contains("no such table"), "{flattened}");
+        assert!(
+            flattened.contains(&source_path.display().to_string()),
+            "{flattened}"
+        );
+        assert!(is_cacheable_sqlite_failure(&error));
     }
 
     #[test]

--- a/src/core/src/usage/aggregator.rs
+++ b/src/core/src/usage/aggregator.rs
@@ -604,7 +604,7 @@ fn scan_usage_database<F>(
             );
         }
         Err(error) => {
-            let failure = error.to_string();
+            let failure = format!("{error:#}");
             diagnostics.failures.push(ScanFailure {
                 provider,
                 source: source.to_path_buf(),
@@ -653,7 +653,7 @@ fn scan_cursor_usage_database(
                 diagnostics.failures.push(ScanFailure {
                     provider,
                     source: tracking_db.to_path_buf(),
-                    error: error.to_string(),
+                    error: format!("{error:#}"),
                 });
                 (FastHashMap::default(), None, false)
             }
@@ -725,7 +725,7 @@ fn scan_cursor_usage_database(
                 }
             }
             Err(error) => {
-                let failure = error.to_string();
+                let failure = format!("{error:#}");
                 diagnostics.failures.push(ScanFailure {
                     provider,
                     source: store.clone(),


### PR DESCRIPTION
Closes #187.

Thirteen parsing-layer items that share one shape: the code reported something
other than what happened, or counted something other than what the session did.
One commit per item, each with a test that fails before it. No public JSON
contract changes.

## Numbers that come out wrong

- **Grok: a read whose body is only newlines vanished entirely.** The guard was
  `content.is_empty()`, so `"\n"` reached `add_read_detail`, which trims to
  nothing, counts no lines, and returns before bumping `tool_counts.read` — the
  invocation was recorded as a successful normalization while disappearing from
  every counter. The guard now matches `add_read_detail`'s own trim, so such a
  read takes the empty-file branch that counts it.
- **DeepSeek: usage before the first `request/context` was counted as
  normalized, then zeroed.** The verdict moved from `apply_usage` to
  `flush_usage`, which is where a sample is known to have survived the
  last-wins slot. Two consequences: an unattributable sample is now a relevant
  record the parser could not normalize instead of a silent zero, and one step's
  two reports (the `assistant/chunk` early sample and the assembled
  `assistant/message`) count as the one billing event they are, rather than two.
- **Codex: a shell output containing a bare `Output:` line was truncated.**
  `strip_exec_command_metadata_prefix` did an unanchored `find`, so a `cat`/`sed`
  of a file whose body has a line reading exactly `Output:` discarded everything
  above it. Stripping now requires every line ahead of the marker to be one of
  Codex's own header lines. The vocabulary is a closed set on purpose — an open
  rule such as "looks like `Key: value`" matches the YAML and log dumps a `cat`
  most often produces, which is the content this guard exists to protect.

## Payloads that should be drift but passed as success

- **Gemini: `tokens: {}` became an all-zero usage row.** It now counts as drift,
  which is what an object of only unknown keys already did.
- **OpenCode: `parse_model_id` turned the text `null` or a number into a model
  name.** The catch-all was matching every non-object, non-string JSON value;
  only a parse *failure* is the legacy plain-name column now.

## Diagnostics that misreported

- **Copilot: an orphaned `tool.execution_complete` was dropped silently.** With
  no start event there is no tool name and so no `tracked` flag to gate on, so
  the record counted is the one that could actually have lost something: an
  orphan reporting success. A failed tool produces no metric even when it does
  pair, so its orphan is not a gap.
- **OpenCode: a part count was added to a record count and logged as records.**
  Split into two warnings; one message can carry many parts.
- **Parser: `malformed line N` cited the wrong N.** Every path now reports the
  physical line number. `read_next_non_empty_line` / `read_next_non_empty_bytes`
  count the lines they consume (blank ones included) and both JSONL iterators
  take that count as their starting offset, so the number no longer restarts at
  1 after a buffered prefix, and the two counting schemes no longer disagree
  about blank lines.
- **SQLite: the failure the user read was not the one the cacheability check
  read.** The four aggregator call sites now flatten the chain (`{error:#}`) the
  same way `is_cacheable_sqlite_failure` already did, so the cause reaches the
  user and the scan cache instead of a bare outer context. That context also
  names the source database rather than a temp copy that no longer exists by the
  time anyone reads the message. The `"unsupported sqlite schema"` needle, which
  nothing in the tree produces, is gone.

## Fragile lookups

- **Cursor: the store model fallback read an arbitrary `meta` row.**
  `SELECT value FROM meta LIMIT 1` against a `(key PRIMARY KEY, value)` table.
  Every row is now decoded and the first carrying `lastUsedModel` wins. Worth
  noting for the issue's record: real stores on disk key that row `0`, not
  `metadata`, so the obvious `WHERE key = 'metadata'` fix would have returned
  no rows and sent every conversation without a tracking-DB entry to `unknown`.
- **DeepSeek: tool results paired on `sourceEventSeqs[0]` only.** Every element
  is searched now. A match at index 0 behaves exactly as before, so this can
  only recover a pairing that used to be dropped. That also settles the
  `pending_calls` note in the issue: mispairing was the only thing that could
  leak an entry, and the map is per-file with a parser that dies in `finish`.

## Two items closed without a code change

- **Codex: a delete hunk records zero edited lines.** The issue flagged this as
  an open question rather than an obvious bug, and the answer is that the
  current behaviour is right. `total_edit_lines` is defined as new-content lines
  (`add_edit_detail_raw`'s doc says so), and every other provider counts a
  deletion the same way — Copilot's and OpenCode's `delete` arms pass the same
  empty `new`. Counting removed lines for Codex alone would make one provider
  disagree with the rest about what the number means. The removed body is not
  lost either: `ParseMode::Full` still stores it as the detail record's
  `old_string`.
- **Codex: leftover `custom_calls` are never reconciled.** The `shell_calls`
  cleanup loop this was measured against records only for
  `PendingCodexShellCall::InvalidArguments` — the one variant that *defers* its
  verdict. A leftover `Parsed` shell call, which is the real counterpart of a
  leftover custom call, deliberately records nothing, because the verdict was
  already taken at the invocation. `custom_tool_call` takes its verdict at the
  invocation too, so there is nothing deferred to close out. Adding a loop that
  records a failure for every leftover would do the opposite of the loop it was
  meant to mirror, and would fire on every live session with an in-flight tool
  call — that is, on every TUI refresh.

## Noticed and left alone

- `dsh.rs`'s `apply_read` carries the same `content.is_empty()` guard as the
  Grok item (its `lines` are joined with `\n`, so two empty lines produce
  `"\n"`). Same one-line shape, but not one of this issue's items.
- `extract_patch_strings` counting `---` / `+++` diff headers (#189's fourth
  bullet, deliberately not carried into #187).
- The non-cached OpenCode analysis path and four sites in `cursor.rs` still
  render a SQLite failure with plain `Display`. The issue named the four paired
  with the cacheability check; the rest are the same shape.

## Applied from review

A `code-review` pass over the branch raised three findings, all of which held
up and are folded into the commits they belong to:

- `store_meta_model` collected the `meta` rows through `rusqlite::Result`, so a
  single NULL or non-text `value` aborted the whole lookup — losing the field in
  exactly the multi-row store the scan exists to handle. Unreadable rows are
  skipped now, with a test row to hold it.
- The Copilot orphan branch double-counted a drifted `tool.execution_start`:
  that event already records a failure and is not paired, so its completion
  landed in the orphan branch and recorded a second one. A start carrying a
  usable `toolCallId` but nothing else now holds a placeholder so its completion
  pairs and stays silent.
- `load_conversation_model_snapshot`'s two failure sites were still rendering
  with plain `Display`, which the doc comment added here says a caller must not
  do. Flattened.

## Verification

`cargo test --workspace`, `make fmt` and `uvx pre-commit run -a` all clean,
rebased onto current `main`.

---

Opened-by: Claude Opus 5
