### PR TITLE
test(bench): cover DeepSeek Harness in the parsing benchmarks

### DIFF
--- a/src/tui/benches/benchmarks.rs
+++ b/src/tui/benches/benchmarks.rs
@@ -114,6 +114,7 @@ fn benchmark_file_parsing(c: &mut Criterion) {
         ("copilot", "sessions/copilot.jsonl"),
         ("gemini", "sessions/gemini.jsonl"),
         ("grok", "sessions/grok/signals.json"),
+        ("dsh", "sessions/dsh/session.jsonl.zstd"),
     ];
 
     for (name, path) in test_files {
@@ -142,6 +143,11 @@ fn benchmark_known_provider_parsing(c: &mut Criterion) {
         ("copilot", "sessions/copilot.jsonl", ExtensionType::Copilot),
         ("gemini", "sessions/gemini.jsonl", ExtensionType::Gemini),
         ("grok", "sessions/grok/signals.json", ExtensionType::Grok),
+        (
+            "dsh",
+            "sessions/dsh/session.jsonl.zstd",
+            ExtensionType::DeepSeek,
+        ),
     ];
 
     for (name, path, provider) in fixtures {
@@ -456,12 +462,14 @@ fn benchmark_batch_analysis(c: &mut Criterion) {
     let copilot_path = fixture("sessions/copilot.jsonl");
     let gemini_path = fixture("sessions/gemini.jsonl");
     let grok_path = fixture("sessions/grok/signals.json");
+    let dsh_path = fixture("sessions/dsh/session.jsonl.zstd");
 
     if !claude_path.exists()
         || !codex_path.exists()
         || !copilot_path.exists()
         || !gemini_path.exists()
         || !grok_path.exists()
+        || !dsh_path.exists()
     {
         return;
     }
@@ -474,6 +482,7 @@ fn benchmark_batch_analysis(c: &mut Criterion) {
                 (copilot_path.clone(), "copilot"),
                 (gemini_path.clone(), "gemini"),
                 (grok_path.clone(), "grok"),
+                (dsh_path.clone(), "dsh"),
             ];
 
             // Simulate batch processing


### PR DESCRIPTION
Closes #231.

`src/tui/benches/benchmarks.rs` measured five of the six file-backed providers. DeepSeek Harness was absent from all three of its provider lists, so `cargo bench` reported parser performance with the one non-line-delimited decode path missing from the picture: a `dsh` log is a concatenation of independent zstd frames that `src/core/src/session/dsh.rs` decodes across before a single record is seen, and a regression there (a frame handled twice, a buffer reallocated per frame) costs nothing on any of the five formats already measured.

## What changed

DSH added to the three lists, using the compressed fixture `sessions/dsh/session.jsonl.zstd` — the shape worth measuring — and placed last, the order the four test lists closed by #203 already use.

- `benchmark_file_parsing`: one more `(name, path)` pair. `parse_session_file_to_value` routes a compressed log by its frame magic before the detector sees it, so nothing else in that function changes.
- `benchmark_known_provider_parsing`: one more `(name, path, ExtensionType)` triple. Both `ParseMode` arms already dispatch `DeepSeek` to `parse_dsh_session`.
- `benchmark_batch_analysis`: a `dsh_path` binding, a sixth term in the `exists()` guard, and a sixth entry in the `paths` vec, so `batch analyze all formats` covers all six.

No production code, no CLI behavior, no flags — the READMEs are unaffected.

## Verification

`cargo bench -p vct-tui` reports a measurement for each new id rather than dropping it through the `exists()` guard:

```
file_parsing/parse_session_file_to_value/dsh   [284.21 µs 334.97 µs 388.58 µs]
known_provider_parse/dsh/usage_only            [465.09 µs 525.56 µs 584.57 µs]
known_provider_parse/dsh/full                  [196.61 µs 228.41 µs 266.78 µs]
batch analyze all formats                      [8.0944 ms 9.0344 ms 10.042 ms]
```

`cargo test --workspace`, `make fmt` and `uvx pre-commit run -a` are all clean.

## Out of scope

`benchmark_format_detection` exercises `detect_extension_type` over in-memory records, and a `dsh` log never reaches that function — the parser routes it on zstd magic first — so there is nothing to add there. The issue names three lists and this is not one of them.

Opened-by: Claude Opus 5
