### PR TITLE
docs: point at the toolchain files instead of copying their versions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -62,7 +62,7 @@ Unsure where to begin contributing? You can start by looking through `good first
 
 #### Prerequisites
 
-- [Rust toolchain](https://rustup.rs/) **1.95 or higher** — pinned in `rust-toolchain.toml` (channel `1.96.1`) and required by `Cargo.toml` (`rust-version = "1.95"`); this project targets the **Rust 2024 edition**. Update with `rustup update` if needed.
+- [Rust toolchain](https://rustup.rs/) — the channel is pinned in `rust-toolchain.toml`, and `rustup` installs it for you on the first `cargo` command inside the repo; the minimum supported version is `Cargo.toml`'s `rust-version`. This project targets the **Rust 2024 edition**.
 - `rustfmt` and `clippy` components (installed by default with `rustup`).
 - Optional: [`pre-commit`](https://pre-commit.com/), [`cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov) for coverage, and Docker if you plan to touch the image build.
 
@@ -75,7 +75,7 @@ Unsure where to begin contributing? You can start by looking through `good first
 .
 ├── benches/          # Criterion benchmarks (pricing, parsing, aggregation)
 ├── cli/              # npm and PyPI wrapper packages (nodejs/, python/)
-├── docker/           # Multi-stage Dockerfile (rust:1.96.1-bookworm builder → ubuntu:26.04 prod)
+├── docker/           # Multi-stage Dockerfile (Rust builder → Ubuntu prod stage)
 ├── docs/             # Reference docs (raw quota + token-refresh curl/jq recipes)
 ├── src/
 │   ├── analysis/     # Collect canonical AnalysisDataset records and project per-model summaries

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Four auxiliary subcommands round out the CLI: `vct version` prints build/toolcha
 
 ## Common commands
 
-The toolchain is pinned to `rust-toolchain.toml` (1.97.0, edition 2024). On this machine `cargo` is **not** on the default `PATH`; export it before invoking any cargo command:
+The toolchain channel is pinned by `rust-toolchain.toml` (read that file for the version; edition 2024). On this machine `cargo` is **not** on the default `PATH`; export it before invoking any cargo command:
 
 ```bash
 export PATH="$HOME/.cargo/bin:$PATH"


### PR DESCRIPTION
Closes #230.

Three prose sentences each carried a copy of a Rust version that a
machine-readable file already owns, and all three had drifted two patch releases
behind. Re-checked against the owning files today, and the drift is real:

| Claim | Said | Owner |
| --- | --- | --- |
| `CLAUDE.md:18` | `1.97.0` | `rust-toolchain.toml` → `1.97.1` |
| `.github/CONTRIBUTING.md:65` | channel `1.96.1` | `rust-toolchain.toml` → `1.97.1` |
| `.github/CONTRIBUTING.md:78` | `rust:1.96.1-bookworm` | `docker/Dockerfile:1` → `rust:1.97.1-bookworm` |

## Should the prose name a version at all?

No. Correcting the three numbers would put them back in step for exactly as long
as it takes the next dependabot bump to move `rust-toolchain.toml` and not the
sentences that talk about it, which is how they got here. So each number is
replaced by a pointer to the file that owns it. There is nothing left to bump,
so nothing left to drift.

That costs the reader nothing, because `rustup` reads `rust-toolchain.toml`
itself and installs the pinned channel on the first `cargo` command inside the
repo. A contributor never needed to type the number, only to know which file
holds it — and `CONTRIBUTING.md:65`, the one line that told them which toolchain
to install, was the one most likely to send them after a stale version by hand.

`.github/CONTRIBUTING.md:78` loses both image tags, not just the Rust one.
`ubuntu:26.04` is correct today, but it is the same kind of mirror of
`docker/Dockerfile`, and half a line of tags reads worse than none.

## Re-checked and deliberately left alone

The issue flagged two spots as "not obviously wrong". Both hold up:

- `Cargo.toml` still has `rust-version = "1.95"` and `.github/workflows/test.yml`
  still runs its MSRV job on `1.95.0`, so `cargo +1.95.0 check` in the PR
  checklist matches both. It stays: a command a contributor runs needs a concrete
  toolchain, it moves together with the CI job that hardcodes the same version,
  and there is no pointer form of a `+toolchain` argument worth the indirection.
- `README*.md:509-510` is illustrative `vct version` output. The same block shows
  `Version 1.3.0`, nowhere near the current release, which is what makes the
  block read as a sample rather than as a claim. Editing it would swap one sample
  number for another and re-open a drift it is not currently causing. No README
  changed, so the three stay in sync.

## Noticed, not fixed here

The CONTRIBUTING "Project Layout" tree that line 78 sits inside is pre-workspace
throughout — `benches/` at the root, `src/analysis/`, `src/cli.rs`, `src/display/`
— and describes a layout the repo has not had since the workspace split. That is
structure rather than version numbers, so it is filed separately rather than
folded in.

Docs only; no code or CI behavior changes. `make fmt` and `uvx pre-commit run -a`
are clean.

---

Opened-by: Claude Opus 5
