### PR TITLE
docs: redraw the CONTRIBUTING project layout as the workspace it is

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -127,7 +127,7 @@ Two release profiles are defined in `Cargo.toml`:
 
 `Cargo.toml` exposes a small set of optional features; the defaults are tuned for long-running TUI sessions.
 
-- **System allocator (default)** — the build links against glibc's `malloc`. Combined with the `mallopt` tuning applied at startup (see `src/utils/heap.rs`) and the per-refresh `malloc_trim(0)` call, this keeps `usage` / `analysis` TUI RSS roughly flat (~30–50 MB) even over hours of refreshes. Use this for anything you plan to leave open.
+- **System allocator (default)** — the build links against glibc's `malloc`. Combined with the `mallopt` tuning applied at startup (see `src/core/src/utils/heap.rs`) and the per-refresh `malloc_trim(0)` call, this keeps `usage` / `analysis` TUI RSS roughly flat (~30–50 MB) even over hours of refreshes. Use this for anything you plan to leave open.
 - **`mimalloc` (opt-in)** — enable with `cargo build --release --features mimalloc`. Links Microsoft's mimalloc as the global allocator. Startup / one-shot commands (`vct usage --json`, `vct analysis file.jsonl`) are slightly faster, but mimalloc's lazy purge retains freed pages — on a 219-session directory the TUI RSS was ~11× higher than the default build in our measurements. Prefer this only for scripted, short-lived invocations.
 
 On Linux/glibc the main binary also calls `mallopt(M_ARENA_MAX, 2)` + `mallopt(M_TRIM_THRESHOLD, 128 KiB)` at start. These cap the number of per-thread allocator arenas (so Rayon workers can't multiply arena-side fragmentation across cores) and pin the trim threshold. The calls are no-ops on other platforms / allocators.
@@ -146,20 +146,20 @@ Common Makefile shortcuts (`make help` to list all):
 
 #### Running Tests
 
-Tests follow the Rust Book's [ch11-03 organization](https://doc.rust-lang.org/book/ch11-03-test-organization.html): unit tests live inline in `src/` inside `#[cfg(test)] mod tests`, and each integration test file under `tests/*.rs` builds as its own Cargo test binary.
+Tests follow the Rust Book's [ch11-03 organization](https://doc.rust-lang.org/book/ch11-03-test-organization.html): unit tests live inline in each crate's `src/` inside `#[cfg(test)] mod tests`, and each integration test file under a crate's `tests/` builds as its own Cargo test binary.
 
 ```bash
 # Everything (library unit tests + integration tests + doctests)
 cargo test --all
 
-# Integration tests only (each file under tests/ is a separate test binary)
+# Integration tests only (each file under a crate's tests/ is a separate binary)
 cargo test --tests
 
-# A specific integration test crate
+# A specific integration test binary
 cargo test --test analysis
 
 # Unit tests for a specific src module (path mirrors the module path)
-cargo test --lib analysis::detector
+cargo test --lib session::detector
 cargo test --lib pricing::matching
 
 # Run a single test by name (works across all binaries)
@@ -177,7 +177,7 @@ VCT_OFFLINE=1 cargo test --all-targets --all-features --locked
 
 #### Benchmarks
 
-Performance-sensitive code paths (pricing lookup, provider parsing, cold and incremental scans, long-preamble detection, aggregation, and TUI rendering) have Criterion benchmarks in `benches/benchmarks.rs`:
+Performance-sensitive code paths (pricing lookup, provider parsing, cold and incremental scans, long-preamble detection, aggregation, and TUI rendering) have Criterion benchmarks in `src/tui/benches/benchmarks.rs`:
 
 ```bash
 cargo bench

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -71,28 +71,27 @@ Unsure where to begin contributing? You can start by looking through `good first
 
 #### Project Layout
 
+The repository is a Cargo workspace: all the Rust code lives in the four members under `src/`, and everything around them is packaging, docs, tooling and test data.
+
 ```
 .
-├── benches/          # Criterion benchmarks (pricing, parsing, aggregation)
+├── assets/           # Repository images (social preview)
 ├── cli/              # npm and PyPI wrapper packages (nodejs/, python/)
 ├── docker/           # Multi-stage Dockerfile (Rust builder → Ubuntu prod stage)
 ├── docs/             # Reference docs (raw quota + token-refresh curl/jq recipes)
-├── src/
-│   ├── analysis/     # Collect canonical AnalysisDataset records and project per-model summaries
-│   ├── cache/        # Library-facing LRU file-parse compatibility API
-│   ├── cli.rs        # clap definitions (commands, flags, TimeRange enum)
-│   ├── constants.rs  # Capacity / buffer-size tuning constants + FastHashMap alias
-│   ├── display/      # TUI dashboards, static tables, plain-text renderers (usage rows sorted by cost ascending)
-│   ├── models/       # Typed structs (CodeAnalysis, Provider, ExtensionType, per-provider log shapes)
-│   ├── pricing/      # LiteLLM fetch, daily on-disk cache, fuzzy model matching, cost calculation
-│   ├── session/      # Per-provider parsers, SQLite readers, detector, and ParseMode
-│   ├── summary_cache.rs # Compact process-local cache for incremental CLI summary scans
-│   ├── update/       # Self-update via GitHub releases (archive extraction)
-│   ├── usage/        # Roll up parsed CodeAnalysis records into per-model token totals + per-provider days
-│   └── utils/        # Path resolution, directory walking, allocator tuning, time helpers
-└── tests/            # Integration test suite (one binary per file; unit tests live inline in src/)
+├── scripts/          # install.sh / install.ps1, plus test.sh to regenerate the JSONL goldens
+├── src/              # The four workspace members
+│   ├── core/         # vct-core: parsing, aggregation, pricing, quota, config, self-update — no terminal deps
+│   ├── tui/          # vct-tui: TUI dashboards, static tables, plain-text renderers, Criterion benchmarks
+│   ├── cli/          # vct-cli: the vibe_coding_tracker binary — clap definitions and command dispatch
+│   └── test-support/ # vct-test-support: dev-only TempHome / fixture helpers (unpublished)
+└── tests/
     └── fixtures/     # Session inputs + golden outputs (sessions/), quota API responses (quota/)
 ```
+
+Crates depend one way only — `vct-core` → `vct-tui` → `vct-cli` — so core never reaches into display or CLI code, and a future GUI can hang off core alone. Unit tests live inline in each crate's `src/`, integration tests under the owning crate's `tests/` directory; the root `tests/` holds fixtures only.
+
+For the module-by-module breakdown inside each crate, see the **Architecture** section of [`CLAUDE.md`](../CLAUDE.md).
 
 #### Building from Source
 


### PR DESCRIPTION
Closes #240

## What

The "Project Layout" tree in `.github/CONTRIBUTING.md` still described the layout the repo had before the workspace split: `benches/` at the root, every module directly under `src/`, and `tests/` as the integration suite. None of those paths exist any more, and the four workspace crates did not appear at all.

## How

Redrawn at **crate granularity** rather than as another module list. The module list is the part that rots — it is exactly what went stale here — and `CLAUDE.md` already carries an accurate module-by-module breakdown under **Architecture**, so the contributor-facing copy points there instead of keeping a second one in sync. Crate boundaries and top-level directories move far less often, and they are what a new contributor needs in order to find the right tree.

The tree now covers the four workspace members (`vct-core`, `vct-tui`, `vct-cli`, `vct-test-support`) plus the two top-level directories the old one omitted (`assets/`, `scripts/`). Two lines of prose underneath carry what a tree cannot: the one-way dependency direction, and the fact that integration tests live under the owning crate's `tests/` while the root `tests/` is fixtures only.

## Second commit

Four more stale paths elsewhere in the same file, same defect and same pre-workspace cause. Fixing the tree and leaving these would just re-file the issue:

| Section | Was | Now |
| --- | --- | --- |
| Build Features | `src/utils/heap.rs` | `src/core/src/utils/heap.rs` |
| Benchmarks | `benches/benchmarks.rs` | `src/tui/benches/benchmarks.rs` |
| Running Tests | "each integration test file under `tests/*.rs`" | under the owning crate's `tests/` |
| Running Tests | `cargo test --lib analysis::detector` | `session::detector` |

That last one was not just a wrong path in prose: `detector.rs` moved into `session/`, so the documented example filter selected zero tests. `session::detector` selects 21.

Left alone deliberately: the `cargo +1.95.0 check` line under Pull Requests. That is a toolchain version rather than a path, and it still matches the version `test.yml`'s MSRV job pins.

## Verification

Every path in the new tree checked against the working tree. The two changed `cargo test` filters were run: `--test analysis` resolves at the workspace root, `--lib session::detector` selects 21 tests, `--lib pricing::matching` selects 26. `make fmt` and `uvx pre-commit run -a` both clean; `mdformat` reflowed nothing.

Docs-only, so `test.yml` is path-ignored for `**/*.md` and runs no test job. That is expected, not a stuck check.

---

Opened-by: Claude Opus 5
