### PR TITLE
fix(scripts): a failed install leaves the installer's staging files in the install directory

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -72,9 +72,10 @@ function Install-Binary {
 
     $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
     New-Item -ItemType Directory -Path $tempDir | Out-Null
-    # Set before the try so the finally can always test it; Remove-Item rejects a null LiteralPath
-    # at parameter binding, which -ErrorAction does not suppress.
+    # Set before the try so the finally can always test them; Remove-Item rejects a null
+    # LiteralPath at parameter binding, which -ErrorAction does not suppress.
     $stageDir = $null
+    $newMarker = $null
 
     try {
         $archive = Join-Path $tempDir $filename
@@ -100,7 +101,6 @@ function Install-Binary {
         $target = Join-Path $installDir "$BinaryName.exe"
         $stagedTarget = Join-Path $stageDir "$BinaryName.exe"
         Copy-Item -Path $binary.FullName -Destination $stagedTarget -Force
-        Move-Item -LiteralPath $stagedTarget -Destination $target -Force
 
         $wrapper = Join-Path $installDir "vct.cmd"
         $stagedWrapper = Join-Path $stageDir "vct.cmd"
@@ -109,11 +109,6 @@ function Install-Binary {
             "@echo off`r`n`"%~dp0$BinaryName.exe`" %*`r`n",
             [System.Text.Encoding]::ASCII
         )
-        Move-Item -LiteralPath $stagedWrapper -Destination $wrapper -Force
-        $legacyAlias = Join-Path $installDir "vct.exe"
-        if (Test-Path -LiteralPath $legacyAlias) {
-            Remove-Item -LiteralPath $legacyAlias -Force
-        }
 
         $markerPath = [System.IO.Path]::GetFullPath($target) + ".vct-managed"
         $stagedMarker = Join-Path $stageDir "$BinaryName.exe.vct-managed"
@@ -121,7 +116,26 @@ function Install-Binary {
             $stagedMarker,
             [System.Text.Encoding]::ASCII.GetBytes("vct-release-installer-v1`n")
         )
+
+        # Every file is ready before any of them lands, and the marker lands first. Renames cannot
+        # be made atomic across files, so this is the order whose half-done state is survivable: a
+        # binary installed without its marker is one the startup auto-update silently never fires
+        # for again, whereas an unaccompanied marker is undone in the finally. Only one this run
+        # put down is undone, since a marker that was already there belongs to the install that is
+        # already there.
+        if (-not (Test-Path -LiteralPath $markerPath)) {
+            $newMarker = $markerPath
+        }
         Move-Item -LiteralPath $stagedMarker -Destination $markerPath -Force
+        Move-Item -LiteralPath $stagedTarget -Destination $target -Force
+        # The binary the marker claims is in place, so the marker is no longer this run's to undo.
+        $newMarker = $null
+        Move-Item -LiteralPath $stagedWrapper -Destination $wrapper -Force
+
+        $legacyAlias = Join-Path $installDir "vct.exe"
+        if (Test-Path -LiteralPath $legacyAlias) {
+            Remove-Item -LiteralPath $legacyAlias -Force
+        }
 
         Write-Host "Installed $BinaryName $Version to $installDir"
         if ($env:Path -notlike "*$installDir*") {
@@ -136,6 +150,9 @@ function Install-Binary {
         Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
         if ($stageDir) {
             Remove-Item -LiteralPath $stageDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+        if ($newMarker) {
+            Remove-Item -LiteralPath $newMarker -Force -ErrorAction SilentlyContinue
         }
     }
 }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -72,6 +72,9 @@ function Install-Binary {
 
     $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid())
     New-Item -ItemType Directory -Path $tempDir | Out-Null
+    # Set before the try so the finally can always test it; Remove-Item rejects a null LiteralPath
+    # at parameter binding, which -ErrorAction does not suppress.
+    $stageDir = $null
 
     try {
         $archive = Join-Path $tempDir $filename
@@ -88,13 +91,19 @@ function Install-Binary {
             New-Item -ItemType Directory -Path $installDir | Out-Null
         }
 
+        # Staged beside the targets so each move into place is a same-volume rename, and inside one
+        # directory of its own so a single Remove-Item in the finally reaps whatever a failed run
+        # staged.
+        $stageDir = Join-Path $installDir ".$BinaryName.$PID.staging"
+        New-Item -ItemType Directory -Path $stageDir -Force | Out-Null
+
         $target = Join-Path $installDir "$BinaryName.exe"
-        $stagedTarget = Join-Path $installDir ".$BinaryName.$PID.new"
+        $stagedTarget = Join-Path $stageDir "$BinaryName.exe"
         Copy-Item -Path $binary.FullName -Destination $stagedTarget -Force
         Move-Item -LiteralPath $stagedTarget -Destination $target -Force
 
         $wrapper = Join-Path $installDir "vct.cmd"
-        $stagedWrapper = Join-Path $installDir ".vct.$PID.cmd"
+        $stagedWrapper = Join-Path $stageDir "vct.cmd"
         [System.IO.File]::WriteAllText(
             $stagedWrapper,
             "@echo off`r`n`"%~dp0$BinaryName.exe`" %*`r`n",
@@ -107,7 +116,7 @@ function Install-Binary {
         }
 
         $markerPath = [System.IO.Path]::GetFullPath($target) + ".vct-managed"
-        $stagedMarker = "$markerPath.$PID.new"
+        $stagedMarker = Join-Path $stageDir "$BinaryName.exe.vct-managed"
         [System.IO.File]::WriteAllBytes(
             $stagedMarker,
             [System.Text.Encoding]::ASCII.GetBytes("vct-release-installer-v1`n")
@@ -125,6 +134,9 @@ function Install-Binary {
     }
     finally {
         Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+        if ($stageDir) {
+            Remove-Item -LiteralPath $stageDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
     }
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -54,6 +54,19 @@ select_install_dir() {
     fi
 }
 
+# Removes what this run created and nothing else, so a failure at any point leaves the install
+# directory as it was found. STAGE_DIR is tested rather than passed straight to rm: BSD `rm -r`
+# hands its whole operand list to fts_open(), which rejects a zero-length name outright, so one
+# empty argument would silently spare every other operand as well. Each removal is kept from
+# failing because under `set -e` a failing trap decides the script's exit status.
+cleanup() {
+    rm -rf "$TEMP_DIR" || true
+    if [ -n "$STAGE_DIR" ]; then
+        rm -rf "$STAGE_DIR" || true
+    fi
+    return 0
+}
+
 install_binary() {
     local platform="$1"
     local version="$2"
@@ -68,11 +81,12 @@ install_binary() {
     fi
 
     local url="https://github.com/${REPO}/releases/download/${version}/${filename}"
-    # Not a local: the EXIT trap outlives this function, and under `set -u` an out-of-scope name
-    # makes the trap fail instead of cleaning up. Armed after mktemp so TEMP_DIR is never unset,
-    # and kept from failing because under `set -e` a failing trap decides the script's exit status.
+    # Not locals: the EXIT trap outlives this function, and under `set -u` an out-of-scope name
+    # makes the trap fail instead of cleaning up. STAGE_DIR stays empty until the install directory
+    # has been chosen; the trap is armed after mktemp so TEMP_DIR is never unset.
+    STAGE_DIR=""
     TEMP_DIR="$(mktemp -d)"
-    trap 'rm -rf "$TEMP_DIR" || true' EXIT
+    trap cleanup EXIT
 
     local archive="${TEMP_DIR}/${filename}"
     curl -fsSL -o "$archive" "$url" || download_failed "$url"
@@ -92,15 +106,21 @@ install_binary() {
     local target="${install_dir}/${BINARY_NAME}"
     local canonical_install_dir
     canonical_install_dir="$(cd -P "$install_dir" && pwd)"
-    local staged_target
-    staged_target="$(mktemp "${canonical_install_dir}/.${BINARY_NAME}.XXXXXX")"
-    local staged_marker
-    staged_marker="$(mktemp "${canonical_install_dir}/.${BINARY_NAME}.marker.XXXXXX")"
+    # Staged beside the targets so each move into place is a same-filesystem rename, and inside one
+    # directory of its own so a single `rm -rf` in the trap reaps whatever a failed run staged.
+    STAGE_DIR="$(mktemp -d "${canonical_install_dir}/.${BINARY_NAME}.XXXXXX")"
+
+    local staged_target="${STAGE_DIR}/${BINARY_NAME}"
+    local staged_marker="${STAGE_DIR}/${BINARY_NAME}.vct-managed"
 
     cp "$binary" "$staged_target"
     chmod +x "$staged_target"
     mv -f "$staged_target" "$target"
     printf 'vct-release-installer-v1\n' > "$staged_marker"
+    # Readable only by the installing user, which for a root install into /usr/local/bin is the only
+    # user who could act on it: the marker is what lets the startup auto-update replace the binary,
+    # and every other user would reach that path only to fail on the same directory it cannot write.
+    chmod 600 "$staged_marker"
     mv -f "$staged_marker" "${canonical_install_dir}/${BINARY_NAME}.vct-managed"
     ln -sf "$target" "${install_dir}/vct"
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -55,14 +55,17 @@ select_install_dir() {
 }
 
 # Removes what this run created and nothing else, so a failure at any point leaves the install
-# directory as it was found. STAGE_DIR is tested rather than passed straight to rm: BSD `rm -r`
-# hands its whole operand list to fts_open(), which rejects a zero-length name outright, so one
-# empty argument would silently spare every other operand as well. Each removal is kept from
+# directory as it was found. STAGE_DIR and NEW_MARKER are tested rather than passed straight to rm:
+# BSD `rm -r` hands its whole operand list to fts_open(), which rejects a zero-length name outright,
+# so one empty argument would silently spare every other operand as well. Each removal is kept from
 # failing because under `set -e` a failing trap decides the script's exit status.
 cleanup() {
     rm -rf "$TEMP_DIR" || true
     if [ -n "$STAGE_DIR" ]; then
         rm -rf "$STAGE_DIR" || true
+    fi
+    if [ -n "$NEW_MARKER" ]; then
+        rm -f "$NEW_MARKER" || true
     fi
     return 0
 }
@@ -82,9 +85,10 @@ install_binary() {
 
     local url="https://github.com/${REPO}/releases/download/${version}/${filename}"
     # Not locals: the EXIT trap outlives this function, and under `set -u` an out-of-scope name
-    # makes the trap fail instead of cleaning up. STAGE_DIR stays empty until the install directory
-    # has been chosen; the trap is armed after mktemp so TEMP_DIR is never unset.
+    # makes the trap fail instead of cleaning up. The other two stay empty until the install
+    # directory has been chosen; the trap is armed after mktemp so TEMP_DIR is never unset.
     STAGE_DIR=""
+    NEW_MARKER=""
     TEMP_DIR="$(mktemp -d)"
     trap cleanup EXIT
 
@@ -111,17 +115,29 @@ install_binary() {
     STAGE_DIR="$(mktemp -d "${canonical_install_dir}/.${BINARY_NAME}.XXXXXX")"
 
     local staged_target="${STAGE_DIR}/${BINARY_NAME}"
-    local staged_marker="${STAGE_DIR}/${BINARY_NAME}.vct-managed"
-
     cp "$binary" "$staged_target"
     chmod +x "$staged_target"
-    mv -f "$staged_target" "$target"
+
+    local marker="${canonical_install_dir}/${BINARY_NAME}.vct-managed"
+    local staged_marker="${STAGE_DIR}/${BINARY_NAME}.vct-managed"
     printf 'vct-release-installer-v1\n' > "$staged_marker"
     # Readable only by the installing user, which for a root install into /usr/local/bin is the only
     # user who could act on it: the marker is what lets the startup auto-update replace the binary,
     # and every other user would reach that path only to fail on the same directory it cannot write.
     chmod 600 "$staged_marker"
-    mv -f "$staged_marker" "${canonical_install_dir}/${BINARY_NAME}.vct-managed"
+
+    # Both files are ready before either lands, and the marker lands first. Two renames cannot be
+    # made atomic, so this is the order whose half-done state is survivable: a binary installed
+    # without its marker is one the startup auto-update silently never fires for again, whereas an
+    # unaccompanied marker is undone below. Only one this run put down is undone, since a marker
+    # that was already there belongs to the install that is already there.
+    if [ ! -e "$marker" ]; then
+        NEW_MARKER="$marker"
+    fi
+    mv -f "$staged_marker" "$marker"
+    mv -f "$staged_target" "$target"
+    # The binary the marker claims is in place, so the marker is no longer this run's to undo.
+    NEW_MARKER=""
     ln -sf "$target" "${install_dir}/vct"
 
     echo "Installed ${BINARY_NAME} ${version} to ${install_dir}"


### PR DESCRIPTION
Closes #245

Both installers staged their files **inside the install directory**, and neither cleanup path knew
about them: `install.sh`'s `EXIT` trap and `install.ps1`'s `finally` removed only the download temp
directory. Any failure between staging and the last move left the staged files behind — in
`~/.local/bin` or `%LOCALAPPDATA%\Programs\VibeCodingTracker`, where nothing ever reaps them, and
each one is a full copy of the binary when the failure comes after the copy.

Worse, the marker moved last. A failed marker move left a working binary with no `.vct-managed`
beside it, which is an install the startup auto-update silently never fires for again.

## What changed

**One staging directory, reaped by the existing cleanup path.** The loose per-file `mktemp` calls
become a single `mktemp -d "${canonical_install_dir}/.${BINARY_NAME}.XXXXXX"`, removed by the `EXIT`
trap alongside `TEMP_DIR`. `install.ps1` gets the same shape with a `.$BinaryName.$PID.staging`
directory removed in the `finally`. Staging stays inside the install directory so every move into
place is still a same-filesystem rename; collecting it into one directory means there is one path to
clean rather than one per staged file.

The trap body becomes a `cleanup` function that tests each optional path before removing it, rather
than passing possibly-empty operands to one `rm -rf`. That is load-bearing on macOS: BSD `rm -r`
hands its whole operand list to `fts_open()`, whose BSD implementation rejects a zero-length name
outright rather than skipping it, and `rm` then treats the resulting `ENOENT` as "nothing to do"
under `-f`. So `rm -rf "$TEMP_DIR" ""` deletes **nothing** and exits 0 there, which would have
reintroduced #228's temp-directory leak on every failure that happens before the install directory
is chosen. GNU's `rm` links gnulib's fts, which deliberately allows zero-length names, so the leak
would have been invisible to every reproduction in the issue body. Verified both halves directly:
an `fts_open()` probe returns `NULL`/`ENOENT` for `{"/tmp/x", "", NULL}`, while GNU `rm -rf a "" b`
removes both `a` and `b`.

The `set -e` hazard from #228 is respected: every removal is `|| true` and `cleanup` ends in
`return 0`, so a failed cleanup cannot decide the script's exit status. `$stageDir` is initialised
to `$null` before the `try`, because `Remove-Item -LiteralPath $null` fails at parameter binding and
`-ErrorAction SilentlyContinue` does not suppress that.

**Every staged file is built before any of them lands, and the marker lands first.** Two renames
cannot be made atomic, so the choice is which half-done state to leave. A binary without its marker
is permanent and invisible: auto-update never fires, nothing says so, and only re-running the
installer fixes it.

The marker is not simply left behind in the other direction, though. `is_release_managed`
canonicalizes the executable and reads the marker beside it, so an orphaned marker is not inert —
it is an ownership claim over whatever binary later occupies that path, including a hand-built one,
which would hand a local build to the auto-updater and break the guarantee that `cargo install` and
local builds never self-update. So the run remembers a marker it created and the cleanup path undoes
it; a marker that was already there is left alone, since it belongs to the install that was already
there. Once the binary is in place the marker is committed and no longer this run's to undo.

## Verification

Reproduced both failure paths from the issue body first, then re-ran the same reproductions against
the fix. `install.sh` is driven through a `PATH` shim (stubbed `curl`, plus `cp` or `mv` rigged to
fail), `install.ps1` through a dot-sourced copy with `Invoke-Download`, `Copy-Item` and `Move-Item`
shadowed, under pwsh 7.4.6 with `LOCALAPPDATA` pointed at a sandbox. Every case was run three ways:
a fresh install directory, over a previous release install, and over a hand-built binary with no
marker of its own.

| case | before | after |
| --- | --- | --- |
| download fails | temp dir reaped | unchanged (and still reaped on BSD `rm`) |
| `cp` / `Copy-Item` fails | two staged files left behind | install directory untouched |
| copy leaves a partial file, then fails | staged copy of the binary left behind | install directory untouched |
| marker move fails | installed binary, no marker, staged marker left behind | install directory untouched |
| binary move fails | n/a (marker moved last) | install directory untouched, marker rolled back |
| happy path | binary + marker + `vct` alias | unchanged |

Also checked: an install directory that is a symlink still puts the marker beside the canonical
binary; and a stale `.$BinaryName.$PID.staging` directory left by a killed run does not break a
later run that draws the same PID, because `New-Item -ItemType Directory -Force` returns the
existing directory and every staged file is overwritten.

One measured side effect, and one deliberate pin. Staging into a fresh directory means the
installed files take their mode from the release archive and the caller's `umask`, instead of from
`mktemp`'s 0600 floor. For the binary that is left as it falls out: 711 → 755 at `umask 022`, which
is the conventional mode for a binary in a `bin` directory, and it can never become group-writable
because `umask` only clears bits and the archived binary is 755. At `umask 077` it stays 700, as
before.

The marker is pinned back to 0600, because its readability is load-bearing where the binary's is
not. On a `sudo` install into `/usr/local/bin`, a 0644 marker makes `is_release_managed` true for
every non-root user, and `auto_update_with` then calls `UpdateLock::try_acquire` — which opens
`<install_dir>/.vct-update.lock` for writing and fails with `EACCES` — *before* it reaches
`check_is_due`. So the daily throttle never applies and it becomes one `log::warn!` per invocation,
creating `~/.vct/logs/` on accounts that would otherwise never write there. 0600 keeps the marker
readable by exactly the user who could act on it. Measured after the pin: marker 0600 at umask 022,
002 and 077, matching `main` at every one.

`install.ps1` parse-checks clean under
`[System.Management.Automation.Language.Parser]::ParseFile`. `shellcheck` passes via
`uvx pre-commit run -a`, and `make fmt` is clean.

Chasing that down turned up a defect on the Rust side that this branch does not touch and now no
longer triggers: the lock is acquired upstream of `check_is_due`, so *any* lock failure escapes the
daily throttle. Filed as #261.

## Not in scope

Signal handling. Neither script traps `INT`/`TERM` today, so a Ctrl-C still skips cleanup exactly as
it does for the download temp directory; changing that is wider than this issue. No shell test
infrastructure is stood up either, for the reason the issue body gives.

Opened-by: Claude Opus 5
