### PR TITLE
fix(scripts): exit 0 and remove the temp directory on a successful install

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -68,16 +68,18 @@ install_binary() {
     fi
 
     local url="https://github.com/${REPO}/releases/download/${version}/${filename}"
-    local temp_dir
-    temp_dir="$(mktemp -d)"
-    trap 'rm -rf "$temp_dir"' EXIT
+    # Not a local: the EXIT trap outlives this function, and under `set -u` an out-of-scope name
+    # makes the trap fail instead of cleaning up. Armed after mktemp so TEMP_DIR is never unset,
+    # and kept from failing because under `set -e` a failing trap decides the script's exit status.
+    TEMP_DIR="$(mktemp -d)"
+    trap 'rm -rf "$TEMP_DIR" || true' EXIT
 
-    local archive="${temp_dir}/${filename}"
+    local archive="${TEMP_DIR}/${filename}"
     curl -fsSL -o "$archive" "$url" || download_failed "$url"
-    tar -xzf "$archive" -C "$temp_dir"
+    tar -xzf "$archive" -C "$TEMP_DIR"
 
     local binary
-    binary="$(find "$temp_dir" -type f -name "$BINARY_NAME" -print -quit)"
+    binary="$(find "$TEMP_DIR" -type f -name "$BINARY_NAME" -print -quit)"
     if [ -z "$binary" ]; then
         echo "Binary not found in downloaded archive." >&2
         exit 1


### PR DESCRIPTION
Closes #228.

## The bug

`install_binary` armed its cleanup as

```bash
local temp_dir
temp_dir="$(mktemp -d)"
trap 'rm -rf "$temp_dir"' EXIT
```

An `EXIT` trap does not run until the script exits, by which point `install_binary` has returned and
its `local` is gone. Under the script's `set -u` the trap body then fails with
`temp_dir: unbound variable`, so the temp directory is never removed and the failing trap is the
last thing the shell does.

`temp_dir` becomes the script-level `TEMP_DIR`, still armed on the line after `mktemp -d` so the
trap is never set against an unset name. `set -euo pipefail` and the trap both stay.

## The second half of the same bug

The out-of-scope name was only the trigger. The mechanism is that under `set -e` a **failing** EXIT
trap decides the script's exit status, and it overrides even an explicit `exit N`:

```
trap 'true'  EXIT + exit 7          -> 7      succeeding trap changes nothing
trap 'true'  EXIT + set -e abort(2) -> 2      succeeding trap changes nothing
trap 'false' EXIT + body succeeds   -> 1      <- this is the reported bug
trap 'false' EXIT + exit 7          -> 1      an explicit status is clobbered too
```

So an `rm -rf` that fails for any other reason — a read-only `/tmp`, a stale NFS handle — still
turns a good install into exit 1. The trap carries `|| true` to close the class. The first two rows
are why that is safe: a trap that succeeds never rewrites the status, so nothing is masked. `rm`
still prints its own reason to stderr; only the exit status is decoupled, which is correct, because
failing to remove a temp directory is not a failed install.

## Verification

Every path, both versions, run with `curl` stubbed by a `PATH` shim and a scoped `TMPDIR` so a leak
is measurable. `before` is `scripts/install.sh` at f4ef317.

```
########## before ##########
success          exit=1   temp_dirs_left=1   unbound_error=yes  installed=yes
download-fail    exit=1   temp_dirs_left=0   unbound_error=no   installed=no
corrupt-tarball  exit=1   temp_dirs_left=1   unbound_error=yes  installed=no
no-binary        exit=1   temp_dirs_left=0   unbound_error=no   installed=no
api-fail         exit=1   temp_dirs_left=0   unbound_error=no   installed=no
unsupported-os   exit=1   temp_dirs_left=0   unbound_error=no   installed=no
########## after ##########
success          exit=0   temp_dirs_left=0   unbound_error=no   installed=yes
download-fail    exit=1   temp_dirs_left=0   unbound_error=no   installed=no
corrupt-tarball  exit=2   temp_dirs_left=0   unbound_error=no   installed=no
no-binary        exit=1   temp_dirs_left=0   unbound_error=no   installed=no
api-fail         exit=1   temp_dirs_left=0   unbound_error=no   installed=no
unsupported-os   exit=1   temp_dirs_left=0   unbound_error=no   installed=no
```

Two rows moved, and it is worth being precise about which, because the obvious guess is wrong. The
failure paths that call `exit` **inside** `install_binary` (`download-fail`, `no-binary`) were never
broken: an explicit `exit` from inside the function keeps the frame alive, so the old trap did see
its `local`. What was broken is the **success** path and any **`set -e` abort**, both of which pop
the frame before the trap runs. `corrupt-tarball` is the second one, and it also stops reporting
`tar`'s status 2 as 1.

The reproduction from the issue was also run unstubbed against the real release, before and after:

```
before:  Installed vibe_coding_tracker v2.6.0 to /tmp/fakehome/.local/bin
         scripts/install.sh: line 1: temp_dir: unbound variable
         exit=1, /tmp/tmp.yozMdPMT5r left behind
after:   exit=0, no temp directory left
```

The binary, the `vct` symlink and the `.vct-managed` marker all install correctly either way.

## The install.ps1 claim

#228 says `scripts/install.ps1` has no equivalent problem. Checked rather than assumed: its
`$tempDir` is created and cleaned inside one function, so the `finally` genuinely does see it. Run
under a portable pwsh 7.4.6 on Linux against the real `Install-Binary`, with only the download
boundary stubbed and `LOCALAPPDATA` pointed at a sandbox:

```
success path:  exit=0   LEAKED_TEMP_DIRS=0   INSTALLED=True
failure path:  exit=1   no GUID temp directory left behind
```

The claim holds. The file also parses clean.

## Not in this PR

Filed as #245: both installers also leak their **staging** files, which live in the install
directory rather than in `/tmp` and so are never reaped. Different trigger (failure paths only) and
it touches both scripts, so it is not folded in here. Its worse variant is that a failed marker
`mv` leaves a working binary with no `.vct-managed`, which silently disables auto-update forever.

No regression test comes with this fix, and that is a deliberate call rather than an oversight:
`shellcheck` passes on the buggy version of the script, so the repo's only shell gate cannot catch
this class, and there is no shell test infrastructure in the repo or in CI to extend. Standing one
up is a bigger question than this bug, so it is recorded in #245 rather than answered here.

No CLI behavior or flags change, so the three READMEs are untouched.

---

Opened-by: Claude Opus 5
