### PR TITLE
refactor(gemini): resolve tool arguments through one read

### DIFF
--- a/src/core/src/session/gemini.rs
+++ b/src/core/src/session/gemini.rs
@@ -295,8 +295,8 @@ fn gemini_tool_status(tool_call: &Value) -> GeminiToolStatus {
 
 /// A Gemini tool this parser tracks, resolved from the name in the log.
 ///
-/// One variant per metric the tool folds into. The schema check, the invocation
-/// counter and the file-operation fold each match exhaustively on the enum, so a
+/// One variant per metric the tool folds into. [`TrackedTool::read_args`] and
+/// [`TrackedTool::record_invocation`] both match exhaustively on the enum, so a
 /// variant one of them forgets is a build error rather than a silently dropped
 /// metric. What the compiler cannot check is [`TrackedTool::from_name`] itself,
 /// which is why every tool name is spelled there and nowhere else.
@@ -333,42 +333,40 @@ impl TrackedTool {
         })
     }
 
-    /// Whether a successful call carries the arguments [`Self::record_operation`]
-    /// needs; a call that does not is counted as an invocation only.
-    fn schema_supported(self, tool_call: &Value) -> bool {
+    /// Reads the arguments a successful call folds into metrics, or `None` when
+    /// this parser cannot read them — that call is counted as an invocation
+    /// only. Every argument key the parser knows, historical alias spellings
+    /// included, is listed here and nowhere else.
+    fn read_args(self, tool_call: &Value) -> Option<ToolArgs<'_>> {
         let args = tool_call.get("args");
-        match self {
-            Self::Read => {
-                args.and_then(|args| args.get("file_path"))
-                    .and_then(Value::as_str)
-                    .is_some_and(|path| !path.is_empty())
-                    && tool_result_output(tool_call).is_some()
-            }
-            Self::Write => {
-                args.and_then(|args| args.get("file_path"))
-                    .and_then(Value::as_str)
-                    .is_some_and(|path| !path.is_empty())
-                    && args
-                        .and_then(|args| args.get("content"))
-                        .is_some_and(Value::is_string)
-            }
-            Self::Edit => {
-                args.and_then(|args| args.get("file_path"))
-                    .and_then(Value::as_str)
-                    .is_some_and(|path| !path.is_empty())
-                    && args
-                        .and_then(|args| args.get("old_string").or_else(|| args.get("old_text")))
-                        .is_some_and(Value::is_string)
-                    && args
-                        .and_then(|args| args.get("new_string").or_else(|| args.get("new_text")))
-                        .is_some_and(Value::is_string)
-            }
-            Self::Shell => args
-                .and_then(|args| args.get("command").or_else(|| args.get("cmd")))
-                .and_then(Value::as_str)
-                .is_some_and(|command| !command.trim().is_empty()),
-            Self::TodoWrite | Self::ReadManyFiles => true,
-        }
+        Some(match self {
+            Self::Read => ToolArgs::Read {
+                file_path: arg_file_path(args)?,
+                content: tool_result_output(tool_call)?,
+            },
+            Self::Write => ToolArgs::Write {
+                file_path: arg_file_path(args)?,
+                content: arg_str(args, &["content"])?,
+            },
+            Self::Edit => ToolArgs::Edit {
+                file_path: arg_file_path(args)?,
+                old_string: arg_str(args, &["old_string", "old_text"])?,
+                new_string: arg_str(args, &["new_string", "new_text"])?,
+            },
+            Self::Shell => ToolArgs::Shell {
+                // A blank command would be dropped by `add_run_command`,
+                // leaving the call with no metric at all, so it counts as
+                // unreadable here and is recorded as an invocation instead.
+                command: arg_str(args, &["command", "cmd"])
+                    .filter(|command| !command.trim().is_empty())?,
+                // Optional, and absent from plenty of real calls: it is
+                // reported alongside the command, not part of what makes the
+                // call foldable.
+                description: arg_str(args, &["description"]).unwrap_or(""),
+            },
+            Self::TodoWrite => ToolArgs::TodoWrite,
+            Self::ReadManyFiles => ToolArgs::ReadManyFiles,
+        })
     }
 
     /// Counts the call without claiming any file operation, for a call that
@@ -382,67 +380,78 @@ impl TrackedTool {
             Self::TodoWrite => state.tool_counts.todo_write += 1,
         }
     }
+}
 
-    /// Folds a successful call whose schema [`Self::schema_supported`] accepted
-    /// into the file-operation metrics.
-    fn record_operation(self, state: &mut SessionParseState, tool_call: &Value, ts: i64) {
-        let args = tool_call.get("args");
+/// The arguments of a successful [`TrackedTool`] call, read once.
+///
+/// Building one *is* the schema check, so a key validation accepts cannot be a
+/// key the fold then fails to read: there is no second reader to disagree with.
+/// The two used to be separate `match` arms over [`TrackedTool`], each spelling
+/// out the alias pair of every argument that has one.
+enum ToolArgs<'a> {
+    Read {
+        file_path: &'a str,
+        content: &'a str,
+    },
+    Write {
+        file_path: &'a str,
+        content: &'a str,
+    },
+    Edit {
+        file_path: &'a str,
+        old_string: &'a str,
+        new_string: &'a str,
+    },
+    Shell {
+        command: &'a str,
+        description: &'a str,
+    },
+    TodoWrite,
+    ReadManyFiles,
+}
+
+impl ToolArgs<'_> {
+    /// Folds the call into the file-operation metrics.
+    fn record(self, state: &mut SessionParseState, ts: i64) {
         match self {
-            Self::Read => {
+            Self::Read { file_path, content } => {
                 state.tool_counts.read += 1;
-                let file_path = args
-                    .and_then(|a| a.get("file_path"))
-                    .and_then(|p| p.as_str())
-                    .unwrap_or("");
-
-                if let Some(content) = tool_result_output(tool_call) {
-                    attach_read_detail(state, file_path, content, ts);
-                }
+                attach_read_detail(state, file_path, content, ts);
             }
-            Self::Write => {
-                let file_path = args
-                    .and_then(|a| a.get("file_path"))
-                    .and_then(|p| p.as_str())
-                    .unwrap_or("");
-                let content = args
-                    .and_then(|a| a.get("content"))
-                    .and_then(|c| c.as_str())
-                    .unwrap_or("");
-
-                state.add_write_detail(file_path, content, ts);
-            }
-            Self::Edit => {
-                let file_path = args
-                    .and_then(|a| a.get("file_path"))
-                    .and_then(|p| p.as_str())
-                    .unwrap_or("");
-                let old_string = args
-                    .and_then(|a| a.get("old_string").or_else(|| a.get("old_text")))
-                    .and_then(|s| s.as_str())
-                    .unwrap_or("");
-                let new_string = args
-                    .and_then(|a| a.get("new_string").or_else(|| a.get("new_text")))
-                    .and_then(|s| s.as_str())
-                    .unwrap_or("");
-
+            Self::Write { file_path, content } => state.add_write_detail(file_path, content, ts),
+            Self::Edit {
+                file_path,
+                old_string,
+                new_string,
+            } => {
+                // `add_edit_detail_raw`, not `add_edit_detail`: an empty
+                // `old_string` here is an edit that replaced nothing, not a new
+                // file expressed as a diff, so it must not turn into a write.
                 state.add_edit_detail_raw(file_path, old_string, new_string, ts);
             }
-            Self::Shell => {
-                let command = args
-                    .and_then(|a| a.get("command").or_else(|| a.get("cmd")))
-                    .and_then(|c| c.as_str())
-                    .unwrap_or("");
-                let description = args
-                    .and_then(|a| a.get("description"))
-                    .and_then(|d| d.as_str())
-                    .unwrap_or("");
-
-                state.add_run_command(command, description, ts);
-            }
+            Self::Shell {
+                command,
+                description,
+            } => state.add_run_command(command, description, ts),
             Self::TodoWrite => state.tool_counts.todo_write += 1,
             Self::ReadManyFiles => state.tool_counts.read += 1,
         }
     }
+}
+
+/// The string under the first of `keys` that `args` carries.
+///
+/// A key present but holding something other than a string ends the search: the
+/// log did spell the argument, just not in a shape this parser can read.
+fn arg_str<'a>(args: Option<&'a Value>, keys: &[&str]) -> Option<&'a str> {
+    let args = args?;
+    keys.iter().find_map(|key| args.get(*key))?.as_str()
+}
+
+/// The `file_path` argument, which every variant carrying one requires to be
+/// non-empty; an operation against no path records nothing downstream.
+fn arg_file_path(args: Option<&Value>) -> Option<&str> {
+    arg_str(args, &["file_path"]).filter(|path| !path.is_empty())
 }
 
 fn record_message_diagnostics(message: &GeminiAnalysisMessage, diagnostics: &mut ParseDiagnostics) {
@@ -455,7 +464,7 @@ fn record_message_diagnostics(message: &GeminiAnalysisMessage, diagnostics: &mut
             continue;
         };
         let normalized = match gemini_tool_status(tool_call) {
-            GeminiToolStatus::Success => tool.schema_supported(tool_call),
+            GeminiToolStatus::Success => tool.read_args(tool_call).is_some(),
             GeminiToolStatus::Failed => true,
             GeminiToolStatus::Pending | GeminiToolStatus::Unsupported => false,
         };
@@ -510,12 +519,13 @@ fn process_gemini_message(state: &mut SessionParseState, message: &GeminiAnalysi
         if status == GeminiToolStatus::Unsupported {
             continue;
         }
-        if status != GeminiToolStatus::Success || !tool.schema_supported(tool_call) {
+        if status == GeminiToolStatus::Success
+            && let Some(args) = tool.read_args(tool_call)
+        {
+            args.record(state, ts);
+        } else {
             tool.record_invocation(state);
-            continue;
         }
-
-        tool.record_operation(state, tool_call, ts);
     }
 }
 
@@ -710,7 +720,7 @@ mod tests {
             ("update_topic", [0, 0, 0, 0, 0]),
         ];
 
-        // A successful call folds through `record_operation`, a failed one
+        // A successful call folds through `ToolArgs::record`, a failed one
         // through `record_invocation`. They are separate matches, and a name
         // must reach the same counter either way.
         for status in ["success", "error"] {

--- a/src/core/src/session/gemini.rs
+++ b/src/core/src/session/gemini.rs
@@ -883,6 +883,153 @@ mod tests {
         assert_eq!(record.tool_call_counts.write, 0);
         assert_eq!(record.total_edit_lines, 0);
         assert_eq!(record.total_write_lines, 0);
+
+        // The other way an edit can turn into a write: an `old_string` that is
+        // present but empty replaced nothing, which is not the same as a new
+        // file expressed as a diff. Only `add_edit_detail_raw` keeps them apart.
+        let empty_old = assistant(
+            "empty-old-edit",
+            "gemini-test",
+            10,
+            json!([{
+                "name": "replace",
+                "args": {
+                    "file_path": "/tmp/a.txt",
+                    "old_string": "",
+                    "new_string": "new"
+                }
+            }]),
+        );
+
+        let parsed =
+            parse_gemini_events_with_diagnostics(session(), vec![empty_old], ParseMode::Full, None)
+                .unwrap();
+        let record = &parsed.analysis.records[0];
+        assert_eq!(parsed.diagnostics.partial_failure_count(), 0);
+        assert_eq!(record.tool_call_counts.edit, 1);
+        assert_eq!(record.tool_call_counts.write, 0);
+        assert_eq!(record.total_edit_lines, 1);
+        assert_eq!(record.total_write_lines, 0);
+    }
+
+    #[test]
+    fn every_argument_alias_reaches_the_fold() {
+        // An argument's alias spellings are stated once, in
+        // `TrackedTool::read_args`, so a dropped alias no longer shows up as
+        // two lists disagreeing — it simply stops resolving. These assert on
+        // the folded content rather than on the counter, because a key that
+        // resolved to nothing would leave the counter right while the detail
+        // it carries went empty, which is the miscount this pairing produced.
+        for (old_key, new_key) in [("old_string", "new_string"), ("old_text", "new_text")] {
+            let mut args = json!({ "file_path": "/tmp/a.txt" });
+            args[old_key] = json!("one");
+            args[new_key] = json!("two\nthree");
+            let message = assistant(
+                "edit",
+                "gemini-test",
+                10,
+                json!([{ "name": "replace", "args": args }]),
+            );
+
+            let parsed = parse_gemini_events_with_diagnostics(
+                session(),
+                vec![message],
+                ParseMode::Full,
+                None,
+            )
+            .unwrap();
+            let record = &parsed.analysis.records[0];
+            assert_eq!(
+                parsed.diagnostics.partial_failure_count(),
+                0,
+                "{old_key}/{new_key} must not raise schema drift"
+            );
+            assert_eq!(record.tool_call_counts.edit, 1);
+            assert_eq!(
+                record.total_edit_lines, 2,
+                "{new_key} did not reach the fold"
+            );
+            assert_eq!(
+                record.edit_file_details[0].old_string, "one",
+                "{old_key} did not reach the fold"
+            );
+        }
+
+        for command_key in ["command", "cmd"] {
+            let mut args = json!({ "description": "list the tree" });
+            args[command_key] = json!("ls -la");
+            let message = assistant(
+                "shell",
+                "gemini-test",
+                10,
+                json!([{ "name": "run_shell_command", "args": args }]),
+            );
+
+            let parsed = parse_gemini_events_with_diagnostics(
+                session(),
+                vec![message],
+                ParseMode::Full,
+                None,
+            )
+            .unwrap();
+            let record = &parsed.analysis.records[0];
+            assert_eq!(
+                parsed.diagnostics.partial_failure_count(),
+                0,
+                "{command_key} must not raise schema drift"
+            );
+            assert_eq!(record.tool_call_counts.bash, 1);
+            assert_eq!(
+                record.run_command_details[0].command, "ls -la",
+                "{command_key} did not reach the fold"
+            );
+        }
+    }
+
+    #[test]
+    fn a_blank_command_is_counted_rather_than_dropped() {
+        // `add_run_command` drops a command that is empty after trimming, so a
+        // blank one must not be treated as readable: it would leave the call
+        // with no counter and no drift at all.
+        let message = assistant(
+            "blank-command",
+            "gemini-test",
+            10,
+            json!([{ "name": "run_shell_command", "args": { "command": "   " } }]),
+        );
+
+        let parsed =
+            parse_gemini_events_with_diagnostics(session(), vec![message], ParseMode::Full, None)
+                .unwrap();
+        let record = &parsed.analysis.records[0];
+        assert_eq!(parsed.diagnostics.partial_failure_count(), 1);
+        assert_eq!(record.tool_call_counts.bash, 1);
+        assert!(record.run_command_details.is_empty());
+    }
+
+    #[test]
+    fn an_unsupported_tool_status_records_nothing() {
+        // A status this parser does not recognize is neither a run nor a
+        // failure, so it moves no counter — unlike every other non-success
+        // status, which counts the invocation.
+        let message = assistant(
+            "unsupported-status",
+            "gemini-test",
+            10,
+            json!([{
+                "name": "write_file",
+                "status": "cancelled",
+                "args": { "file_path": "/tmp/a.txt", "content": "one" }
+            }]),
+        );
+
+        let parsed =
+            parse_gemini_events_with_diagnostics(session(), vec![message], ParseMode::Full, None)
+                .unwrap();
+        let record = &parsed.analysis.records[0];
+        assert_eq!(parsed.diagnostics.partial_failure_count(), 1);
+        assert_eq!(record.tool_call_counts.write, 0);
+        assert_eq!(record.total_write_lines, 0);
     }
 
     #[test]


### PR DESCRIPTION
Closes #234.

`src/core/src/session/gemini.rs` read every tool argument twice: once in
`TrackedTool::schema_supported`, to decide whether a successful call could be
folded, and again in `TrackedTool::record_operation`, to get the value out.
Three arguments have a historical alias, and each pair was spelled in both
places — `old_string`/`old_text`, `new_string`/`new_text`, `command`/`cmd`.

Two separate `match` arms over the same enum, so the compiler was satisfied
whatever they disagreed about, and each direction of disagreement failed
silently: a key validation accepted but the fold did not read produced a
successful fold over an empty string, and a key the fold read but validation
did not accept sent a good call down the invocation-only path and reported it
as schema drift.

## What changed

Validation and extraction collapse into one read, so there is no second reader
to disagree with.

- `TrackedTool::read_args(tool_call) -> Option<ToolArgs<'_>>` replaces
  `schema_supported`. `None` is exactly what "schema unsupported" meant before.
  Every argument key the parser knows, alias spellings included, is now spelled
  here and nowhere else.
- `ToolArgs` is the result: one variant per `TrackedTool` variant, carrying the
  values that variant's fold needs. `ToolArgs::record` replaces
  `record_operation` and reads no keys at all.
- `arg_str(args, &[...])` is the one accessor that resolves an alias list, and
  `arg_file_path` the "present and non-empty" rule Read/Write/Edit share.
- `record_message_diagnostics` asks `read_args(..).is_some()`;
  `process_gemini_message` keeps its `Unsupported` early-continue and folds the
  rest through a let-chain.

An alias accepted by validation but unread by the fold is no longer
expressible. What the compiler still cannot check — `TrackedTool::from_name`,
and the alias lists themselves — is what the new test pins.

## Behaviour

Unchanged, including the parts this shape makes easy to lose:

- key-resolution order: `arg_str` takes the first key *present* and then
  requires a string, which is what `.get(a).or_else(|| .get(b)).and_then(as_str)`
  did
- `Shell` still requires a command non-empty **after trimming**, so a blank one
  stays invocation-only instead of reaching `add_run_command`, which drops it
  and would leave no counter at all
- `description` is still optional, not part of the schema check
- the `Read` fold still increments `tool_counts.read` itself, with
  `attach_read_detail` holding that count steady
- `Edit` still folds through `add_edit_detail_raw`, never `add_edit_detail`,
  which reclassifies an empty-old edit as a write
- an `Unsupported` tool status still records nothing

`record_operation`'s Read arm re-checked `tool_result_output` under an `if let`
that `schema_supported` had already made true; the value now arrives in
`ToolArgs::Read` and the re-check is gone.

## Coverage

`edit_requires_both_old_and_new_text_without_falling_back_to_write` keeps its
meaning and gains the case its name always promised: an edit whose `old_string`
is present but empty must still land as an edit. That is the difference between
the two `add_edit_detail*` helpers and nothing pinned it before.

New `every_argument_alias_reaches_the_fold` walks all six spellings and asserts
on the folded content — `edit_file_details[0].old_string` and the
`run_command_details` entry — not on a counter, because an alias that resolved
to nothing would leave the counter right and the detail empty. The historical
half of each pair had no coverage at all before this.

Two more guards for behaviour the rewrite could have dropped without any test
noticing: `a_blank_command_is_counted_rather_than_dropped` and
`an_unsupported_tool_status_records_nothing`.

Every one verified non-vacuous by mutation — dropping `"old_text"`, dropping
`"cmd"`, accepting a blank command, removing the `Unsupported` skip, swapping
`add_edit_detail_raw` for `add_edit_detail`, and making the old text optional
each turn the named test red.

`cargo test --workspace`, `make fmt` and `uvx pre-commit run -a` are clean, and
each commit is green on its own.

---

Opened-by: Claude Opus 5
