### PR TITLE
chore(usage): drop the uncalled PerProviderUsage accessor chain

### DIFF
--- a/src/core/src/models/usage.rs
+++ b/src/core/src/models/usage.rs
@@ -2,7 +2,6 @@
 //! display layer.
 
 use crate::constants::FastHashMap;
-use crate::models::Provider;
 use serde::Serialize;
 
 /// Token usage data aggregated by model name (across all dates).
@@ -58,6 +57,16 @@ pub struct ProviderActiveDays {
 /// session to Claude Code. Keeping one `UsageResult` per provider lets the
 /// display layer sum tokens and cost by source with no prefix heuristics. It
 /// is populated at the same time as the global merged map.
+///
+/// There is deliberately no keyed accessor on this type. Its nine buckets are
+/// one per [`ExtensionType`](crate::models::ExtensionType) variant, so a
+/// [`Provider`](crate::models::Provider)-keyed lookup would carry a tenth
+/// `Unknown` naming no bucket here. And nothing ever arrives holding a single
+/// key to look up: the summary and pricing passes each need all nine under a
+/// per-provider rule, one aggregation path names all nine fields directly, and
+/// the one that does key its write keys it on `ExtensionType`.
+// A `Provider`-keyed `get` / `get_mut` pair, reachable only through the equally
+// uncalled `UsageData::provider_usage`, was removed in #237.
 #[derive(Debug, Default, Clone, Serialize)]
 pub struct PerProviderUsage {
     /// Per-model usage attributed to Claude Code.
@@ -78,39 +87,4 @@ pub struct PerProviderUsage {
     pub grok: UsageResult,
     /// Per-model usage attributed to DeepSeek Harness.
     pub deepseek: UsageResult,
-}
-
-impl PerProviderUsage {
-    /// Returns the usage map for `provider`, or `None` for [`Provider::Unknown`].
-    pub fn get(&self, provider: Provider) -> Option<&UsageResult> {
-        match provider {
-            Provider::ClaudeCode => Some(&self.claude),
-            Provider::Codex => Some(&self.codex),
-            Provider::Copilot => Some(&self.copilot),
-            Provider::Gemini => Some(&self.gemini),
-            Provider::OpenCode => Some(&self.opencode),
-            Provider::Cursor => Some(&self.cursor),
-            Provider::Hermes => Some(&self.hermes),
-            Provider::Grok => Some(&self.grok),
-            Provider::DeepSeek => Some(&self.deepseek),
-            Provider::Unknown => None,
-        }
-    }
-
-    /// Returns a mutable handle to the usage map for `provider`, or `None` for
-    /// [`Provider::Unknown`].
-    pub fn get_mut(&mut self, provider: Provider) -> Option<&mut UsageResult> {
-        match provider {
-            Provider::ClaudeCode => Some(&mut self.claude),
-            Provider::Codex => Some(&mut self.codex),
-            Provider::Copilot => Some(&mut self.copilot),
-            Provider::Gemini => Some(&mut self.gemini),
-            Provider::OpenCode => Some(&mut self.opencode),
-            Provider::Cursor => Some(&mut self.cursor),
-            Provider::Hermes => Some(&mut self.hermes),
-            Provider::Grok => Some(&mut self.grok),
-            Provider::DeepSeek => Some(&mut self.deepseek),
-            Provider::Unknown => None,
-        }
-    }
 }

--- a/src/core/src/usage/aggregator.rs
+++ b/src/core/src/usage/aggregator.rs
@@ -13,7 +13,7 @@ use crate::config::ProvidersConfig;
 use crate::constants::{FastHashMap, FastHashSet, capacity};
 use crate::models::TimeRange;
 use crate::models::{
-    CodeAnalysis, ExtensionType, PerProviderUsage, Provider, ProviderActiveDays, UsageResult,
+    CodeAnalysis, ExtensionType, PerProviderUsage, ProviderActiveDays, UsageResult,
 };
 use crate::pricing::TierThresholds;
 use crate::session::cursor::{
@@ -1060,14 +1060,6 @@ fn usage_map_has_activity(usage: &FastHashMap<String, Value>, stored_cost: f64) 
         || usage
             .values()
             .any(|value| crate::utils::extract_token_counts(value).has_activity())
-}
-
-impl UsageData {
-    /// Returns the per-provider usage slice for `provider`, or `None` when the
-    /// provider has no dedicated bucket ([`Provider::Unknown`]).
-    pub fn provider_usage(&self, provider: Provider) -> Option<&UsageResult> {
-        self.per_provider.get(provider)
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #237.

Removes the three uncalled `pub` items the issue names, and records the decision on `PerProviderUsage`'s own doc comment so the next sweep finds it at the code rather than re-filing the same three names.

## The decision

The issue's third reading is the answer, and it settles the other two: a `Provider`-keyed accessor is the wrong interface on this type.

`PerProviderUsage` has exactly nine buckets, one per `ExtensionType` variant, and `ExtensionType` has no `Unknown`. `Provider` has ten. So a `Provider`-keyed accessor over this type returns an `Option` whose `None` arm names a bucket the type does not have. Nothing in the tree can even produce a `Provider` from a parsed session (`Provider::from_model_name` went in #193), so that arm was unreachable as well as meaningless.

The four consumers all agree, and none of them holds a single key. `calculate_provider_totals_from_per_provider` names all nine buckets, `resolve_merged_model_cost` walks them in two cost-basis groups, `aggregate_usage_from_paths_with_providers` names all nine fields directly, and `UsageAccumulator::add` is the one site that does key its write, keyed on `ExtensionType` with an exhaustive match. (`src/core/tests/usage.rs` exhaustively destructures the struct, which is what keeps a newly added field from going silently unhandled.) A keyed accessor serves a caller holding one key that wants one bucket, and this type has no such caller.

Deleting the accessors' `match` costs no compile-time guard either: `Provider::display_name` is still an exhaustive ten-arm match, so a new `Provider` variant still breaks the build.

That also disposes of the argument for keeping them. #193's resolution pointed at these as the shape to copy, because they return `Option` rather than handing out `&mut overall`. That is true and stays true, but it is an argument about the *return type*, and #193's body is the durable record of it. Keeping three uncalled `pub` functions as a footnote on a closed issue is worse than no example: this one is `Provider`-keyed on a type whose buckets are `ExtensionType`-shaped, so the next person to copy it copies the wrong key.

## Considered and rejected

Retargeting `get_mut` to `ExtensionType` and calling it from `UsageAccumulator::add`. It moves the same exhaustive nine-arm match from `aggregator.rs` into `models/usage.rs`, adds published API for one in-crate caller, and changes nothing about what the compiler catches when a provider is added.

## Public API

All three are `pub` in the published `vct-core`:

- `UsageData::provider_usage`
- `PerProviderUsage::get`
- `PerProviderUsage::get_mut`

Removing them is a breaking change for an external library consumer. Nothing in this workspace (core, tui, cli, integration tests or benches) references any of them, and no command output, JSON contract or fixture changes. Not marking this breaking myself; what it means for the version is the repo owner's call.

## Verification

`cargo test --workspace` (1049 tests, all pass), `cargo doc --no-deps --workspace` with and without `--document-private-items`, `make fmt`, `uvx pre-commit run -a`.

Opened-by: Claude Opus 5
