### PR TITLE
chore: enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,11 @@
+# Normalize every text file to LF, in the repo and in the working tree, so a
+# Windows checkout cannot introduce CRLF.
+* text=auto eol=lf
+
+# cmd.exe needs CRLF in batch files.
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
 # *.md linguist-detectable=false
 # *.sh linguist-detectable=false
 # Makefile linguist-detectable=false


### PR DESCRIPTION
## What this does

Adds a repo-level line-ending rule to `.gitattributes`:

- `* text=auto eol=lf` normalizes every text file to LF both in the repository and in the working tree, so a checkout on Windows cannot introduce CRLF.
- `*.bat` and `*.cmd` are pinned to CRLF, because `cmd.exe` needs it.

The existing `linguist-detectable` lines are kept unchanged, below the new block.

## Why

On Windows, VS Code writes files with CRLF. Git's `core.autocrlf=input` only normalizes on the way *into* the repository, so the working tree keeps CRLF and pre-commit's `mixed-line-ending` hook rewrites those files on every run. A `.gitattributes` rule fixes this for everyone, including CI and contributors who have no such git config of their own.

## Notes

- This is a fan-out from the Mai0313 templates, applied to every downstream repo.
- `git add --renormalize .` reported no changes, so no already-committed blob needed rewriting. This PR touches `.gitattributes` only.
- `Code Quality Check` is already failing on `main` before this branch; that failure is pre-existing and unrelated.

Opened-by: claude-opus-5[1m]
