### PR TITLE
test(cli): pin the version command's JSON output to the build constants

### DIFF
--- a/src/cli/tests/cli.rs
+++ b/src/cli/tests/cli.rs
@@ -100,8 +100,8 @@ fn test_version_command_json_matches_build_constants() {
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     // The whole object rather than a field at a time: the subcommand renders
     // `get_version_info()` while `--version` prints `VERSION` from `main.rs`
-    // ahead of clap, so this is what holds those two paths to one answer, and
-    // an exact match pins the key set on top of the values.
+    // ahead of clap, so this pins the subcommand's side of that pair to the
+    // same constants, and an exact match pins the key set as well as the values.
     assert_eq!(
         json,
         json!({

--- a/src/cli/tests/cli.rs
+++ b/src/cli/tests/cli.rs
@@ -23,7 +23,7 @@ use assert_cmd::Command;
 use predicates::prelude::*;
 use serde_json::json;
 use vct_core::session::{ParseMode, parse_session_file_typed_with_mode};
-use vct_core::{VERSION, parse_session_file_typed};
+use vct_core::{CARGO_VERSION, RUST_VERSION, VERSION, parse_session_file_typed};
 use vct_test_support::{TempHome, fixture};
 
 /// A minimal cost-fields pricing map used to seed the offline cache so `usage`
@@ -89,7 +89,7 @@ fn test_short_version_flag_outputs_build_version_only() {
 }
 
 #[test]
-fn test_version_command_json() {
+fn test_version_command_json_matches_build_constants() {
     let home = TempHome::new();
     let output = child_cmd(&home)
         .arg("version")
@@ -98,7 +98,18 @@ fn test_version_command_json() {
         .unwrap();
     assert!(output.status.success());
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert!(json["Version"].is_string(), "Should have Version field");
+    // The whole object rather than a field at a time: the subcommand renders
+    // `get_version_info()` while `--version` prints `VERSION` from `main.rs`
+    // ahead of clap, so this is what holds those two paths to one answer, and
+    // an exact match pins the key set on top of the values.
+    assert_eq!(
+        json,
+        json!({
+            "Version": VERSION,
+            "Rust Version": RUST_VERSION,
+            "Cargo Version": CARGO_VERSION,
+        })
+    );
 }
 
 #[test]
@@ -576,19 +587,6 @@ fn test_quota_multiple_output_formats() {
             .failure()
             .stderr(predicate::str::contains("cannot be used with"));
     }
-}
-
-#[test]
-fn test_cli_version_matches_cargo() {
-    let home = TempHome::new();
-    let output = child_cmd(&home)
-        .arg("version")
-        .arg("--json")
-        .output()
-        .unwrap();
-    assert!(output.status.success());
-    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert!(json["Version"].is_string(), "Should have Version field");
 }
 
 // ============================================================================


### PR DESCRIPTION
`src/cli/tests/cli.rs` carried `test_version_command_json` and
`test_cli_version_matches_cargo` as line-for-line copies of each other: run
`version --json`, assert the child succeeded, assert `json["Version"]` is a
string. The second name promised a comparison the body never made.

## The call, and why

The issue left the choice open between dropping the duplicate and keeping both
names with a real comparison added to the second. This takes the first, and
moves the promised comparison into the survivor.

- The value assertion subsumes the shape assertion. `json["Version"] == VERSION`
  implies `is_string()`, so keeping both names would leave one test whose whole
  job is a weaker restatement of the other's first line, paid for with a second
  child-process spawn.
- The name would still have been wrong with the comparison bolted on. `vct
  version` reports `vct_core::VERSION`, which is `BUILD_VERSION` — a
  git-describe string that falls back to the `Cargo.toml` version only outside a
  git tree. Keeping "matches cargo" would have traded one wrong promise for a
  subtler one, so the survivor is named for what it pins instead.
- The relationship is real and was unpinned. `--version` / `-V` are
  short-circuited in `main.rs` ahead of clap and print `VERSION` directly, while
  `version --json` renders `get_version_info()`. Two code paths reporting the
  same fact, and nothing asserting they agree.

Net coverage is up, not down: one behavior that had two weak tests now has one
test that pins the values and the key set.

## The assertion compares the whole object

Not three field comparisons. An exact `serde_json::Value` match pins the key set
as well, so a field added to the `--json` payload cannot appear unnoticed — that
payload is a public output contract.

## Proof it can fail

Both halves were mutated and watched go red before committing, then reverted
(`main.rs` is byte-identical to its pre-probe state in this branch):

- `"Version": version_info.version` → `"0.0.0-probe"`: fails with
  `left: "0.0.0-probe"` / `right: "2.6.1-g7e24e1b-dirty"`.
- an extra `"Probe Key": "probe"` in the JSON arm: fails on the surplus key.

The failure output also confirms the test binary and the CLI binary link the
same `vct-core` rlib, so the constants really are the ones the binary was built
with.

## Checks

`make fmt`, `uvx pre-commit run -a` and `cargo test --workspace` all pass
locally. The surviving test already ran through the `child_cmd(&home)`
isolated-home helper, so the requirement from #233 is untouched.

Closes #247

---

Opened-by: Claude Opus 5
